### PR TITLE
Add graph validation to GraphBuilder.build

### DIFF
--- a/src/graphon/graph/graph.py
+++ b/src/graphon/graph/graph.py
@@ -443,13 +443,17 @@ class GraphBuilder:
             out_edges[edge.tail].append(edge.id)
             in_edges[edge.head].append(edge.id)
 
-        return self._graph_cls(
+        graph = self._graph_cls(
             nodes=nodes,
             edges=edges,
             in_edges=dict(in_edges),
             out_edges=dict(out_edges),
             root_node=self._nodes[0],
         )
+
+        get_graph_validator().validate(graph)
+
+        return graph
 
     def _register_node(self, node: Node) -> None:
         if not node.id:

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -1,8 +1,11 @@
 from unittest.mock import Mock
 
+import pytest
+
 from graphon.enums import BuiltinNodeTypes, NodeExecutionType, NodeState
 from graphon.graph.edge import Edge
 from graphon.graph.graph import Graph
+from graphon.graph.validation import GraphValidationError
 from graphon.nodes.base.node import Node
 
 
@@ -17,6 +20,16 @@ def create_mock_node(
     node.state = state
     node.node_type = BuiltinNodeTypes.START
     return node
+
+
+class TestGraphBuilder:
+    def test_build_runs_default_validators(self):
+        root = create_mock_node("root", NodeExecutionType.EXECUTABLE)
+
+        with pytest.raises(GraphValidationError) as exc:
+            Graph.new().add_root(root).build()
+
+        assert any(issue.code == "INVALID_ROOT" for issue in exc.value.issues)
 
 
 class TestMarkInactiveRootBranches:


### PR DESCRIPTION
## Summary
- validate graphs built via `GraphBuilder.build()` before returning them
- align builder-created graphs with the existing validation behavior in `Graph.init()`
- add a regression test covering invalid root-node detection in the builder path

## Testing
- `uv run pytest tests/graph/test_graph.py tests/graph/test_graph_validation.py -q`