### PR TITLE
refactor(runtime)!: simplify dispatch and validation flows

### DIFF
--- a/examples/graphon_openai_slim/workflow.py
+++ b/examples/graphon_openai_slim/workflow.py
@@ -4,8 +4,8 @@ Run from this directory:
 
     python3 workflow.py "Explain Graphon in one short sentence."
 
-The script automatically loads `examples/graphon_openai_slim/.env`. Existing environment variables
-take precedence over `.env` values.
+The script automatically loads `examples/graphon_openai_slim/.env`.
+Existing environment variables take precedence over `.env` values.
 
 Required environment variables:
 - `OPENAI_API_KEY`
@@ -20,7 +20,6 @@ Optional environment variables:
 
 from __future__ import annotations
 
-# ruff: noqa: E402
 import argparse
 import importlib.util
 import os
@@ -61,6 +60,7 @@ bootstrap_local_python()
 if importlib.util.find_spec("graphon") is None and str(LOCAL_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(LOCAL_SRC_DIR))
 
+# ruff: noqa: E402
 from graphon.entities.graph_init_params import GraphInitParams
 from graphon.file.enums import FileType
 from graphon.file.models import File
@@ -119,7 +119,8 @@ def load_default_env_file() -> None:
 def load_env_file(path: Path) -> None:
     env_dir = path.resolve().parent
     for line_number, raw_line in enumerate(
-        path.read_text(encoding="utf-8").splitlines(), start=1
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
     ):
         line = raw_line.strip()
         if not line or line.startswith("#"):
@@ -127,16 +128,17 @@ def load_env_file(path: Path) -> None:
         if line.startswith("export "):
             line = line.removeprefix("export ").strip()
         if "=" not in line:
-            raise ValueError(f"Invalid .env line {line_number} in {path}: {raw_line}")
+            msg = f"Invalid .env line {line_number} in {path}: {raw_line}"
+            raise ValueError(msg)
 
         key, value = line.split("=", 1)
         key = key.strip()
         if not key:
-            raise ValueError(f"Invalid .env key on line {line_number} in {path}")
+            msg = f"Invalid .env key on line {line_number} in {path}"
+            raise ValueError(msg)
         if key not in ALLOWED_ENV_VARS:
-            raise ValueError(
-                f"Unsupported .env key {key!r} on line {line_number} in {path}"
-            )
+            msg = f"Unsupported .env key {key!r} on line {line_number} in {path}"
+            raise ValueError(msg)
 
         os.environ.setdefault(
             key,
@@ -186,18 +188,21 @@ class TextOnlyFileSaver:
         extension_override: str | None = None,
     ) -> File:
         _ = data, mime_type, file_type, extension_override
-        raise RuntimeError("This example only supports text responses.")
+        msg = "This example only supports text responses."
+        raise RuntimeError(msg)
 
     def save_remote_url(self, url: str, file_type: FileType) -> File:
         _ = url, file_type
-        raise RuntimeError("This example only supports text responses.")
+        msg = "This example only supports text responses."
+        raise RuntimeError(msg)
 
 
 def require_env(name: str) -> str:
     value = env_value(name)
     if value:
         return value
-    raise ValueError(f"{name} is required.")
+    msg = f"{name} is required."
+    raise ValueError(msg)
 
 
 def env_value(name: str) -> str:
@@ -205,7 +210,9 @@ def env_value(name: str) -> str:
     if raw_value is not None:
         return raw_value.strip()
     return normalize_env_value(
-        name, ALLOWED_ENV_VARS[name], base_dir=EXAMPLE_DIR
+        name,
+        ALLOWED_ENV_VARS[name],
+        base_dir=EXAMPLE_DIR,
     ).strip()
 
 
@@ -226,10 +233,10 @@ def build_runtime() -> tuple[SlimRuntime, str]:
                     plugin_id=require_env("SLIM_PLUGIN_ID"),
                     provider=provider,
                     plugin_root=plugin_root,
-                )
+                ),
             ],
             local=SlimLocalSettings(folder=plugin_folder),
-        )
+        ),
     )
     return runtime, provider
 
@@ -242,7 +249,7 @@ def build_graph(
     graph_runtime_state: GraphRuntimeState,
 ) -> Graph:
     start_node = StartNode(
-        id="start",
+        node_id="start",
         config={
             "id": "start",
             "data": StartNodeData(
@@ -253,7 +260,7 @@ def build_graph(
                         label="Query",
                         type=VariableEntityType.PARAGRAPH,
                         required=True,
-                    )
+                    ),
                 ],
             ),
         },
@@ -262,7 +269,7 @@ def build_graph(
     )
 
     llm_node = LLMNode(
-        id="llm",
+        node_id="llm",
         config={
             "id": "llm",
             "data": LLMNodeData(
@@ -293,7 +300,7 @@ def build_graph(
     )
 
     output_node = AnswerNode(
-        id="output",
+        node_id="output",
         config={
             "id": "output",
             "data": AnswerNodeData(
@@ -327,7 +334,9 @@ def write_stream_chunk(event: object, *, stream_output: IO[str]) -> bool:
 
 
 def _execute_workflow(
-    query: str, *, stream_output: IO[str] | None = None
+    query: str,
+    *,
+    stream_output: IO[str] | None = None,
 ) -> tuple[str, bool]:
     load_default_env_file()
     runtime, provider = build_runtime()
@@ -367,13 +376,15 @@ def _execute_workflow(
     streamed = False
     for event in engine.run():
         if stream_output is not None and write_stream_chunk(
-            event, stream_output=stream_output
+            event,
+            stream_output=stream_output,
         ):
             streamed = True
 
     answer = graph_runtime_state.get_output("answer")
     if not isinstance(answer, str):
-        raise RuntimeError("Workflow did not produce a text answer.")
+        msg = "Workflow did not produce a text answer."
+        raise TypeError(msg)
     if stream_output is not None and streamed and not answer.endswith("\n"):
         stream_output.write("\n")
         stream_output.flush()
@@ -402,7 +413,8 @@ def main() -> int:
     args = parse_args()
     answer, streamed = _execute_workflow(args.query, stream_output=sys.stdout)
     if not streamed:
-        print(answer)
+        sys.stdout.write(f"{answer}\n")
+        sys.stdout.flush()
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,110 +49,44 @@ required-version = '>=0.15'
 [tool.ruff.lint]
 select = ['ALL']
 ignore = [
-    'ERA',    # 存在误识别问题
-    'COM',    # 与格式化冲突
-    'ISC001', # 与格式化冲突
-    'ANN',    # 全标注要求太过严苛
-    'S',      # 不适用
-    'D',      # 不适用
-    'PGH003', # 不适用
-    'CPY',    # 不适用
-    'FBT',    # 不适用
-    'SLF',    # 不适用
-    'TID',    # 不适用
-    'FIX',    # 不适用
-    ########### TODO(99): 临时禁用 ###########
-    'TRY003',
-    'TC001',
-    'G004',
-    'T201',
-    'E501',
+    'COM812', # Conflicts with `ruff format`.
+    'ERA',    # False positives are common.
+    'ANN',    # Full annotation coverage is too strict for this codebase.
+    'TC',     # Runtime use of typing constructs is common here.
+    'S',      # Security rules are temporarily handled separately.
+    'D',      # Docstring rules are not applicable here.
+    'PGH003', # Not applicable here.
+    'CPY',    # Not applicable here.
+    'FBT',    # Not applicable here.
+    'SLF',    # Not applicable here.
+    'TID',    # Not applicable here.
+    'FIX',    # Not applicable here.
+    ########### TODO(99): Temporarily disabled ###########
     'C901',
-    'TC003',
     'TRY004',
-    'BLE001',
-    'TRY400',
-    'RUF001',
-    'B904',
-    'A002',
-    'TD003',
-    'RET504',
-    'TRY300',
-    'PLW1514',
-    'TD002',
-    'DTZ005',
-    'PLW2901',
-    'TRY002',
-    'A001',
-    'G003',
-    'RUF005',
-    'PLW0603',
-    'TRY301',
-    'EXE001',
-    'INP001',
-    'N806',
-    'RUF052',
-    'UP007',
-    'B901',
-    'N815',
-    'PLW0108',
-    'TD001',
-    'TD004',
     'TD005',
-    'E721',
-    'FURB101',
-    'ISC004',
-    'LOG004',
-    'PD002',
-    'PERF402',
-    'PIE810',
-    'PLW0602',
-    'PTH100',
-    'PTH118',
-    'PTH120',
-    'RET503',
-    'RUF012',
-    'RUF027',
-    'RUF066',
-    'RUF070',
-    'TRY201',
-    'DOC201',
-    'EM102',
-    'EM101',
+    'TD004',
+    'TD003',
+    'TD002',
+    'TD001',
+    'PLW0603',
     'PLR6301',
-    'DOC501',
-    'ARG002',
     'PLR2004',
+    'PLR1702',
+    'PLR0917',
+    'PLR0915',
+    'PLR0914',
     'PLR0913',
     'PLR0912',
-    'PLR0917',
-    'PLR1702',
-    'PLC0415',
-    'PLR0911',
-    'PLR6201',
-    'PLR0915',
-    'ARG003',
-    'PLR0914',
-    'PLC1901',
-    'PT011',
-    'DOC402',
-    'RUF069',
-    'ARG001',
-    'DOC202',
-    'DOC502',
-    'PLC2701',
-    'PLR0904',
-    'PLR0916',
-    'PLR1714',
-    'A004',
-    'ARG004',
-    'ARG005',
-    'DOC102',
-    'DTZ001',
-    'PLR6104',
-    'SIM117',
 ]
 
+[tool.ruff.lint.pydoclint]
+ignore-one-line-docstrings = true
+
+[tool.ruff.lint.per-file-ignores]
+'tests/**/*.py' = [
+    'S101', # Pytest convention relies on plain assert statements.
+]
 
 [tool.pytest]
 minversion = '9.0'

--- a/src/graphon/entities/base_node_data.py
+++ b/src/graphon/entities/base_node_data.py
@@ -46,8 +46,9 @@ class DefaultValue(BaseModel):
         """Unified JSON parsing handler"""
         try:
             return json.loads(value)
-        except json.JSONDecodeError:
-            raise DefaultValueTypeError(f"Invalid JSON format for value: {value}")
+        except json.JSONDecodeError as error:
+            msg = f"Invalid JSON format for value: {value}"
+            raise DefaultValueTypeError(msg) from error
 
     @staticmethod
     def _validate_array(value: Any, element_type: type_ | tuple[type_, ...]) -> bool:
@@ -61,8 +62,9 @@ class DefaultValue(BaseModel):
         """Unified number conversion handler"""
         try:
             return float(value)
-        except ValueError:
-            raise DefaultValueTypeError(f"Cannot convert to number: {value}")
+        except ValueError as error:
+            msg = f"Cannot convert to number: {value}"
+            raise DefaultValueTypeError(msg) from error
 
     @model_validator(mode="after")
     def validate_value_type(self) -> DefaultValue:
@@ -102,7 +104,8 @@ class DefaultValue(BaseModel):
             if self.type == DefaultValueType.ARRAY_FILES:
                 # Handle files type
                 return self
-            raise DefaultValueTypeError(f"Unsupported type: {self.type}")
+            msg = f"Unsupported type: {self.type}"
+            raise DefaultValueTypeError(msg)
 
         # Handle string input cases
         if isinstance(self.value, str) and self.type != DefaultValueType.STRING:
@@ -110,18 +113,19 @@ class DefaultValue(BaseModel):
 
         # Validate base type
         if not isinstance(self.value, validator["type"]):
-            raise DefaultValueTypeError(
-                f"Value must be {validator['type'].__name__} type for {self.value}"
-            )
+            msg = f"Value must be {validator['type'].__name__} type for {self.value}"
+            raise DefaultValueTypeError(msg)
 
         # Validate array element types
-        if validator["type"] == list and not self._validate_array(
-            self.value, validator["element_type"]
+        if validator["type"] is list and not self._validate_array(
+            self.value,
+            validator["element_type"],
         ):
-            raise DefaultValueTypeError(
+            msg = (
                 f"All elements must be {validator['element_type'].__name__} "
                 f"for {self.value}"
             )
+            raise DefaultValueTypeError(msg)
 
         return self
 
@@ -153,9 +157,15 @@ class BaseNodeData(ABC, BaseModel):
         return {}
 
     def __getitem__(self, key: str) -> Any:
-        """
-        Dict-style access without calling model_dump() on every lookup.
+        """Dict-style access without calling model_dump() on every lookup.
         Prefer using model fields and Pydantic's extra storage.
+
+        Returns:
+            The declared field value or compatibility extra stored under `key`.
+
+        Raises:
+            KeyError: If `key` is neither a declared field nor a stored extra.
+
         """
         # First, check declared model fields
         if key in self.__class__.model_fields:
@@ -171,9 +181,7 @@ class BaseNodeData(ABC, BaseModel):
         raise KeyError(key)
 
     def get(self, key: str, default: Any = None) -> Any:
-        """
-        Dict-style .get() without calling model_dump() on every lookup.
-        """
+        """Dict-style .get() without calling model_dump() on every lookup."""
         if key in self.__class__.model_fields:
             return getattr(self, key)
 

--- a/src/graphon/entities/pause_reason.py
+++ b/src/graphon/entities/pause_reason.py
@@ -46,5 +46,6 @@ class SchedulingPause(BaseModel):
 
 
 type PauseReason = Annotated[
-    HumanInputRequired | SchedulingPause, Field(discriminator="TYPE")
+    HumanInputRequired | SchedulingPause,
+    Field(discriminator="TYPE"),
 ]

--- a/src/graphon/entities/workflow_execution.py
+++ b/src/graphon/entities/workflow_execution.py
@@ -1,5 +1,4 @@
-"""
-Domain entities for workflow execution.
+"""Domain entities for workflow execution.
 
 Models describe graph runtime state and avoid infrastructure-specific details.
 """
@@ -16,9 +15,7 @@ from graphon.enums import WorkflowExecutionStatus, WorkflowType
 
 
 class WorkflowExecution(BaseModel):
-    """
-    Domain model for a workflow execution within the graph runtime.
-    """
+    """Domain model for a workflow execution within the graph runtime."""
 
     id_: str = Field(...)
     workflow_id: str = Field(...)
@@ -40,8 +37,7 @@ class WorkflowExecution(BaseModel):
 
     @property
     def elapsed_time(self) -> float:
-        """
-        Calculate elapsed time in seconds.
+        """Calculate elapsed time in seconds.
         If workflow is not finished, use current time.
         """
         end_time = self.finished_at or datetime.now(UTC).replace(tzinfo=None)

--- a/src/graphon/entities/workflow_node_execution.py
+++ b/src/graphon/entities/workflow_node_execution.py
@@ -1,5 +1,4 @@
-"""
-Domain entities for workflow node execution.
+"""Domain entities for workflow node execution.
 
 These models capture node-level execution state for the graph runtime without
 describing storage or application-layer concerns.
@@ -19,8 +18,7 @@ from graphon.enums import (
 
 
 class WorkflowNodeExecution(BaseModel):
-    """
-    Domain model for workflow node execution.
+    """Domain model for workflow node execution.
 
     This model represents the graph-level record of a node execution and
     contains only execution state relevant to the runtime.
@@ -96,7 +94,8 @@ class WorkflowNodeExecution(BaseModel):
         self._truncated_outputs = truncated_outputs
 
     def set_truncated_process_data(
-        self, truncated_process_data: Mapping[str, Any] | None
+        self,
+        truncated_process_data: Mapping[str, Any] | None,
     ):
         self._truncated_process_data = truncated_process_data
 
@@ -137,14 +136,14 @@ class WorkflowNodeExecution(BaseModel):
         outputs: Mapping[str, Any] | None = None,
         metadata: Mapping[WorkflowNodeExecutionMetadataKey, Any] | None = None,
     ):
-        """
-        Update the model from mappings.
+        """Update the model from mappings.
 
         Args:
             inputs: The inputs to update
             process_data: The process data to update
             outputs: The outputs to update
             metadata: The metadata to update
+
         """
         if inputs is not None:
             self.inputs = dict(inputs)

--- a/src/graphon/enums.py
+++ b/src/graphon/enums.py
@@ -101,9 +101,7 @@ class FailBranchSourceHandle(StrEnum):
 
 
 class WorkflowType(StrEnum):
-    """
-    Workflow Type Enum for domain layer
-    """
+    """Workflow Type Enum for domain layer"""
 
     WORKFLOW = "workflow"
     CHAT = "chat"
@@ -197,8 +195,7 @@ _END_STATE = frozenset([
 
 
 class WorkflowNodeExecutionMetadataKey(StrEnum):
-    """
-    Node Run Metadata Key.
+    """Node Run Metadata Key.
 
     Values in this enum are persisted as execution metadata and must stay in sync
     with every node that writes `NodeRunResult.metadata`.

--- a/src/graphon/errors.py
+++ b/src/graphon/errors.py
@@ -2,7 +2,7 @@ from graphon.nodes.base.node import Node
 
 
 class WorkflowNodeRunFailedError(Exception):
-    def __init__(self, node: Node, err_msg: str):
+    def __init__(self, node: Node, err_msg: str) -> None:
         self._node = node
         self._error = err_msg
         super().__init__(f"Node {node.title} run failed: {err_msg}")

--- a/src/graphon/file/constants.py
+++ b/src/graphon/file/constants.py
@@ -15,31 +15,35 @@ def _with_case_variants(extensions: Iterable[str]) -> frozenset[str]:
     return frozenset(normalized | {extension.upper() for extension in normalized})
 
 
-IMAGE_EXTENSIONS = _with_case_variants({"jpg", "jpeg", "png", "webp", "gif", "svg"})
-VIDEO_EXTENSIONS = _with_case_variants({"mp4", "mov", "mpeg", "webm"})
-AUDIO_EXTENSIONS = _with_case_variants({"mp3", "m4a", "wav", "amr", "mpga"})
-DOCUMENT_EXTENSIONS = _with_case_variants({
-    "txt",
-    "markdown",
-    "md",
-    "mdx",
-    "pdf",
-    "html",
-    "htm",
-    "xlsx",
-    "xls",
-    "vtt",
-    "properties",
-    "doc",
-    "docx",
-    "csv",
-    "eml",
-    "msg",
-    "ppt",
-    "pptx",
-    "xml",
-    "epub",
-})
+IMAGE_EXTENSIONS = _with_case_variants(
+    frozenset(("jpg", "jpeg", "png", "webp", "gif", "svg")),
+)
+VIDEO_EXTENSIONS = _with_case_variants(frozenset(("mp4", "mov", "mpeg", "webm")))
+AUDIO_EXTENSIONS = _with_case_variants(frozenset(("mp3", "m4a", "wav", "amr", "mpga")))
+DOCUMENT_EXTENSIONS = _with_case_variants(
+    frozenset((
+        "txt",
+        "markdown",
+        "md",
+        "mdx",
+        "pdf",
+        "html",
+        "htm",
+        "xlsx",
+        "xls",
+        "vtt",
+        "properties",
+        "doc",
+        "docx",
+        "csv",
+        "eml",
+        "msg",
+        "ppt",
+        "pptx",
+        "xml",
+        "epub",
+    )),
+)
 
 
 def maybe_file_object(o: Any) -> bool:

--- a/src/graphon/file/file_factory.py
+++ b/src/graphon/file/file_factory.py
@@ -8,9 +8,7 @@ from .enums import FileType
 
 
 def standardize_file_type(*, extension: str = "", mime_type: str = "") -> FileType:
-    """
-    Infer the actual file type from extension and mime type.
-    """
+    """Infer the actual file type from extension and mime type."""
     guessed_type = None
     if extension:
         guessed_type = _get_file_type_by_extension(extension)

--- a/src/graphon/file/file_manager.py
+++ b/src/graphon/file/file_manager.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from operator import attrgetter
 
 from graphon.model_runtime.entities.message_entities import (
     AudioPromptMessageContent,
@@ -16,25 +17,52 @@ from .enums import FileAttribute, FileTransferMethod, FileType
 from .models import File
 from .runtime import get_workflow_file_runtime
 
+_DOWNLOAD_TRANSFER_METHODS = frozenset((
+    FileTransferMethod.TOOL_FILE,
+    FileTransferMethod.LOCAL_FILE,
+    FileTransferMethod.DATASOURCE_FILE,
+))
+
+
+def _to_url(f: File, /) -> str:
+    url = f.generate_url()
+    if url is None:
+        msg = f"Unsupported transfer method: {f.transfer_method}"
+        raise ValueError(msg)
+    return url
+
+
+def _get_file_type_value(file: File) -> str:
+    return file.type.value
+
+
+def _get_file_transfer_method_value(file: File) -> str:
+    return file.transfer_method.value
+
+
+_FILE_ATTRIBUTE_GETTERS: Mapping[FileAttribute, Callable[[File], object]] = {
+    FileAttribute.TYPE: _get_file_type_value,
+    FileAttribute.SIZE: attrgetter("size"),
+    FileAttribute.NAME: attrgetter("filename"),
+    FileAttribute.MIME_TYPE: attrgetter("mime_type"),
+    FileAttribute.TRANSFER_METHOD: _get_file_transfer_method_value,
+    FileAttribute.URL: _to_url,
+    FileAttribute.EXTENSION: attrgetter("extension"),
+    FileAttribute.RELATED_ID: attrgetter("related_id"),
+}
+_PROMPT_CONTENT_CLASS_BY_FILE_TYPE: Mapping[
+    FileType,
+    type[PromptMessageContentUnionTypes],
+] = {
+    FileType.IMAGE: ImagePromptMessageContent,
+    FileType.AUDIO: AudioPromptMessageContent,
+    FileType.VIDEO: VideoPromptMessageContent,
+    FileType.DOCUMENT: DocumentPromptMessageContent,
+}
+
 
 def get_attr(*, file: File, attr: FileAttribute):
-    match attr:
-        case FileAttribute.TYPE:
-            return file.type.value
-        case FileAttribute.SIZE:
-            return file.size
-        case FileAttribute.NAME:
-            return file.filename
-        case FileAttribute.MIME_TYPE:
-            return file.mime_type
-        case FileAttribute.TRANSFER_METHOD:
-            return file.transfer_method.value
-        case FileAttribute.URL:
-            return _to_url(file)
-        case FileAttribute.EXTENSION:
-            return file.extension
-        case FileAttribute.RELATED_ID:
-            return file.related_id
+    return _FILE_ATTRIBUTE_GETTERS[attr](file)
 
 
 def to_prompt_message_content(
@@ -45,20 +73,15 @@ def to_prompt_message_content(
 ) -> PromptMessageContentUnionTypes:
     """Convert a file to prompt message content."""
     if f.extension is None:
-        raise ValueError("Missing file extension")
+        msg = "Missing file extension"
+        raise ValueError(msg)
     if f.mime_type is None:
-        raise ValueError("Missing file mime_type")
+        msg = "Missing file mime_type"
+        raise ValueError(msg)
 
-    prompt_class_map: Mapping[FileType, type[PromptMessageContentUnionTypes]] = {
-        FileType.IMAGE: ImagePromptMessageContent,
-        FileType.AUDIO: AudioPromptMessageContent,
-        FileType.VIDEO: VideoPromptMessageContent,
-        FileType.DOCUMENT: DocumentPromptMessageContent,
-    }
-
-    if f.type not in prompt_class_map:
+    if f.type not in _PROMPT_CONTENT_CLASS_BY_FILE_TYPE:
         return TextPromptMessageContent(
-            data=f"[Unsupported file type: {f.filename} ({f.type.value})]"
+            data=f"[Unsupported file type: {f.filename} ({f.type.value})]",
         )
 
     send_format = get_workflow_file_runtime().multimodal_send_format
@@ -72,25 +95,24 @@ def to_prompt_message_content(
     if f.type == FileType.IMAGE:
         params["detail"] = image_detail_config or ImagePromptMessageContent.DETAIL.LOW
 
-    return prompt_class_map[f.type].model_validate(params)
+    return _PROMPT_CONTENT_CLASS_BY_FILE_TYPE[f.type].model_validate(params)
 
 
 def download(f: File, /) -> bytes:
-    if f.transfer_method in (
-        FileTransferMethod.TOOL_FILE,
-        FileTransferMethod.LOCAL_FILE,
-        FileTransferMethod.DATASOURCE_FILE,
-    ):
+    if f.transfer_method in _DOWNLOAD_TRANSFER_METHODS:
         return _download_file_content(f)
     if f.transfer_method == FileTransferMethod.REMOTE_URL:
         if f.remote_url is None:
-            raise ValueError("Missing file remote_url")
+            msg = "Missing file remote_url"
+            raise ValueError(msg)
         response = get_workflow_file_runtime().http_get(
-            f.remote_url, follow_redirects=True
+            f.remote_url,
+            follow_redirects=True,
         )
         response.raise_for_status()
         return response.content
-    raise ValueError(f"unsupported transfer method: {f.transfer_method}")
+    msg = f"unsupported transfer method: {f.transfer_method}"
+    raise ValueError(msg)
 
 
 def _download_file_content(file: File, /) -> bytes:
@@ -102,9 +124,11 @@ def _get_encoded_string(f: File, /) -> str:
     match f.transfer_method:
         case FileTransferMethod.REMOTE_URL:
             if f.remote_url is None:
-                raise ValueError("Missing file remote_url")
+                msg = "Missing file remote_url"
+                raise ValueError(msg)
             response = get_workflow_file_runtime().http_get(
-                f.remote_url, follow_redirects=True
+                f.remote_url,
+                follow_redirects=True,
             )
             response.raise_for_status()
             data = response.content
@@ -116,13 +140,6 @@ def _get_encoded_string(f: File, /) -> str:
             data = _download_file_content(f)
 
     return base64.b64encode(data).decode("utf-8")
-
-
-def _to_url(f: File, /):
-    url = f.generate_url()
-    if url is None:
-        raise ValueError(f"Unsupported transfer method: {f.transfer_method}")
-    return url
 
 
 class FileManager:

--- a/src/graphon/file/helpers.py
+++ b/src/graphon/file/helpers.py
@@ -10,12 +10,15 @@ if TYPE_CHECKING:
 
 def resolve_file_url(file: File, /, *, for_external: bool = True) -> str | None:
     return get_workflow_file_runtime().resolve_file_url(
-        file=file, for_external=for_external
+        file=file,
+        for_external=for_external,
     )
 
 
 def get_signed_file_url(
-    upload_file_id: str, as_attachment: bool = False, for_external: bool = True
+    upload_file_id: str,
+    as_attachment: bool = False,
+    for_external: bool = True,
 ) -> str:
     return get_workflow_file_runtime().resolve_upload_file_url(
         upload_file_id=upload_file_id,
@@ -25,7 +28,9 @@ def get_signed_file_url(
 
 
 def get_signed_tool_file_url(
-    tool_file_id: str, extension: str, for_external: bool = True
+    tool_file_id: str,
+    extension: str,
+    for_external: bool = True,
 ) -> str:
     return get_workflow_file_runtime().resolve_tool_file_url(
         tool_file_id=tool_file_id,
@@ -35,7 +40,11 @@ def get_signed_tool_file_url(
 
 
 def verify_image_signature(
-    *, upload_file_id: str, timestamp: str, nonce: str, sign: str
+    *,
+    upload_file_id: str,
+    timestamp: str,
+    nonce: str,
+    sign: str,
 ) -> bool:
     return get_workflow_file_runtime().verify_preview_signature(
         preview_kind="image",
@@ -47,7 +56,11 @@ def verify_image_signature(
 
 
 def verify_file_signature(
-    *, upload_file_id: str, timestamp: str, nonce: str, sign: str
+    *,
+    upload_file_id: str,
+    timestamp: str,
+    nonce: str,
+    sign: str,
 ) -> bool:
     return get_workflow_file_runtime().verify_preview_signature(
         preview_kind="file",

--- a/src/graphon/file/models.py
+++ b/src/graphon/file/models.py
@@ -17,10 +17,12 @@ _FILE_REFERENCE_PREFIX = "dify-file-ref:"
 
 
 def sign_tool_file(
-    *, tool_file_id: str, extension: str, for_external: bool = True
+    *,
+    tool_file_id: str,
+    extension: str,
+    for_external: bool = True,
 ) -> str:
-    """Compatibility shim for tests and legacy callers patching
-    ``models.sign_tool_file``."""
+    """Return a signed tool-file URL shim for tests and legacy patches."""
     return helpers.get_signed_tool_file_url(
         tool_file_id=tool_file_id,
         extension=extension,
@@ -29,8 +31,7 @@ def sign_tool_file(
 
 
 class ImageConfig(BaseModel):
-    """
-    NOTE: This part of validation is deprecated, but still used in app
+    """NOTE: This part of validation is deprecated, but still used in app
     features "Image Upload".
     """
 
@@ -40,15 +41,13 @@ class ImageConfig(BaseModel):
 
 
 class FileUploadConfig(BaseModel):
-    """
-    File Upload Entity.
-    """
+    """File Upload Entity."""
 
     image_config: ImageConfig | None = None
     allowed_file_types: Sequence[FileType] = Field(default_factory=list)
     allowed_file_extensions: Sequence[str] = Field(default_factory=list)
     allowed_file_upload_methods: Sequence[FileTransferMethod] = Field(
-        default_factory=list
+        default_factory=list,
     )
     number_limits: int = 0
 
@@ -102,7 +101,8 @@ class File(BaseModel):
     reference: str | None = None
     filename: str | None = None
     extension: str | None = Field(
-        default=None, description="File extension, should contain dot"
+        default=None,
+        description="File extension, should contain dot",
     )
     mime_type: str | None = None
     size: int = -1
@@ -111,9 +111,9 @@ class File(BaseModel):
     def __init__(
         self,
         *,
-        id: str | None = None,
+        file_id: str | None = None,
         tenant_id: str | None = None,
-        type: FileType,
+        file_type: FileType,
         transfer_method: FileTransferMethod,
         remote_url: str | None = None,
         reference: str | None = None,
@@ -129,7 +129,7 @@ class File(BaseModel):
         tool_file_id: str | None = None,
         upload_file_id: str | None = None,
         datasource_file_id: str | None = None,
-    ):
+    ) -> None:
         legacy_record_id = (
             related_id or tool_file_id or upload_file_id or datasource_file_id
         )
@@ -139,8 +139,8 @@ class File(BaseModel):
         _, parsed_storage_key = _parse_reference(normalized_reference)
 
         super().__init__(
-            id=id,
-            type=type,
+            id=file_id,
+            type=file_type,
             transfer_method=transfer_method,
             remote_url=remote_url,
             reference=normalized_reference,
@@ -193,20 +193,26 @@ class File(BaseModel):
         match self.transfer_method:
             case FileTransferMethod.REMOTE_URL:
                 if not self.remote_url:
-                    raise ValueError("Missing file url")
+                    msg = "Missing file url"
+                    raise ValueError(msg)
                 if not isinstance(
-                    self.remote_url, str
+                    self.remote_url,
+                    str,
                 ) or not self.remote_url.startswith("http"):
-                    raise ValueError("Invalid file url")
+                    msg = "Invalid file url"
+                    raise ValueError(msg)
             case FileTransferMethod.LOCAL_FILE:
                 if not self.reference:
-                    raise ValueError("Missing file reference")
+                    msg = "Missing file reference"
+                    raise ValueError(msg)
             case FileTransferMethod.TOOL_FILE:
                 if not self.reference:
-                    raise ValueError("Missing file reference")
+                    msg = "Missing file reference"
+                    raise ValueError(msg)
             case FileTransferMethod.DATASOURCE_FILE:
                 if not self.reference:
-                    raise ValueError("Missing file reference")
+                    msg = "Missing file reference"
+                    raise ValueError(msg)
         return self
 
     @property

--- a/src/graphon/file/protocols.py
+++ b/src/graphon/file/protocols.py
@@ -21,7 +21,10 @@ class WorkflowFileRuntimeProtocol(Protocol):
     def multimodal_send_format(self) -> str: ...
 
     def http_get(
-        self, url: str, *, follow_redirects: bool = True
+        self,
+        url: str,
+        *,
+        follow_redirects: bool = True,
     ) -> HttpResponseProtocol: ...
 
     def storage_load(self, path: str, *, stream: bool = False) -> bytes | Generator: ...
@@ -29,7 +32,10 @@ class WorkflowFileRuntimeProtocol(Protocol):
     def load_file_bytes(self, *, file: File) -> bytes: ...
 
     def resolve_file_url(
-        self, *, file: File, for_external: bool = True
+        self,
+        *,
+        file: File,
+        for_external: bool = True,
     ) -> str | None: ...
 
     def resolve_upload_file_url(
@@ -41,7 +47,11 @@ class WorkflowFileRuntimeProtocol(Protocol):
     ) -> str: ...
 
     def resolve_tool_file_url(
-        self, *, tool_file_id: str, extension: str, for_external: bool = True
+        self,
+        *,
+        tool_file_id: str,
+        extension: str,
+        for_external: bool = True,
     ) -> str: ...
 
     def verify_preview_signature(

--- a/src/graphon/file/runtime.py
+++ b/src/graphon/file/runtime.py
@@ -15,32 +15,43 @@ class WorkflowFileRuntimeNotConfiguredError(RuntimeError):
 
 class _UnconfiguredWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
     def _raise(self) -> NoReturn:
-        raise WorkflowFileRuntimeNotConfiguredError(
+        msg = (
             "workflow file runtime is not configured, call "
             "set_workflow_file_runtime(...) first"
         )
+        raise WorkflowFileRuntimeNotConfiguredError(msg)
 
     @property
     @override
     def multimodal_send_format(self) -> str:
-        self._raise()
+        return self._raise()
 
     @override
     def http_get(
-        self, url: str, *, follow_redirects: bool = True
+        self,
+        url: str,
+        *,
+        follow_redirects: bool = True,
     ) -> HttpResponseProtocol:
+        _ = url
+        _ = follow_redirects
         self._raise()
 
     @override
     def storage_load(self, path: str, *, stream: bool = False) -> bytes | Generator:
+        _ = path
+        _ = stream
         self._raise()
 
     @override
     def load_file_bytes(self, *, file: File) -> bytes:
+        _ = file
         self._raise()
 
     @override
     def resolve_file_url(self, *, file: File, for_external: bool = True) -> str | None:
+        _ = file
+        _ = for_external
         self._raise()
 
     @override
@@ -51,12 +62,22 @@ class _UnconfiguredWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         as_attachment: bool = False,
         for_external: bool = True,
     ) -> str:
+        _ = upload_file_id
+        _ = as_attachment
+        _ = for_external
         self._raise()
 
     @override
     def resolve_tool_file_url(
-        self, *, tool_file_id: str, extension: str, for_external: bool = True
+        self,
+        *,
+        tool_file_id: str,
+        extension: str,
+        for_external: bool = True,
     ) -> str:
+        _ = tool_file_id
+        _ = extension
+        _ = for_external
         self._raise()
 
     @override
@@ -69,6 +90,11 @@ class _UnconfiguredWorkflowFileRuntime(WorkflowFileRuntimeProtocol):
         nonce: str,
         sign: str,
     ) -> bool:
+        _ = preview_kind
+        _ = file_id
+        _ = timestamp
+        _ = nonce
+        _ = sign
         self._raise()
 
 

--- a/src/graphon/graph/graph.py
+++ b/src/graphon/graph/graph.py
@@ -21,16 +21,14 @@ _ListObjectDict = TypeAdapter(list[dict[str, object]])
 
 
 class NodeFactory(Protocol):
-    """
-    Protocol for creating Node instances from node data dictionaries.
+    """Protocol for creating Node instances from node data dictionaries.
 
     This protocol decouples the Graph class from specific node mapping implementations,
     allowing for different node creation strategies while maintaining type safety.
     """
 
     def create_node(self, node_config: NodeConfigDict) -> Node:
-        """
-        Create a Node instance from node configuration data.
+        """Create a Node instance from node configuration data.
 
         :param node_config: node configuration dictionary containing type and other data
         :return: initialized Node instance
@@ -54,9 +52,8 @@ class Graph:
         in_edges: dict[str, list[str]] | None = None,
         out_edges: dict[str, list[str]] | None = None,
         root_node: Node,
-    ):
-        """
-        Initialize Graph instance.
+    ) -> None:
+        """Initialize Graph instance.
 
         :param nodes: graph nodes mapping (node id: node object)
         :param edges: graph edges mapping (edge id: edge object)
@@ -72,13 +69,16 @@ class Graph:
 
     @classmethod
     def _parse_node_configs(
-        cls, node_configs: list[NodeConfigDict]
+        cls,
+        node_configs: list[NodeConfigDict],
     ) -> dict[str, NodeConfigDict]:
-        """
-        Parse node configurations and build a mapping of node IDs to configs.
+        """Parse node configurations and build a mapping of node IDs to configs.
 
         :param node_configs: list of node configuration dictionaries
-        :return: mapping of node ID to node config
+
+        Returns:
+            Mapping of node ID to node config.
+
         """
         node_configs_map: dict[str, NodeConfigDict] = {}
 
@@ -89,13 +89,16 @@ class Graph:
 
     @classmethod
     def _build_edges(
-        cls, edge_configs: list[dict[str, object]]
+        cls,
+        edge_configs: list[dict[str, object]],
     ) -> tuple[dict[str, Edge], dict[str, list[str]], dict[str, list[str]]]:
-        """
-        Build edge objects and mappings from edge configurations.
+        """Build edge objects and mappings from edge configurations.
 
         :param edge_configs: list of edge configurations
-        :return: tuple of (edges dict, in_edges dict, out_edges dict)
+
+        Returns:
+            Tuple of `edges`, `in_edges`, and `out_edges` mappings.
+
         """
         edges: dict[str, Edge] = {}
         in_edges: dict[str, list[str]] = defaultdict(list)
@@ -136,12 +139,14 @@ class Graph:
         node_configs_map: dict[str, NodeConfigDict],
         node_factory: NodeFactory,
     ) -> dict[str, Node]:
-        """
-        Create node instances from configurations using the node factory.
+        """Create node instances from configurations using the node factory.
 
         :param node_configs_map: mapping of node ID to node config
         :param node_factory: factory for creating node instances
-        :return: mapping of node ID to node instance
+
+        Returns:
+            Mapping of node ID to node instance.
+
         """
         nodes: dict[str, Node] = {}
 
@@ -150,7 +155,8 @@ class Graph:
                 node_instance = node_factory.create_node(node_config)
             except Exception:
                 logger.exception(
-                    "Failed to create node instance for node_id %s", node_id
+                    "Failed to create node instance for node_id %s",
+                    node_id,
                 )
                 raise
             nodes[node_id] = node_instance
@@ -160,20 +166,22 @@ class Graph:
     @classmethod
     def new(cls) -> GraphBuilder:
         """Create a fluent builder for assembling a graph programmatically."""
-
         return GraphBuilder(graph_cls=cls)
 
     @staticmethod
     def _filter_canvas_only_nodes(
         node_configs: Sequence[Mapping[str, object]],
     ) -> list[dict[str, object]]:
-        """
-        Remove editor-only nodes before `NodeConfigDict` validation.
+        """Remove editor-only nodes before `NodeConfigDict` validation.
 
         Persisted note widgets use a top-level `type == "custom-note"` but leave
         `data.type` empty because they are never executable graph nodes. Filter
         them while configs are still raw dicts so Pydantic does not validate
         their placeholder payloads against `BaseNodeData.type: NodeType`.
+
+        Returns:
+            Raw node configs with editor-only note widgets removed.
+
         """
         filtered_node_configs: list[dict[str, object]] = []
         for node_config in node_configs:
@@ -184,8 +192,7 @@ class Graph:
 
     @classmethod
     def _promote_fail_branch_nodes(cls, nodes: dict[str, Node]) -> None:
-        """
-        Promote nodes configured with FAIL_BRANCH error strategy
+        """Promote nodes configured with FAIL_BRANCH error strategy
         to branch execution type.
 
         :param nodes: mapping of node ID to node instance
@@ -203,8 +210,7 @@ class Graph:
         out_edges: dict[str, list[str]],
         active_root_id: str,
     ) -> None:
-        """
-        Mark nodes and edges from inactive root branches as skipped.
+        """Mark nodes and edges from inactive root branches as skipped.
 
         Algorithm:
         1. Mark inactive root nodes as skipped
@@ -275,13 +281,18 @@ class Graph:
         root_node_id: str,
         skip_validation: bool = False,
     ) -> Graph:
-        """
-        Initialize a graph with an explicit execution entry point.
+        """Initialize a graph with an explicit execution entry point.
 
         :param graph_config: graph config containing nodes and edges
         :param node_factory: factory for creating node instances from config data
         :param root_node_id: active root node id
-        :return: graph instance
+
+        Returns:
+            Initialized graph instance rooted at `root_node_id`.
+
+        Raises:
+            ValueError: If the graph has no nodes or `root_node_id` does not exist.
+
         """
         # Parse configs
         edge_configs = graph_config.get("edges", [])
@@ -293,13 +304,15 @@ class Graph:
         node_configs = _ListNodeConfigDict.validate_python(node_configs)
 
         if not node_configs:
-            raise ValueError("Graph must have at least one node")
+            msg = "Graph must have at least one node"
+            raise ValueError(msg)
 
         # Parse node configurations
         node_configs_map = cls._parse_node_configs(node_configs)
 
         if root_node_id not in node_configs_map:
-            raise ValueError(f"Root node id {root_node_id} not found in the graph")
+            msg = f"Root node id {root_node_id} not found in the graph"
+            raise ValueError(msg)
 
         # Build edges
         edges, in_edges, out_edges = cls._build_edges(edge_configs)
@@ -315,7 +328,11 @@ class Graph:
 
         # Mark inactive root branches as skipped
         cls._mark_inactive_root_branches(
-            nodes, edges, in_edges, out_edges, root_node_id
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            root_node_id,
         )
 
         # Create and return the graph
@@ -335,29 +352,32 @@ class Graph:
 
     @property
     def node_ids(self) -> list[str]:
-        """
-        Get list of node IDs (compatibility property for existing code)
+        """Get list of node IDs (compatibility property for existing code)
 
         :return: list of node IDs
         """
         return list(self.nodes.keys())
 
     def get_outgoing_edges(self, node_id: str) -> list[Edge]:
-        """
-        Get all outgoing edges from a node (V2 method)
+        """Get all outgoing edges from a node (V2 method)
 
         :param node_id: node id
-        :return: list of outgoing edges
+
+        Returns:
+            All edges whose tail is `node_id`.
+
         """
         edge_ids = self.out_edges.get(node_id, [])
         return [self.edges[eid] for eid in edge_ids if eid in self.edges]
 
     def get_incoming_edges(self, node_id: str) -> list[Edge]:
-        """
-        Get all incoming edges to a node (V2 method)
+        """Get all incoming edges to a node (V2 method)
 
         :param node_id: node id
-        :return: list of incoming edges
+
+        Returns:
+            All edges whose head is `node_id`.
+
         """
         edge_ids = self.in_edges.get(node_id, [])
         return [self.edges[eid] for eid in edge_ids if eid in self.edges]
@@ -367,7 +387,7 @@ class Graph:
 class GraphBuilder:
     """Fluent helper for constructing simple graphs, primarily for tests."""
 
-    def __init__(self, *, graph_cls: type[Graph]):
+    def __init__(self, *, graph_cls: type[Graph]) -> None:
         self._graph_cls = graph_cls
         self._nodes: list[Node] = []
         self._nodes_by_id: dict[str, Node] = {}
@@ -376,9 +396,9 @@ class GraphBuilder:
 
     def add_root(self, node: Node) -> GraphBuilder:
         """Register the root node. Must be called exactly once."""
-
         if self._nodes:
-            raise ValueError("Root node has already been added")
+            msg = "Root node has already been added"
+            raise ValueError(msg)
         self._register_node(node)
         self._nodes.append(node)
         return self
@@ -391,13 +411,14 @@ class GraphBuilder:
         source_handle: str = "source",
     ) -> GraphBuilder:
         """Append a node and connect it from the specified predecessor."""
-
         if not self._nodes:
-            raise ValueError("Root node must be added before adding other nodes")
+            msg = "Root node must be added before adding other nodes"
+            raise ValueError(msg)
 
         predecessor_id = from_node_id or self._nodes[-1].id
         if predecessor_id not in self._nodes_by_id:
-            raise ValueError(f"Predecessor node '{predecessor_id}' not found")
+            msg = f"Predecessor node '{predecessor_id}' not found"
+            raise ValueError(msg)
 
         predecessor = self._nodes_by_id[predecessor_id]
         self._register_node(node)
@@ -406,21 +427,29 @@ class GraphBuilder:
         edge_id = f"edge_{self._edge_counter}"
         self._edge_counter += 1
         edge = Edge(
-            id=edge_id, tail=predecessor.id, head=node.id, source_handle=source_handle
+            id=edge_id,
+            tail=predecessor.id,
+            head=node.id,
+            source_handle=source_handle,
         )
         self._edges.append(edge)
 
         return self
 
     def connect(
-        self, *, tail: str, head: str, source_handle: str = "source"
+        self,
+        *,
+        tail: str,
+        head: str,
+        source_handle: str = "source",
     ) -> GraphBuilder:
         """Connect two existing nodes without adding a new node."""
-
         if tail not in self._nodes_by_id:
-            raise ValueError(f"Tail node '{tail}' not found")
+            msg = f"Tail node '{tail}' not found"
+            raise ValueError(msg)
         if head not in self._nodes_by_id:
-            raise ValueError(f"Head node '{head}' not found")
+            msg = f"Head node '{head}' not found"
+            raise ValueError(msg)
 
         edge_id = f"edge_{self._edge_counter}"
         self._edge_counter += 1
@@ -431,9 +460,9 @@ class GraphBuilder:
 
     def build(self) -> Graph:
         """Materialize the graph instance from the accumulated nodes and edges."""
-
         if not self._nodes:
-            raise ValueError("Cannot build an empty graph")
+            msg = "Cannot build an empty graph"
+            raise ValueError(msg)
 
         nodes = {node.id: node for node in self._nodes}
         edges = {edge.id: edge for edge in self._edges}
@@ -458,7 +487,9 @@ class GraphBuilder:
 
     def _register_node(self, node: Node) -> None:
         if not node.id:
-            raise ValueError("Node must have a non-empty id")
+            msg = "Node must have a non-empty id"
+            raise ValueError(msg)
         if node.id in self._nodes_by_id:
-            raise ValueError(f"Duplicate node id detected: {node.id}")
+            msg = f"Duplicate node id detected: {node.id}"
+            raise ValueError(msg)
         self._nodes_by_id[node.id] = node

--- a/src/graphon/graph/graph_template.py
+++ b/src/graphon/graph/graph_template.py
@@ -4,8 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class GraphTemplate(BaseModel):
-    """
-    Graph Template for container nodes and subgraph expansion
+    """Graph Template for container nodes and subgraph expansion
 
     According to GraphEngine V2 spec, GraphTemplate contains:
     - nodes: mapping of node definitions
@@ -15,12 +14,15 @@ class GraphTemplate(BaseModel):
     """
 
     nodes: dict[str, dict[str, Any]] = Field(
-        default_factory=dict, description="node definitions mapping"
+        default_factory=dict,
+        description="node definitions mapping",
     )
     edges: dict[str, dict[str, Any]] = Field(
-        default_factory=dict, description="edge definitions mapping"
+        default_factory=dict,
+        description="edge definitions mapping",
     )
     root_ids: list[str] = Field(default_factory=list, description="root node IDs")
     output_selectors: list[str] = Field(
-        default_factory=list, description="output selectors"
+        default_factory=list,
+        description="output selectors",
     )

--- a/src/graphon/graph/validation.py
+++ b/src/graphon/graph/validation.py
@@ -24,7 +24,8 @@ class GraphValidationError(ValueError):
 
     def __init__(self, issues: Sequence[GraphValidationIssue]) -> None:
         if not issues:
-            raise ValueError("GraphValidationError requires at least one issue.")
+            msg = "GraphValidationError requires at least one issue."
+            raise ValueError(msg)
         self.issues: tuple[GraphValidationIssue, ...] = tuple(issues)
         message = "; ".join(f"[{issue.code}] {issue.message}" for issue in self.issues)
         super().__init__(message)
@@ -56,7 +57,7 @@ class _EdgeEndpointValidator:
                             f"'{edge.tail}'."
                         ),
                         node_id=edge.tail,
-                    )
+                    ),
                 )
             if edge.head not in graph.nodes:
                 issues.append(
@@ -67,7 +68,7 @@ class _EdgeEndpointValidator:
                             f"'{edge.head}'."
                         ),
                         node_id=edge.head,
-                    )
+                    ),
                 )
         return issues
 
@@ -93,7 +94,7 @@ class _RootNodeValidator:
                         f"Root node '{root_node.id}' is missing from the node registry."
                     ),
                     node_id=root_node.id,
-                )
+                ),
             )
             return issues
 
@@ -110,7 +111,7 @@ class _RootNodeValidator:
                         "type 'root'."
                     ),
                     node_id=root_node.id,
-                )
+                ),
             )
         return issues
 

--- a/src/graphon/graph_engine/_engine_utils.py
+++ b/src/graphon/graph_engine/_engine_utils.py
@@ -12,5 +12,9 @@ def get_timestamp() -> float:
 
     To address this, the function uses the wall clock as the time source.
     However, it assumes that the clocks of all servers are properly synchronized.
+
+    Returns:
+        Rounded wall-clock seconds since the Unix epoch.
+
     """
     return round(time.time())

--- a/src/graphon/graph_engine/command_channels/in_memory_channel.py
+++ b/src/graphon/graph_engine/command_channels/in_memory_channel.py
@@ -1,11 +1,10 @@
-"""
-In-memory implementation of CommandChannel for local/testing scenarios.
+"""In-memory implementation of CommandChannel for local/testing scenarios.
 
 This implementation uses a thread-safe queue for command communication
 within a single process. Each instance handles commands for one workflow execution.
 """
 
-from queue import Queue
+from queue import Empty, Queue
 from typing import final
 
 from ..entities.commands import GraphEngineCommand
@@ -13,8 +12,7 @@ from ..entities.commands import GraphEngineCommand
 
 @final
 class InMemoryChannel:
-    """
-    In-memory command channel implementation using a thread-safe queue.
+    """In-memory command channel implementation using a thread-safe queue.
 
     Each instance is dedicated to a single GraphEngine/workflow execution.
     Suitable for local development, testing, and single-instance deployments.
@@ -25,11 +23,11 @@ class InMemoryChannel:
         self._queue: Queue[GraphEngineCommand] = Queue()
 
     def fetch_commands(self) -> list[GraphEngineCommand]:
-        """
-        Fetch all pending commands from the queue.
+        """Fetch all pending commands from the queue.
 
         Returns:
             List of pending commands (drains the queue)
+
         """
         commands: list[GraphEngineCommand] = []
 
@@ -38,16 +36,16 @@ class InMemoryChannel:
             try:
                 command = self._queue.get_nowait()
                 commands.append(command)
-            except Exception:
+            except Empty:
                 break
 
         return commands
 
     def send_command(self, command: GraphEngineCommand) -> None:
-        """
-        Send a command to this channel's queue.
+        """Send a command to this channel's queue.
 
         Args:
             command: The command to send
+
         """
         self._queue.put(command)

--- a/src/graphon/graph_engine/command_channels/protocol.py
+++ b/src/graphon/graph_engine/command_channels/protocol.py
@@ -1,5 +1,4 @@
-"""
-CommandChannel protocol for GraphEngine command communication.
+"""CommandChannel protocol for GraphEngine command communication.
 
 This protocol defines the interface for sending and receiving commands
 to/from a GraphEngine instance, supporting both local and distributed scenarios.
@@ -11,31 +10,30 @@ from ..entities.commands import GraphEngineCommand
 
 
 class CommandChannel(Protocol):
-    """
-    Protocol for bidirectional command communication with GraphEngine.
+    """Protocol for bidirectional command communication with GraphEngine.
 
     Since each GraphEngine instance processes only one workflow execution,
     this channel is dedicated to that single execution.
     """
 
     def fetch_commands(self) -> list[GraphEngineCommand]:
-        """
-        Fetch pending commands for this GraphEngine instance.
+        """Fetch pending commands for this GraphEngine instance.
 
         Called by GraphEngine to poll for commands that need to be processed.
 
         Returns:
             List of pending commands (may be empty)
+
         """
         ...
 
     def send_command(self, command: GraphEngineCommand) -> None:
-        """
-        Send a command to be processed by this GraphEngine instance.
+        """Send a command to be processed by this GraphEngine instance.
 
         Called by external systems to send control commands to the running workflow.
 
         Args:
             command: The command to send
+
         """
         ...

--- a/src/graphon/graph_engine/command_channels/redis_channel.py
+++ b/src/graphon/graph_engine/command_channels/redis_channel.py
@@ -1,5 +1,4 @@
-"""
-Redis-based implementation of CommandChannel for distributed scenarios.
+"""Redis-based implementation of CommandChannel for distributed scenarios.
 
 This implementation uses Redis lists for command queuing, supporting
 multi-instance deployments and cross-server communication.
@@ -17,6 +16,12 @@ from ..entities.commands import (
     PauseCommand,
     UpdateVariablesCommand,
 )
+
+_COMMAND_MODEL_BY_TYPE: dict[CommandType, type[GraphEngineCommand]] = {
+    CommandType.ABORT: AbortCommand,
+    CommandType.PAUSE: PauseCommand,
+    CommandType.UPDATE_VARIABLES: UpdateVariablesCommand,
+}
 
 
 class RedisPipelineProtocol(Protocol):
@@ -39,8 +44,7 @@ class RedisClientProtocol(Protocol):
 
 @final
 class RedisChannel:
-    """
-    Redis-based command channel implementation for distributed systems.
+    """Redis-based command channel implementation for distributed systems.
 
     Each instance uses a unique Redis key for its command queue.
     Commands are JSON-serialized for transport.
@@ -52,13 +56,13 @@ class RedisChannel:
         channel_key: str,
         command_ttl: int = 3600,
     ) -> None:
-        """
-        Initialize the Redis channel.
+        """Initialize the Redis channel.
 
         Args:
             redis_client: Redis client instance
             channel_key: Unique key for this channel's command queue
             command_ttl: TTL for command keys in seconds (default: 3600)
+
         """
         self._redis = redis_client
         self._key = channel_key
@@ -66,11 +70,11 @@ class RedisChannel:
         self._pending_key = f"{channel_key}:pending"
 
     def fetch_commands(self) -> list[GraphEngineCommand]:
-        """
-        Fetch all pending commands from Redis.
+        """Fetch all pending commands from Redis.
 
         Returns:
             List of pending commands (drains the Redis list)
+
         """
         if not self._has_pending_commands():
             return []
@@ -99,11 +103,11 @@ class RedisChannel:
         return commands
 
     def send_command(self, command: GraphEngineCommand) -> None:
-        """
-        Send a command to Redis.
+        """Send a command to Redis.
 
         Args:
             command: The command to send
+
         """
         command_json = json.dumps(command.model_dump())
 
@@ -115,14 +119,14 @@ class RedisChannel:
             pipe.execute()
 
     def _deserialize_command(self, data: dict[str, Any]) -> GraphEngineCommand | None:
-        """
-        Deserialize a command from dictionary data.
+        """Deserialize a command from dictionary data.
 
         Args:
             data: Command data dictionary
 
         Returns:
             Deserialized command or None if invalid
+
         """
         command_type_value = data.get("command_type")
         if not isinstance(command_type_value, str):
@@ -130,26 +134,18 @@ class RedisChannel:
 
         try:
             command_type = CommandType(command_type_value)
-
-            if command_type == CommandType.ABORT:
-                return AbortCommand.model_validate(data)
-            if command_type == CommandType.PAUSE:
-                return PauseCommand.model_validate(data)
-            if command_type == CommandType.UPDATE_VARIABLES:
-                return UpdateVariablesCommand.model_validate(data)
-
-            # For other command types, use base class
-            return GraphEngineCommand.model_validate(data)
+            command_model = _COMMAND_MODEL_BY_TYPE.get(command_type, GraphEngineCommand)
+            return command_model.model_validate(data)
 
         except (ValueError, TypeError):
             return None
 
     def _has_pending_commands(self) -> bool:
-        """
-        Check and consume the pending marker to avoid unnecessary list reads.
+        """Check and consume the pending marker to avoid unnecessary list reads.
 
         Returns:
             True if commands should be fetched from Redis.
+
         """
         with self._redis.pipeline() as pipe:
             pipe.get(self._pending_key)

--- a/src/graphon/graph_engine/command_processing/__init__.py
+++ b/src/graphon/graph_engine/command_processing/__init__.py
@@ -1,5 +1,4 @@
-"""
-Command processing subsystem for graph engine.
+"""Command processing subsystem for graph engine.
 
 This package handles external commands sent to the engine
 during execution.

--- a/src/graphon/graph_engine/command_processing/command_processor.py
+++ b/src/graphon/graph_engine/command_processing/command_processor.py
@@ -1,6 +1,4 @@
-"""
-Main command processor for handling external commands.
-"""
+"""Main command processor for handling external commands."""
 
 import logging
 from typing import Protocol, final
@@ -16,14 +14,15 @@ class CommandHandler(Protocol):
     """Protocol for command handlers."""
 
     def handle(
-        self, command: GraphEngineCommand, execution: GraphExecution
+        self,
+        command: GraphEngineCommand,
+        execution: GraphExecution,
     ) -> None: ...
 
 
 @final
 class CommandProcessor:
-    """
-    Processes external commands sent to the engine.
+    """Processes external commands sent to the engine.
 
     This polls the command channel and dispatches commands to
     appropriate handlers.
@@ -34,26 +33,28 @@ class CommandProcessor:
         command_channel: CommandChannel,
         graph_execution: GraphExecution,
     ) -> None:
-        """
-        Initialize the command processor.
+        """Initialize the command processor.
 
         Args:
             command_channel: Channel for receiving commands
             graph_execution: Graph execution aggregate
+
         """
         self._command_channel = command_channel
         self._graph_execution = graph_execution
         self._handlers: dict[type[GraphEngineCommand], CommandHandler] = {}
 
     def register_handler(
-        self, command_type: type[GraphEngineCommand], handler: CommandHandler
+        self,
+        command_type: type[GraphEngineCommand],
+        handler: CommandHandler,
     ) -> None:
-        """
-        Register a handler for a command type.
+        """Register a handler for a command type.
 
         Args:
             command_type: Type of command to handle
             handler: Handler for the command
+
         """
         self._handlers[command_type] = handler
 
@@ -63,15 +64,15 @@ class CommandProcessor:
             commands = self._command_channel.fetch_commands()
             for command in commands:
                 self._handle_command(command)
-        except Exception as e:
-            logger.warning("Error processing commands: %s", e)
+        except Exception:
+            logger.exception("Error processing commands")
 
     def _handle_command(self, command: GraphEngineCommand) -> None:
-        """
-        Handle a single command.
+        """Handle a single command.
 
         Args:
             command: The command to handle
+
         """
         handler = self._handlers.get(type(command))
         if handler:
@@ -79,9 +80,11 @@ class CommandProcessor:
                 handler.handle(command, self._graph_execution)
             except Exception:
                 logger.exception(
-                    "Error handling command %s", command.__class__.__name__
+                    "Error handling command %s",
+                    command.__class__.__name__,
                 )
         else:
             logger.warning(
-                "No handler registered for command: %s", command.__class__.__name__
+                "No handler registered for command: %s",
+                command.__class__.__name__,
             )

--- a/src/graphon/graph_engine/config.py
+++ b/src/graphon/graph_engine/config.py
@@ -1,6 +1,4 @@
-"""
-GraphEngine configuration models.
-"""
+"""GraphEngine configuration models."""
 
 from pydantic import BaseModel, ConfigDict
 

--- a/src/graphon/graph_engine/domain/__init__.py
+++ b/src/graphon/graph_engine/domain/__init__.py
@@ -1,5 +1,4 @@
-"""
-Domain models for graph engine.
+"""Domain models for graph engine.
 
 This package contains the core domain entities, value objects, and aggregates
 that represent the business concepts of workflow graph execution.

--- a/src/graphon/graph_engine/domain/graph_execution.py
+++ b/src/graphon/graph_engine/domain/graph_execution.py
@@ -47,13 +47,12 @@ class GraphExecutionState(BaseModel):
     error: GraphExecutionErrorState | None = Field(default=None)
     exceptions_count: int = Field(default=0)
     node_executions: list[NodeExecutionState] = Field(
-        default_factory=list[NodeExecutionState]
+        default_factory=list[NodeExecutionState],
     )
 
 
 def _serialize_error(error: Exception | None) -> GraphExecutionErrorState | None:
     """Convert an exception into its serializable representation."""
-
     if error is None:
         return None
 
@@ -66,7 +65,6 @@ def _serialize_error(error: Exception | None) -> GraphExecutionErrorState | None
 
 def _resolve_exception_class(module_name: str, qualname: str) -> type[Exception]:
     """Locate an exception class from its module and qualified name."""
-
     module = import_module(module_name)
     attr: object = module
     for part in qualname.split("."):
@@ -75,12 +73,12 @@ def _resolve_exception_class(module_name: str, qualname: str) -> type[Exception]
     if isinstance(attr, type) and issubclass(attr, Exception):
         return attr
 
-    raise TypeError(f"{qualname} in {module_name} is not an Exception subclass")
+    msg = f"{qualname} in {module_name} is not an Exception subclass"
+    raise TypeError(msg)
 
 
 def _deserialize_error(state: GraphExecutionErrorState | None) -> Exception | None:
     """Reconstruct an exception instance from serialized data."""
-
     if state is None:
         return None
 
@@ -89,7 +87,7 @@ def _deserialize_error(state: GraphExecutionErrorState | None) -> Exception | No
         if state.message is None:
             return exception_class()
         return exception_class(state.message)
-    except Exception:
+    except (ImportError, AttributeError, TypeError, ValueError):
         # Fallback to RuntimeError when reconstruction fails
         if state.message is None:
             return RuntimeError(state.qualname)
@@ -98,8 +96,7 @@ def _deserialize_error(state: GraphExecutionErrorState | None) -> Exception | No
 
 @dataclass
 class GraphExecution:
-    """
-    Aggregate root for graph execution.
+    """Aggregate root for graph execution.
 
     This manages the overall execution state of a workflow graph,
     coordinating between multiple node executions.
@@ -113,22 +110,25 @@ class GraphExecution:
     pause_reasons: list[PauseReason] = field(default_factory=list)
     error: Exception | None = None
     node_executions: dict[str, NodeExecution] = field(
-        default_factory=dict[str, NodeExecution]
+        default_factory=dict[str, NodeExecution],
     )
     exceptions_count: int = 0
 
     def start(self) -> None:
         """Mark the graph execution as started."""
         if self.started:
-            raise RuntimeError("Graph execution already started")
+            msg = "Graph execution already started"
+            raise RuntimeError(msg)
         self.started = True
 
     def complete(self) -> None:
         """Mark the graph execution as completed."""
         if not self.started:
-            raise RuntimeError("Cannot complete execution that hasn't started")
+            msg = "Cannot complete execution that hasn't started"
+            raise RuntimeError(msg)
         if self.completed:
-            raise RuntimeError("Graph execution already completed")
+            msg = "Graph execution already completed"
+            raise RuntimeError(msg)
         self.completed = True
 
     def abort(self, reason: str) -> None:
@@ -139,9 +139,11 @@ class GraphExecution:
     def pause(self, reason: PauseReason) -> None:
         """Pause the graph execution without marking it complete."""
         if self.completed:
-            raise RuntimeError("Cannot pause execution that has completed")
+            msg = "Cannot pause execution that has completed"
+            raise RuntimeError(msg)
         if self.aborted:
-            raise RuntimeError("Cannot pause execution that has been aborted")
+            msg = "Cannot pause execution that has been aborted"
+            raise RuntimeError(msg)
         self.paused = True
         self.pause_reasons.append(reason)
 
@@ -182,7 +184,6 @@ class GraphExecution:
 
     def dumps(self) -> str:
         """Serialize the aggregate state into a JSON string."""
-
         node_states = [
             NodeExecutionState(
                 node_id=node_id,
@@ -210,17 +211,19 @@ class GraphExecution:
 
     def loads(self, data: str) -> None:
         """Restore aggregate state from a serialized JSON string."""
-
         state = GraphExecutionState.model_validate_json(data)
 
         if state.type != "GraphExecution":
-            raise ValueError(f"Invalid serialized data type: {state.type}")
+            msg = f"Invalid serialized data type: {state.type}"
+            raise ValueError(msg)
 
         if state.version != "1.0":
-            raise ValueError(f"Unsupported serialized version: {state.version}")
+            msg = f"Unsupported serialized version: {state.version}"
+            raise ValueError(msg)
 
         if self.workflow_id != state.workflow_id:
-            raise ValueError("Serialized workflow_id does not match aggregate identity")
+            msg = "Serialized workflow_id does not match aggregate identity"
+            raise ValueError(msg)
 
         self.started = state.started
         self.completed = state.completed

--- a/src/graphon/graph_engine/domain/node_execution.py
+++ b/src/graphon/graph_engine/domain/node_execution.py
@@ -1,6 +1,4 @@
-"""
-NodeExecution entity representing a node's execution state.
-"""
+"""NodeExecution entity representing a node's execution state."""
 
 from dataclasses import dataclass
 
@@ -9,8 +7,7 @@ from graphon.enums import NodeState
 
 @dataclass
 class NodeExecution:
-    """
-    Entity representing the execution state of a single node.
+    """Entity representing the execution state of a single node.
 
     This is a mutable entity that tracks the runtime state of a node
     during graph execution.

--- a/src/graphon/graph_engine/entities/commands.py
+++ b/src/graphon/graph_engine/entities/commands.py
@@ -1,5 +1,4 @@
-"""
-GraphEngine command entities for external control.
+"""GraphEngine command entities for external control.
 
 This module defines command types that can be sent to a running GraphEngine
 instance to control its execution flow.
@@ -27,7 +26,8 @@ class GraphEngineCommand(BaseModel):
 
     command_type: CommandType = Field(..., description="Type of command")
     payload: dict[str, Any] | None = Field(
-        default=None, description="Optional command payload"
+        default=None,
+        description="Optional command payload",
     )
 
 
@@ -35,7 +35,8 @@ class AbortCommand(GraphEngineCommand):
     """Command to abort a running workflow execution."""
 
     command_type: CommandType = Field(
-        default=CommandType.ABORT, description="Type of command"
+        default=CommandType.ABORT,
+        description="Type of command",
     )
     reason: str | None = Field(default=None, description="Optional reason for abort")
 
@@ -44,7 +45,8 @@ class PauseCommand(GraphEngineCommand):
     """Command to pause a running workflow execution."""
 
     command_type: CommandType = Field(
-        default=CommandType.PAUSE, description="Type of command"
+        default=CommandType.PAUSE,
+        description="Type of command",
     )
     reason: str = Field(default="unknown reason", description="reason for pause")
 
@@ -59,8 +61,10 @@ class UpdateVariablesCommand(GraphEngineCommand):
     """Command to update a group of variables in the variable pool."""
 
     command_type: CommandType = Field(
-        default=CommandType.UPDATE_VARIABLES, description="Type of command"
+        default=CommandType.UPDATE_VARIABLES,
+        description="Type of command",
     )
     updates: Sequence[VariableUpdate] = Field(
-        default_factory=list, description="Variable updates"
+        default_factory=list,
+        description="Variable updates",
     )

--- a/src/graphon/graph_engine/error_handler.py
+++ b/src/graphon/graph_engine/error_handler.py
@@ -1,6 +1,4 @@
-"""
-Main error handler that coordinates error strategies.
-"""
+"""Main error handler that coordinates error strategies."""
 
 import logging
 import time
@@ -30,8 +28,7 @@ logger = logging.getLogger(__name__)
 
 @final
 class ErrorHandler:
-    """
-    Coordinates error handling strategies for node failures.
+    """Coordinates error handling strategies for node failures.
 
     This acts as a facade for the various error strategies,
     selecting and applying the appropriate strategy based on
@@ -39,21 +36,21 @@ class ErrorHandler:
     """
 
     def __init__(self, graph: Graph, graph_execution: "GraphExecution") -> None:
-        """
-        Initialize the error handler.
+        """Initialize the error handler.
 
         Args:
             graph: The workflow graph
             graph_execution: The graph execution state
+
         """
         self._graph = graph
         self._graph_execution = graph_execution
 
     def handle_node_failure(
-        self, event: NodeRunFailedEvent
+        self,
+        event: NodeRunFailedEvent,
     ) -> GraphNodeEventBase | None:
-        """
-        Handle a node failure event.
+        """Handle a node failure event.
 
         Selects and applies the appropriate error strategy based on
         the node's configuration.
@@ -63,11 +60,12 @@ class ErrorHandler:
 
         Returns:
             Optional new event to process, or None to abort
+
         """
         node = self._graph.nodes[event.node_id]
         # Get retry count from NodeExecution
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         retry_count = node_execution.retry_count
 
@@ -89,9 +87,8 @@ class ErrorHandler:
             case ErrorStrategyEnum.DEFAULT_VALUE:
                 return self._handle_default_value(event)
 
-    def _handle_abort(self, event: NodeRunFailedEvent):
-        """
-        Handle error by aborting execution.
+    def _handle_abort(self, event: NodeRunFailedEvent) -> None:
+        """Handle error by aborting execution.
 
         This is the default strategy when no other strategy is specified.
         It stops the entire graph execution when a node fails.
@@ -99,17 +96,20 @@ class ErrorHandler:
         Args:
             event: The failure event
 
-        Returns:
-            None - signals abortion
         """
         logger.error(
-            "Node %s failed with ABORT strategy: %s", event.node_id, event.error
+            "Node %s failed with ABORT strategy: %s",
+            event.node_id,
+            event.error,
         )
         # Return None to signal that execution should stop
 
-    def _handle_retry(self, event: NodeRunFailedEvent, retry_count: int):
-        """
-        Handle error by retrying the node.
+    def _handle_retry(
+        self,
+        event: NodeRunFailedEvent,
+        retry_count: int,
+    ) -> NodeRunRetryEvent | None:
+        """Handle error by retrying the node.
 
         This strategy re-attempts node execution up to a configured
         maximum number of retries with configurable intervals.
@@ -120,6 +120,7 @@ class ErrorHandler:
 
         Returns:
             NodeRunRetryEvent if retry should occur, None otherwise
+
         """
         node = self._graph.nodes[event.node_id]
 
@@ -142,9 +143,8 @@ class ErrorHandler:
             retry_index=retry_count + 1,
         )
 
-    def _handle_fail_branch(self, event: NodeRunFailedEvent):
-        """
-        Handle error by taking the fail branch.
+    def _handle_fail_branch(self, event: NodeRunFailedEvent) -> NodeRunExceptionEvent:
+        """Handle error by taking the fail branch.
 
         This strategy converts failures to exceptions and routes execution
         through a designated fail-branch edge.
@@ -154,6 +154,7 @@ class ErrorHandler:
 
         Returns:
             NodeRunExceptionEvent to continue via fail branch
+
         """
         outputs = {
             "error_message": event.node_run_result.error,
@@ -181,9 +182,8 @@ class ErrorHandler:
             error=event.error,
         )
 
-    def _handle_default_value(self, event: NodeRunFailedEvent):
-        """
-        Handle error by using default values.
+    def _handle_default_value(self, event: NodeRunFailedEvent) -> NodeRunExceptionEvent:
+        """Handle error by using default values.
 
         This strategy allows nodes to fail gracefully by providing
         predefined default output values.
@@ -193,6 +193,7 @@ class ErrorHandler:
 
         Returns:
             NodeRunExceptionEvent with default values
+
         """
         node = self._graph.nodes[event.node_id]
 

--- a/src/graphon/graph_engine/event_management/__init__.py
+++ b/src/graphon/graph_engine/event_management/__init__.py
@@ -1,5 +1,4 @@
-"""
-Event management subsystem for graph engine.
+"""Event management subsystem for graph engine.
 
 This package handles event routing, collection, and emission for
 workflow graph execution events.

--- a/src/graphon/graph_engine/event_management/event_handlers.py
+++ b/src/graphon/graph_engine/event_management/event_handlers.py
@@ -1,6 +1,4 @@
-"""
-Event handler implementations for different event types.
-"""
+"""Event handler implementations for different event types."""
 
 import logging
 from collections.abc import Mapping
@@ -51,8 +49,7 @@ logger = logging.getLogger(__name__)
 
 @final
 class EventHandler:
-    """
-    Registry of event handlers for different event types.
+    """Registry of event handlers for different event types.
 
     This centralizes the business logic for handling specific events,
     keeping it separate from the routing and collection infrastructure.
@@ -69,8 +66,7 @@ class EventHandler:
         state_manager: "GraphStateManager",
         error_handler: "ErrorHandler",
     ) -> None:
-        """
-        Initialize the event handler registry.
+        """Initialize the event handler registry.
 
         Args:
             graph: The workflow graph
@@ -81,6 +77,7 @@ class EventHandler:
             edge_processor: Edge processor for edge traversal
             state_manager: Unified state manager
             error_handler: Error handler
+
         """
         self._graph = graph
         self._graph_runtime_state = graph_runtime_state
@@ -92,11 +89,11 @@ class EventHandler:
         self._error_handler = error_handler
 
     def dispatch(self, event: GraphNodeEventBase) -> None:
-        """
-        Handle any node event by dispatching to the appropriate handler.
+        """Handle any node event by dispatching to the appropriate handler.
 
         Args:
             event: The event to handle
+
         """
         if isinstance(event, NodeRunVariableUpdatedEvent):
             self._dispatch(event)
@@ -128,15 +125,15 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunStartedEvent) -> None:
-        """
-        Handle node started event.
+        """Handle node started event.
 
         Args:
             event: The node started event
+
         """
         # Track execution in domain model
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         is_initial_attempt = node_execution.retry_count == 0
         node_execution.mark_started(event.id)
@@ -151,11 +148,11 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunStreamChunkEvent) -> None:
-        """
-        Handle stream chunk event with full processing.
+        """Handle stream chunk event with full processing.
 
         Args:
             event: The stream chunk event
+
         """
         # Process with response coordinator
         streaming_events = list(self._response_coordinator.intercept_event(event))
@@ -166,31 +163,31 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunVariableUpdatedEvent) -> None:
-        """
-        Apply a node-requested variable mutation before downstream observers run.
+        """Apply a node-requested variable mutation before downstream observers run.
 
         The event is collected like other node events so parent/container engines can
         forward the updated payload to outer layers, including persistence listeners.
         """
         self._graph_runtime_state.variable_pool.add(
-            event.variable.selector, event.variable
+            event.variable.selector,
+            event.variable,
         )
         self._event_collector.collect(event)
 
     @_dispatch.register
     def _(self, event: NodeRunSucceededEvent) -> None:
-        """
-        Handle node success by coordinating subsystems.
+        """Handle node success by coordinating subsystems.
 
         This method coordinates between different subsystems to process
         node completion, handle edges, and trigger downstream execution.
 
         Args:
             event: The node succeeded event
+
         """
         # Update domain model
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         node_execution.mark_taken()
 
@@ -209,7 +206,8 @@ class EventHandler:
         if node.execution_type == NodeExecutionType.BRANCH:
             ready_nodes, edge_streaming_events = (
                 self._edge_processor.handle_branch_completion(
-                    event.node_id, event.node_run_result.edge_source_handle
+                    event.node_id,
+                    event.node_run_result.edge_source_handle,
                 )
             )
         else:
@@ -243,7 +241,6 @@ class EventHandler:
     @_dispatch.register
     def _(self, event: NodeRunPauseRequestedEvent) -> None:
         """Handle pause requests emitted by nodes."""
-
         pause_reason = event.reason
         self._graph_execution.pause(pause_reason)
         self._state_manager.finish_execution(event.node_id)
@@ -254,15 +251,15 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunFailedEvent) -> None:
-        """
-        Handle node failure using error handler.
+        """Handle node failure using error handler.
 
         Args:
             event: The node failed event
+
         """
         # Update domain model
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         node_execution.mark_failed(event.error)
         self._graph_execution.record_node_failure()
@@ -282,15 +279,15 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunExceptionEvent) -> None:
-        """
-        Handle node exception event (fail-branch strategy).
+        """Handle node exception event (fail-branch strategy).
 
         Args:
             event: The node exception event
+
         """
         # Node continues via fail-branch/default-value, treat as completion
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         node_execution.mark_taken()
 
@@ -308,13 +305,13 @@ class EventHandler:
         elif node.error_strategy == ErrorStrategy.FAIL_BRANCH:
             ready_nodes, edge_streaming_events = (
                 self._edge_processor.handle_branch_completion(
-                    event.node_id, event.node_run_result.edge_source_handle
+                    event.node_id,
+                    event.node_run_result.edge_source_handle,
                 )
             )
         else:
-            raise NotImplementedError(
-                f"Unsupported error strategy: {node.error_strategy}"
-            )
+            msg = f"Unsupported error strategy: {node.error_strategy}"
+            raise NotImplementedError(msg)
 
         for edge_event in edge_streaming_events:
             self._event_collector.collect(edge_event)
@@ -334,14 +331,14 @@ class EventHandler:
 
     @_dispatch.register
     def _(self, event: NodeRunRetryEvent) -> None:
-        """
-        Handle node retry event.
+        """Handle node retry event.
 
         Args:
             event: The node retry event
+
         """
         node_execution = self._graph_execution.get_or_create_node_execution(
-            event.node_id
+            event.node_id,
         )
         node_execution.increment_retry()
 
@@ -369,15 +366,17 @@ class EventHandler:
             self._graph_runtime_state.llm_usage = current_usage.plus(usage)
 
     def _store_node_outputs(self, node_id: str, outputs: Mapping[str, object]) -> None:
-        """
-        Store node outputs in the variable pool.
+        """Store node outputs in the variable pool.
 
         Args:
-            event: The node succeeded event containing outputs
+            node_id: Identifier of the node whose outputs are being stored.
+            outputs: Mapping of output names to values produced by the node.
+
         """
         for variable_name, variable_value in outputs.items():
             self._graph_runtime_state.variable_pool.add(
-                (node_id, variable_name), variable_value
+                (node_id, variable_name),
+                variable_value,
             )
 
     def _update_response_outputs(self, outputs: Mapping[str, object]) -> None:

--- a/src/graphon/graph_engine/event_management/event_manager.py
+++ b/src/graphon/graph_engine/event_management/event_manager.py
@@ -1,6 +1,4 @@
-"""
-Unified event manager for collecting and emitting events.
-"""
+"""Unified event manager for collecting and emitting events."""
 
 import logging
 import threading
@@ -18,8 +16,7 @@ _logger = logging.getLogger(__name__)
 
 @final
 class ReadWriteLock:
-    """
-    A read-write lock implementation that allows multiple concurrent readers
+    """A read-write lock implementation that allows multiple concurrent readers
     but only one writer at a time.
     """
 
@@ -76,8 +73,7 @@ class ReadWriteLock:
 
 @final
 class EventManager:
-    """
-    Unified event manager that collects, buffers, and emits events.
+    """Unified event manager that collects, buffers, and emits events.
 
     This class combines event collection with event emission, providing
     thread-safe event management with support for notifying layers and
@@ -92,11 +88,11 @@ class EventManager:
         self._execution_complete = threading.Event()
 
     def set_layers(self, layers: list[GraphEngineLayer]) -> None:
-        """
-        Set the layers to notify on event collection.
+        """Set the layers to notify on event collection.
 
         Args:
             layers: List of layers to notify
+
         """
         self._layers = layers
 
@@ -105,11 +101,11 @@ class EventManager:
         self._notify_layers(event)
 
     def collect(self, event: GraphEngineEvent) -> None:
-        """
-        Thread-safe method to collect an event.
+        """Thread-safe method to collect an event.
 
         Args:
             event: The event to collect
+
         """
         with self._lock.write_lock():
             self._events.append(event)
@@ -122,24 +118,24 @@ class EventManager:
         self._notify_layers(event)
 
     def _get_new_events(self, start_index: int) -> list[GraphEngineEvent]:
-        """
-        Get new events starting from a specific index.
+        """Get new events starting from a specific index.
 
         Args:
             start_index: The index to start from
 
         Returns:
             List of new events
+
         """
         with self._lock.read_lock():
             return list(self._events[start_index:])
 
     def _event_count(self) -> int:
-        """
-        Get the current count of collected events.
+        """Get the current count of collected events.
 
         Returns:
             Number of collected events
+
         """
         with self._lock.read_lock():
             return len(self._events)
@@ -149,11 +145,11 @@ class EventManager:
         self._execution_complete.set()
 
     def emit_events(self) -> Generator[GraphEngineEvent, None, None]:
-        """
-        Generator that yields events as they're collected.
+        """Generator that yields events as they're collected.
 
         Yields:
             GraphEngineEvent instances as they're processed
+
         """
         yielded_count = 0
 
@@ -173,13 +169,13 @@ class EventManager:
                 time.sleep(0.001)
 
     def _notify_layers(self, event: GraphEngineEvent) -> None:
-        """
-        Notify all layers of an event.
+        """Notify all layers of an event.
 
         Layer exceptions are caught and logged to prevent disrupting collection.
 
         Args:
             event: The event to send to layers
+
         """
         for layer in self._layers:
             try:

--- a/src/graphon/graph_engine/graph_engine.py
+++ b/src/graphon/graph_engine/graph_engine.py
@@ -1,5 +1,4 @@
-"""
-QueueBasedGraphEngine - Main orchestrator for queue-based workflow execution.
+"""QueueBasedGraphEngine - Main orchestrator for queue-based workflow execution.
 
 This engine uses a modular architecture with separated packages following
 Domain-Driven Design principles for improved maintainability and testability.
@@ -62,8 +61,7 @@ _DEFAULT_CONFIG = GraphEngineConfig()
 
 @final
 class GraphEngine:
-    """
-    Queue-based graph execution engine.
+    """Queue-based graph execution engine.
 
     Uses a modular architecture that delegates responsibilities to specialized
     subsystems, following Domain-Driven Design and SOLID principles.
@@ -79,7 +77,6 @@ class GraphEngine:
         child_engine_builder: ChildGraphEngineBuilderProtocol | None = None,
     ) -> None:
         """Initialize the graph engine with all subsystems and dependencies."""
-
         # Bind runtime state to current workflow context
         self._graph = graph
         self._graph_runtime_state = graph_runtime_state
@@ -148,10 +145,11 @@ class GraphEngine:
         self._command_processor.register_handler(PauseCommand, pause_handler)
 
         update_variables_handler = UpdateVariablesCommandHandler(
-            self._graph_runtime_state.variable_pool
+            self._graph_runtime_state.variable_pool,
         )
         self._command_processor.register_handler(
-            UpdateVariablesCommand, update_variables_handler
+            UpdateVariablesCommand,
+            update_variables_handler,
         )
 
         # === Worker Pool Setup ===
@@ -204,10 +202,11 @@ class GraphEngine:
         expected_state_id = id(self._graph_runtime_state)
         for node in self._graph.nodes.values():
             if id(node.graph_runtime_state) != expected_state_id:
-                raise ValueError(
+                msg = (
                     "GraphRuntimeState consistency violation: Node "
                     f"'{node.id}' has a different instance"
                 )
+                raise ValueError(msg)
 
     def _bind_layer_context(
         self,
@@ -227,7 +226,7 @@ class GraphEngine:
     def request_abort(self, reason: str | None = None) -> None:
         """Queue an abort command for this engine."""
         self._command_channel.send_command(
-            AbortCommand(reason=reason or "User requested abort")
+            AbortCommand(reason=reason or "User requested abort"),
         )
 
     def create_child_engine(
@@ -246,11 +245,11 @@ class GraphEngine:
         )
 
     def run(self) -> Generator[GraphEngineEvent, None, None]:
-        """
-        Execute the graph using the modular architecture.
+        """Execute the graph using the modular architecture.
 
-        Returns:
-            Generator yielding GraphEngineEvent instances
+        Yields:
+            `GraphEngineEvent` instances emitted during workflow execution.
+
         """
         try:
             # Initialize layers
@@ -278,51 +277,11 @@ class GraphEngine:
             yield from self._event_manager.emit_events()
 
             # Handle completion
-            if self._graph_execution.is_paused:
-                pause_reasons = self._graph_execution.pause_reasons
-                assert pause_reasons, (
-                    "pause_reasons should not be empty when execution is paused."
-                )
-                # Ensure we have a valid PauseReason for the event
-                paused_event = GraphRunPausedEvent(
-                    reasons=pause_reasons,
-                    outputs=self._graph_runtime_state.outputs,
-                )
-                self._event_manager.notify_layers(paused_event)
-                yield paused_event
-            elif self._graph_execution.aborted:
-                abort_reason = "Workflow execution aborted by user command"
-                if self._graph_execution.error:
-                    abort_reason = str(self._graph_execution.error)
-                aborted_event = GraphRunAbortedEvent(
-                    reason=abort_reason,
-                    outputs=self._graph_runtime_state.outputs,
-                )
-                self._event_manager.notify_layers(aborted_event)
-                yield aborted_event
-            elif self._graph_execution.has_error:
-                if self._graph_execution.error:
-                    raise self._graph_execution.error
-            else:
-                outputs = self._graph_runtime_state.outputs
-                exceptions_count = self._graph_execution.exceptions_count
-                if exceptions_count > 0:
-                    partial_event = GraphRunPartialSucceededEvent(
-                        exceptions_count=exceptions_count,
-                        outputs=outputs,
-                    )
-                    self._event_manager.notify_layers(partial_event)
-                    yield partial_event
-                else:
-                    succeeded_event = GraphRunSucceededEvent(
-                        outputs=outputs,
-                    )
-                    self._event_manager.notify_layers(succeeded_event)
-                    yield succeeded_event
+            yield from self._emit_terminal_events()
 
-        except Exception as e:
+        except Exception as error:
             failed_event = GraphRunFailedEvent(
-                error=str(e),
+                error=str(error),
                 exceptions_count=self._graph_execution.exceptions_count,
             )
             self._event_manager.notify_layers(failed_event)
@@ -332,6 +291,56 @@ class GraphEngine:
         finally:
             self._stop_execution()
 
+    def _emit_terminal_events(self) -> Generator[GraphEngineEvent, None, None]:
+        if self._graph_execution.is_paused:
+            pause_reasons = self._graph_execution.pause_reasons
+            assert pause_reasons, (
+                "pause_reasons should not be empty when execution is paused."
+            )
+            # Ensure we have a valid PauseReason for the event
+            paused_event = GraphRunPausedEvent(
+                reasons=pause_reasons,
+                outputs=self._graph_runtime_state.outputs,
+            )
+            self._event_manager.notify_layers(paused_event)
+            yield paused_event
+            return
+
+        if self._graph_execution.aborted:
+            abort_reason = "Workflow execution aborted by user command"
+            if self._graph_execution.error:
+                abort_reason = str(self._graph_execution.error)
+            aborted_event = GraphRunAbortedEvent(
+                reason=abort_reason,
+                outputs=self._graph_runtime_state.outputs,
+            )
+            self._event_manager.notify_layers(aborted_event)
+            yield aborted_event
+            return
+
+        if self._graph_execution.has_error:
+            error = self._graph_execution.error
+            if error is not None:
+                raise error
+            return
+
+        outputs = self._graph_runtime_state.outputs
+        exceptions_count = self._graph_execution.exceptions_count
+        if exceptions_count > 0:
+            partial_event = GraphRunPartialSucceededEvent(
+                exceptions_count=exceptions_count,
+                outputs=outputs,
+            )
+            self._event_manager.notify_layers(partial_event)
+            yield partial_event
+            return
+
+        succeeded_event = GraphRunSucceededEvent(
+            outputs=outputs,
+        )
+        self._event_manager.notify_layers(succeeded_event)
+        yield succeeded_event
+
     def _initialize_layers(self) -> None:
         """Initialize layers with context."""
         self._event_manager.set_layers(self._layers)
@@ -340,7 +349,8 @@ class GraphEngine:
                 layer.on_graph_start()
             except Exception:
                 logger.exception(
-                    "Layer %s failed on_graph_start", layer.__class__.__name__
+                    "Layer %s failed on_graph_start",
+                    layer.__class__.__name__,
                 )
 
     def _start_execution(self, *, resume: bool = False) -> None:
@@ -388,7 +398,8 @@ class GraphEngine:
                 layer.on_graph_end(self._graph_execution.error)
             except Exception:
                 logger.exception(
-                    "Layer %s failed on_graph_end", layer.__class__.__name__
+                    "Layer %s failed on_graph_end",
+                    layer.__class__.__name__,
                 )
 
     # Public property accessors for attributes that need external access

--- a/src/graphon/graph_engine/graph_state_manager.py
+++ b/src/graphon/graph_engine/graph_state_manager.py
@@ -1,6 +1,4 @@
-"""
-Graph state manager that combines node, edge, and execution tracking.
-"""
+"""Graph state manager that combines node, edge, and execution tracking."""
 
 import threading
 from collections.abc import Sequence
@@ -24,12 +22,12 @@ class EdgeStateAnalysis(TypedDict):
 @final
 class GraphStateManager:
     def __init__(self, graph: Graph, ready_queue: ReadyQueue) -> None:
-        """
-        Initialize the state manager.
+        """Initialize the state manager.
 
         Args:
             graph: The workflow graph
             ready_queue: Queue for nodes ready to execute
+
         """
         self._graph = graph
         self._ready_queue = ready_queue
@@ -41,32 +39,31 @@ class GraphStateManager:
     # ============= Node State Operations =============
 
     def enqueue_node(self, node_id: str) -> None:
-        """
-        Mark a node as TAKEN and add it to the ready queue.
+        """Mark a node as TAKEN and add it to the ready queue.
 
         This combines the state transition and enqueueing operations
         that always occur together when preparing a node for execution.
 
         Args:
             node_id: The ID of the node to enqueue
+
         """
         with self._lock:
             self._graph.nodes[node_id].state = NodeState.TAKEN
             self._ready_queue.put(node_id)
 
     def mark_node_skipped(self, node_id: str) -> None:
-        """
-        Mark a node as SKIPPED.
+        """Mark a node as SKIPPED.
 
         Args:
             node_id: The ID of the node to skip
+
         """
         with self._lock:
             self._graph.nodes[node_id].state = NodeState.SKIPPED
 
     def is_node_ready(self, node_id: str) -> bool:
-        """
-        Check if a node is ready to be executed.
+        """Check if a node is ready to be executed.
 
         A node is ready when all its incoming edges from taken branches
         have been satisfied.
@@ -76,6 +73,7 @@ class GraphStateManager:
 
         Returns:
             True if the node is ready for execution
+
         """
         with self._lock:
             # Get all incoming edges to this node
@@ -93,14 +91,14 @@ class GraphStateManager:
             return any(edge.state == NodeState.TAKEN for edge in incoming_edges)
 
     def get_node_state(self, node_id: str) -> NodeState:
-        """
-        Get the current state of a node.
+        """Get the current state of a node.
 
         Args:
             node_id: The ID of the node
 
         Returns:
             The current node state
+
         """
         with self._lock:
             return self._graph.nodes[node_id].state
@@ -108,34 +106,34 @@ class GraphStateManager:
     # ============= Edge State Operations =============
 
     def mark_edge_taken(self, edge_id: str) -> None:
-        """
-        Mark an edge as TAKEN.
+        """Mark an edge as TAKEN.
 
         Args:
             edge_id: The ID of the edge to mark
+
         """
         with self._lock:
             self._graph.edges[edge_id].state = NodeState.TAKEN
 
     def mark_edge_skipped(self, edge_id: str) -> None:
-        """
-        Mark an edge as SKIPPED.
+        """Mark an edge as SKIPPED.
 
         Args:
             edge_id: The ID of the edge to mark
+
         """
         with self._lock:
             self._graph.edges[edge_id].state = NodeState.SKIPPED
 
     def analyze_edge_states(self, edges: list[Edge]) -> EdgeStateAnalysis:
-        """
-        Analyze the states of edges and return summary flags.
+        """Analyze the states of edges and return summary flags.
 
         Args:
             edges: List of edges to analyze
 
         Returns:
             Analysis result with state flags
+
         """
         with self._lock:
             states = {edge.state for edge in edges}
@@ -143,27 +141,30 @@ class GraphStateManager:
             return EdgeStateAnalysis(
                 has_unknown=NodeState.UNKNOWN in states,
                 has_taken=NodeState.TAKEN in states,
-                all_skipped=states == {NodeState.SKIPPED} if states else True,
+                all_skipped=(
+                    states == frozenset((NodeState.SKIPPED,)) if states else True
+                ),
             )
 
     def get_edge_state(self, edge_id: str) -> NodeState:
-        """
-        Get the current state of an edge.
+        """Get the current state of an edge.
 
         Args:
             edge_id: The ID of the edge
 
         Returns:
             The current edge state
+
         """
         with self._lock:
             return self._graph.edges[edge_id].state
 
     def categorize_branch_edges(
-        self, node_id: str, selected_handle: str
+        self,
+        node_id: str,
+        selected_handle: str,
     ) -> tuple[Sequence[Edge], Sequence[Edge]]:
-        """
-        Categorize branch edges into selected and unselected.
+        """Categorize branch edges into selected and unselected.
 
         Args:
             node_id: The ID of the branch node
@@ -171,6 +172,7 @@ class GraphStateManager:
 
         Returns:
             A tuple of (selected_edges, unselected_edges)
+
         """
         with self._lock:
             outgoing_edges = self._graph.get_outgoing_edges(node_id)
@@ -188,44 +190,44 @@ class GraphStateManager:
     # ============= Execution Tracking Operations =============
 
     def start_execution(self, node_id: str) -> None:
-        """
-        Mark a node as executing.
+        """Mark a node as executing.
 
         Args:
             node_id: The ID of the node starting execution
+
         """
         with self._lock:
             self._executing_nodes.add(node_id)
 
     def finish_execution(self, node_id: str) -> None:
-        """
-        Mark a node as no longer executing.
+        """Mark a node as no longer executing.
 
         Args:
             node_id: The ID of the node finishing execution
+
         """
         with self._lock:
             self._executing_nodes.discard(node_id)
 
     def is_executing(self, node_id: str) -> bool:
-        """
-        Check if a node is currently executing.
+        """Check if a node is currently executing.
 
         Args:
             node_id: The ID of the node to check
 
         Returns:
             True if the node is executing
+
         """
         with self._lock:
             return node_id in self._executing_nodes
 
     def get_executing_count(self) -> int:
-        """
-        Get the count of currently executing nodes.
+        """Get the count of currently executing nodes.
 
         Returns:
             Number of executing nodes
+
         """
         # This count is a best-effort snapshot and can change concurrently.
         # Only use it for pause-drain checks where scheduling is already frozen.
@@ -233,11 +235,11 @@ class GraphStateManager:
             return len(self._executing_nodes)
 
     def get_executing_nodes(self) -> set[str]:
-        """
-        Get a copy of the set of executing node IDs.
+        """Get a copy of the set of executing node IDs.
 
         Returns:
             Set of node IDs currently executing
+
         """
         with self._lock:
             return self._executing_nodes.copy()
@@ -250,8 +252,7 @@ class GraphStateManager:
     # ============= Composite Operations =============
 
     def is_execution_complete(self) -> bool:
-        """
-        Check if graph execution is complete.
+        """Check if graph execution is complete.
 
         Execution is complete when:
         - Ready queue is empty
@@ -259,25 +260,26 @@ class GraphStateManager:
 
         Returns:
             True if execution is complete
+
         """
         with self._lock:
             return self._ready_queue.empty() and len(self._executing_nodes) == 0
 
     def get_queue_depth(self) -> int:
-        """
-        Get the current depth of the ready queue.
+        """Get the current depth of the ready queue.
 
         Returns:
             Number of nodes in the ready queue
+
         """
         return self._ready_queue.qsize()
 
     def get_execution_stats(self) -> dict[str, int]:
-        """
-        Get execution statistics.
+        """Get execution statistics.
 
         Returns:
             Dictionary with execution statistics
+
         """
         with self._lock:
             taken_nodes = sum(

--- a/src/graphon/graph_engine/graph_traversal/__init__.py
+++ b/src/graphon/graph_engine/graph_traversal/__init__.py
@@ -1,5 +1,4 @@
-"""
-Graph traversal subsystem for graph engine.
+"""Graph traversal subsystem for graph engine.
 
 This package handles graph navigation, edge processing,
 and skip propagation logic.

--- a/src/graphon/graph_engine/graph_traversal/edge_processor.py
+++ b/src/graphon/graph_engine/graph_traversal/edge_processor.py
@@ -1,6 +1,4 @@
-"""
-Edge processing logic for graph traversal.
-"""
+"""Edge processing logic for graph traversal."""
 
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, final
@@ -19,8 +17,7 @@ if TYPE_CHECKING:
 
 @final
 class EdgeProcessor:
-    """
-    Processes edges during graph execution.
+    """Processes edges during graph execution.
 
     This handles marking edges as taken or skipped, notifying
     the response coordinator, triggering downstream node execution,
@@ -34,14 +31,14 @@ class EdgeProcessor:
         response_coordinator: ResponseStreamCoordinator,
         skip_propagator: "SkipPropagator",
     ) -> None:
-        """
-        Initialize the edge processor.
+        """Initialize the edge processor.
 
         Args:
             graph: The workflow graph
             state_manager: Unified state manager
             response_coordinator: Response stream coordinator
             skip_propagator: Propagator for skip states
+
         """
         self._graph = graph
         self._state_manager = state_manager
@@ -49,10 +46,11 @@ class EdgeProcessor:
         self._skip_propagator = skip_propagator
 
     def process_node_success(
-        self, node_id: str, selected_handle: str | None = None
+        self,
+        node_id: str,
+        selected_handle: str | None = None,
     ) -> tuple[Sequence[str], Sequence[NodeRunStreamChunkEvent]]:
-        """
-        Process edges after a node succeeds.
+        """Process edges after a node succeeds.
 
         Args:
             node_id: The ID of the succeeded node
@@ -61,6 +59,7 @@ class EdgeProcessor:
         Returns:
             Tuple of (list of downstream node IDs that are now ready,
             list of streaming events)
+
         """
         node = self._graph.nodes[node_id]
 
@@ -69,10 +68,10 @@ class EdgeProcessor:
         return self._process_non_branch_node_edges(node_id)
 
     def _process_non_branch_node_edges(
-        self, node_id: str
+        self,
+        node_id: str,
     ) -> tuple[Sequence[str], Sequence[NodeRunStreamChunkEvent]]:
-        """
-        Process edges for non-branch nodes (mark all as TAKEN).
+        """Process edges for non-branch nodes (mark all as TAKEN).
 
         Args:
             node_id: The ID of the succeeded node
@@ -80,6 +79,7 @@ class EdgeProcessor:
         Returns:
             Tuple of (list of downstream nodes ready for execution,
             list of streaming events)
+
         """
         ready_nodes: list[str] = []
         all_streaming_events: list[NodeRunStreamChunkEvent] = []
@@ -93,10 +93,11 @@ class EdgeProcessor:
         return ready_nodes, all_streaming_events
 
     def _process_branch_node_edges(
-        self, node_id: str, selected_handle: str | None
+        self,
+        node_id: str,
+        selected_handle: str | None,
     ) -> tuple[Sequence[str], Sequence[NodeRunStreamChunkEvent]]:
-        """
-        Process edges for branch nodes.
+        """Process edges for branch nodes.
 
         Args:
             node_id: The ID of the branch node
@@ -108,16 +109,19 @@ class EdgeProcessor:
 
         Raises:
             ValueError: If no edge was selected
+
         """
         if not selected_handle:
-            raise ValueError(f"Branch node {node_id} did not select any edge")
+            msg = f"Branch node {node_id} did not select any edge"
+            raise ValueError(msg)
 
         ready_nodes: list[str] = []
         all_streaming_events: list[NodeRunStreamChunkEvent] = []
 
         # Categorize edges
         selected_edges, unselected_edges = self._state_manager.categorize_branch_edges(
-            node_id, selected_handle
+            node_id,
+            selected_handle,
         )
 
         # Process unselected edges first (mark as skipped)
@@ -133,10 +137,10 @@ class EdgeProcessor:
         return ready_nodes, all_streaming_events
 
     def _process_taken_edge(
-        self, edge: Edge
+        self,
+        edge: Edge,
     ) -> tuple[Sequence[str], Sequence[NodeRunStreamChunkEvent]]:
-        """
-        Mark edge as taken and check downstream node.
+        """Mark edge as taken and check downstream node.
 
         Args:
             edge: The edge to process
@@ -146,6 +150,7 @@ class EdgeProcessor:
                 list containing downstream node ID if it's ready,
                 list of streaming events
             )
+
         """
         # Mark edge as taken
         self._state_manager.mark_edge_taken(edge.id)
@@ -161,19 +166,20 @@ class EdgeProcessor:
         return ready_nodes, streaming_events
 
     def _process_skipped_edge(self, edge: Edge) -> None:
-        """
-        Mark edge as skipped.
+        """Mark edge as skipped.
 
         Args:
             edge: The edge to skip
+
         """
         self._state_manager.mark_edge_skipped(edge.id)
 
     def handle_branch_completion(
-        self, node_id: str, selected_handle: str | None
+        self,
+        node_id: str,
+        selected_handle: str | None,
     ) -> tuple[Sequence[str], Sequence[NodeRunStreamChunkEvent]]:
-        """
-        Handle completion of a branch node.
+        """Handle completion of a branch node.
 
         Args:
             node_id: The ID of the branch node
@@ -185,15 +191,16 @@ class EdgeProcessor:
 
         Raises:
             ValueError: If no branch was selected
+
         """
         if not selected_handle:
-            raise ValueError(
-                f"Branch node {node_id} completed without selecting a branch"
-            )
+            msg = f"Branch node {node_id} completed without selecting a branch"
+            raise ValueError(msg)
 
         # Categorize edges into selected and unselected
         _, unselected_edges = self._state_manager.categorize_branch_edges(
-            node_id, selected_handle
+            node_id,
+            selected_handle,
         )
 
         # Skip all unselected paths
@@ -203,8 +210,7 @@ class EdgeProcessor:
         return self.process_node_success(node_id, selected_handle)
 
     def validate_branch_selection(self, node_id: str, selected_handle: str) -> bool:
-        """
-        Validate that a branch selection is valid.
+        """Validate that a branch selection is valid.
 
         Args:
             node_id: The ID of the branch node
@@ -212,6 +218,7 @@ class EdgeProcessor:
 
         Returns:
             True if the selection is valid
+
         """
         outgoing_edges = self._graph.get_outgoing_edges(node_id)
         valid_handles = {edge.source_handle for edge in outgoing_edges}

--- a/src/graphon/graph_engine/graph_traversal/skip_propagator.py
+++ b/src/graphon/graph_engine/graph_traversal/skip_propagator.py
@@ -1,6 +1,4 @@
-"""
-Skip state propagation through the graph.
-"""
+"""Skip state propagation through the graph."""
 
 from collections.abc import Sequence
 from typing import final
@@ -13,8 +11,7 @@ from ..graph_state_manager import GraphStateManager
 
 @final
 class SkipPropagator:
-    """
-    Propagates skip states through the graph.
+    """Propagates skip states through the graph.
 
     When a node is skipped, this ensures all downstream nodes
     that depend solely on it are also skipped.
@@ -25,19 +22,18 @@ class SkipPropagator:
         graph: Graph,
         state_manager: GraphStateManager,
     ) -> None:
-        """
-        Initialize the skip propagator.
+        """Initialize the skip propagator.
 
         Args:
             graph: The workflow graph
             state_manager: Unified state manager
+
         """
         self._graph = graph
         self._state_manager = state_manager
 
     def propagate_skip_from_edge(self, edge_id: str) -> None:
-        """
-        Recursively propagate skip state from a skipped edge.
+        """Recursively propagate skip state from a skipped edge.
 
         Rules:
         - If a node has any UNKNOWN incoming edges, stop processing
@@ -46,6 +42,7 @@ class SkipPropagator:
 
         Args:
             edge_id: The ID of the skipped edge to start from
+
         """
         downstream_node_id = self._graph.edges[edge_id].head
         incoming_edges = self._graph.get_incoming_edges(downstream_node_id)
@@ -69,11 +66,11 @@ class SkipPropagator:
             self._propagate_skip_to_node(downstream_node_id)
 
     def _propagate_skip_to_node(self, node_id: str) -> None:
-        """
-        Mark a node and all its outgoing edges as skipped.
+        """Mark a node and all its outgoing edges as skipped.
 
         Args:
             node_id: The ID of the node to skip
+
         """
         # Mark node as skipped
         self._state_manager.mark_node_skipped(node_id)
@@ -86,11 +83,11 @@ class SkipPropagator:
             self.propagate_skip_from_edge(edge.id)
 
     def skip_branch_paths(self, unselected_edges: Sequence[Edge]) -> None:
-        """
-        Skip all paths from unselected branch edges.
+        """Skip all paths from unselected branch edges.
 
         Args:
             unselected_edges: List of edges not taken by the branch
+
         """
         for edge in unselected_edges:
             self._state_manager.mark_edge_skipped(edge.id)

--- a/src/graphon/graph_engine/layers/__init__.py
+++ b/src/graphon/graph_engine/layers/__init__.py
@@ -1,5 +1,4 @@
-"""
-Layer system for GraphEngine extensibility.
+"""Layer system for GraphEngine extensibility.
 
 This module provides the layer infrastructure for extending GraphEngine functionality
 with middleware-like components that can observe events and interact with execution.

--- a/src/graphon/graph_engine/layers/base.py
+++ b/src/graphon/graph_engine/layers/base.py
@@ -1,5 +1,4 @@
-"""
-Base layer class for GraphEngine extensions.
+"""Base layer class for GraphEngine extensions.
 
 This module provides the abstract base class for implementing layers that can
 intercept and respond to GraphEngine events.
@@ -23,13 +22,12 @@ class GraphEngineLayerNotInitializedError(Exception):
         name = layer_name or "GraphEngineLayer"
         super().__init__(
             f"{name} runtime state is not initialized. "
-            "Bind the layer to a GraphEngine before access."
+            "Bind the layer to a GraphEngine before access.",
         )
 
 
 class GraphEngineLayer(ABC):
-    """
-    Abstract base class for GraphEngine layers.
+    """Abstract base class for GraphEngine layers.
 
     Layers are middleware-like components that can:
     - Observe all events emitted by the GraphEngine
@@ -56,23 +54,23 @@ class GraphEngineLayer(ABC):
         graph_runtime_state: ReadOnlyGraphRuntimeState,
         command_channel: CommandChannel,
     ) -> None:
-        """
-        Initialize the layer with engine dependencies.
+        """Initialize the layer with engine dependencies.
 
         Called by GraphEngine to inject the read-only runtime state and command channel.
         This is invoked when the layer is registered with a `GraphEngine` instance.
         Implementations should be idempotent.
+
         Args:
             graph_runtime_state: Read-only view of the runtime state
             command_channel: Channel for sending commands to the engine
+
         """
         self._graph_runtime_state = graph_runtime_state
         self.command_channel = command_channel
 
     @abstractmethod
     def on_graph_start(self) -> None:
-        """
-        Called when graph execution starts.
+        """Called when graph execution starts.
 
         This is called after the engine has been initialized but before any nodes
         are executed. Layers can use this to set up resources or log start information.
@@ -80,8 +78,7 @@ class GraphEngineLayer(ABC):
 
     @abstractmethod
     def on_event(self, event: GraphEngineEvent) -> None:
-        """
-        Called for every event emitted by the engine.
+        """Called for every event emitted by the engine.
 
         This method receives all events generated during graph execution, including:
         - Graph lifecycle events (start, success, failure)
@@ -91,23 +88,23 @@ class GraphEngineLayer(ABC):
 
         Args:
             event: The event emitted by the engine
+
         """
 
     @abstractmethod
     def on_graph_end(self, error: Exception | None) -> None:
-        """
-        Called when graph execution ends.
+        """Called when graph execution ends.
 
         This is called after all nodes have been executed or when execution is
         aborted. Layers can use this to clean up resources or log final state.
 
         Args:
             error: The exception that caused execution to fail, or None if successful
+
         """
 
     def on_node_run_start(self, node: Node) -> None:
-        """
-        Called immediately before a node begins execution.
+        """Called immediately before a node begins execution.
 
         Layers can override to inject behavior (e.g., start spans)
         prior to node execution.
@@ -116,8 +113,9 @@ class GraphEngineLayer(ABC):
 
         Args:
             node: The node instance about to be executed
+
         """
-        return
+        _ = node
 
     def on_node_run_end(
         self,
@@ -125,8 +123,7 @@ class GraphEngineLayer(ABC):
         error: Exception | None,
         result_event: GraphNodeEventBase | None = None,
     ) -> None:
-        """
-        Called after a node finishes execution.
+        """Called after a node finishes execution.
 
         The node's execution ID is available via `node._node_execution_id` and matches
         the `id` field in all events emitted by this node execution.
@@ -136,5 +133,8 @@ class GraphEngineLayer(ABC):
             error: Exception instance if the node failed, otherwise None
             result_event: The final result event from node execution
             (succeeded/failed/paused), if any
+
         """
-        return
+        _ = node
+        _ = error
+        _ = result_event

--- a/src/graphon/graph_engine/layers/debug_logging.py
+++ b/src/graphon/graph_engine/layers/debug_logging.py
@@ -1,5 +1,4 @@
-"""
-Debug logging layer for GraphEngine.
+"""Debug logging layer for GraphEngine.
 
 This module provides a layer that logs all events and state changes during
 graph execution for debugging purposes.
@@ -43,8 +42,7 @@ from .base import GraphEngineLayer
 
 @final
 class DebugLoggingLayer(GraphEngineLayer):
-    """
-    A layer that provides comprehensive logging of GraphEngine execution.
+    """A layer that provides comprehensive logging of GraphEngine execution.
 
     This layer logs all events with configurable detail levels, helping developers
     debug workflow execution and understand the flow of events.
@@ -59,8 +57,7 @@ class DebugLoggingLayer(GraphEngineLayer):
         logger_name: str = "GraphEngine.Debug",
         max_value_length: int = 500,
     ) -> None:
-        """
-        Initialize the debug logging layer.
+        """Initialize the debug logging layer.
 
         Args:
             level: Logging level (DEBUG, INFO, WARNING, ERROR)
@@ -69,6 +66,7 @@ class DebugLoggingLayer(GraphEngineLayer):
             include_process_data: Whether to log node process data
             logger_name: Name of the logger to use
             max_value_length: Maximum length of logged values (truncated if longer)
+
         """
         super().__init__()
         self.level = level
@@ -122,138 +120,174 @@ class DebugLoggingLayer(GraphEngineLayer):
     def on_event(self, event: GraphEngineEvent) -> None:
         """Log individual events based on their type."""
         event_class = event.__class__.__name__
+        match event:
+            case GraphRunStartedEvent():
+                self._log_graph_run_started_event(event)
+            case GraphRunSucceededEvent():
+                self._log_graph_run_succeeded_event(event)
+            case GraphRunPartialSucceededEvent():
+                self._log_graph_run_partial_succeeded_event(event)
+            case GraphRunFailedEvent():
+                self._log_graph_run_failed_event(event)
+            case GraphRunAbortedEvent():
+                self._log_graph_run_aborted_event(event)
+            case NodeRunRetryEvent():
+                self._log_node_run_retry_event(event)
+            case NodeRunStartedEvent():
+                self._log_node_run_started_event(event)
+            case NodeRunSucceededEvent():
+                self._log_node_run_succeeded_event(event)
+            case NodeRunFailedEvent():
+                self._log_node_run_failed_event(event)
+            case NodeRunExceptionEvent():
+                self._log_node_run_exception_event(event)
+            case NodeRunStreamChunkEvent():
+                self._log_node_run_stream_chunk_event(event)
+            case NodeRunIterationStartedEvent():
+                self._log_iteration_started_event(event)
+            case NodeRunIterationNextEvent():
+                self._log_iteration_next_event(event)
+            case NodeRunIterationSucceededEvent():
+                self._log_iteration_succeeded_event(event)
+            case NodeRunIterationFailedEvent():
+                self._log_iteration_failed_event(event)
+            case NodeRunLoopStartedEvent():
+                self._log_loop_started_event(event)
+            case NodeRunLoopNextEvent():
+                self._log_loop_next_event(event)
+            case NodeRunLoopSucceededEvent():
+                self._log_loop_succeeded_event(event)
+            case NodeRunLoopFailedEvent():
+                self._log_loop_failed_event(event)
+            case _:
+                self.logger.debug("Event: %s", event_class)
 
-        # Graph-level events
-        if isinstance(event, GraphRunStartedEvent):
-            self.logger.debug("Graph run started event")
+    def _log_graph_run_started_event(self, event: GraphRunStartedEvent) -> None:
+        _ = event
+        self.logger.debug("Graph run started event")
 
-        elif isinstance(event, GraphRunSucceededEvent):
-            self.logger.info("✅ Graph run succeeded")
-            if self.include_outputs and event.outputs:
-                self.logger.info(
-                    "  Final outputs: %s", self._format_dict(event.outputs)
-                )
+    def _log_graph_run_succeeded_event(self, event: GraphRunSucceededEvent) -> None:
+        self.logger.info("✅ Graph run succeeded")
+        if self.include_outputs and event.outputs:
+            self.logger.info("  Final outputs: %s", self._format_dict(event.outputs))
 
-        elif isinstance(event, GraphRunPartialSucceededEvent):
-            self.logger.warning("⚠️ Graph run partially succeeded")
-            if event.exceptions_count > 0:
-                self.logger.warning("  Total exceptions: %s", event.exceptions_count)
-            if self.include_outputs and event.outputs:
-                self.logger.info(
-                    "  Final outputs: %s", self._format_dict(event.outputs)
-                )
+    def _log_graph_run_partial_succeeded_event(
+        self,
+        event: GraphRunPartialSucceededEvent,
+    ) -> None:
+        self.logger.warning("⚠️ Graph run partially succeeded")
+        if event.exceptions_count > 0:
+            self.logger.warning("  Total exceptions: %s", event.exceptions_count)
+        if self.include_outputs and event.outputs:
+            self.logger.info("  Final outputs: %s", self._format_dict(event.outputs))
 
-        elif isinstance(event, GraphRunFailedEvent):
-            self.logger.error("❌ Graph run failed: %s", event.error)
-            if event.exceptions_count > 0:
-                self.logger.error("  Total exceptions: %s", event.exceptions_count)
+    def _log_graph_run_failed_event(self, event: GraphRunFailedEvent) -> None:
+        self.logger.error("❌ Graph run failed: %s", event.error)
+        if event.exceptions_count > 0:
+            self.logger.error("  Total exceptions: %s", event.exceptions_count)
 
-        elif isinstance(event, GraphRunAbortedEvent):
-            self.logger.warning("⚠️ Graph run aborted: %s", event.reason)
-            if event.outputs:
-                self.logger.info(
-                    "  Partial outputs: %s", self._format_dict(event.outputs)
-                )
+    def _log_graph_run_aborted_event(self, event: GraphRunAbortedEvent) -> None:
+        self.logger.warning("⚠️ Graph run aborted: %s", event.reason)
+        if event.outputs:
+            self.logger.info("  Partial outputs: %s", self._format_dict(event.outputs))
 
-        # Node-level events
-        # Retry before Started because Retry subclasses Started;
-        elif isinstance(event, NodeRunRetryEvent):
-            self.retry_count += 1
-            self.logger.warning(
-                "🔄 Node retry: %s (attempt %s)", event.node_id, event.retry_index
-            )
-            self.logger.warning("  Previous error: %s", event.error)
+    def _log_node_run_retry_event(self, event: NodeRunRetryEvent) -> None:
+        self.retry_count += 1
+        self.logger.warning(
+            "🔄 Node retry: %s (attempt %s)",
+            event.node_id,
+            event.retry_index,
+        )
+        self.logger.warning("  Previous error: %s", event.error)
 
-        elif isinstance(event, NodeRunStartedEvent):
-            self.node_count += 1
-            self.logger.info(
-                '▶️ Node started: %s - "%s" (type: %s)',
-                event.node_id,
-                event.node_title,
-                event.node_type,
-            )
-
-            if self.include_inputs and event.node_run_result.inputs:
-                self.logger.debug(
-                    "  Inputs: %s", self._format_dict(event.node_run_result.inputs)
-                )
-
-        elif isinstance(event, NodeRunSucceededEvent):
-            self.success_count += 1
-            self.logger.info("✅ Node succeeded: %s", event.node_id)
-
-            if self.include_outputs and event.node_run_result.outputs:
-                self.logger.debug(
-                    "  Outputs: %s", self._format_dict(event.node_run_result.outputs)
-                )
-
-            if self.include_process_data and event.node_run_result.process_data:
-                self.logger.debug(
-                    "  Process data: %s",
-                    self._format_dict(event.node_run_result.process_data),
-                )
-
-        elif isinstance(event, NodeRunFailedEvent):
-            self.failure_count += 1
-            self.logger.error("❌ Node failed: %s", event.node_id)
-            self.logger.error("  Error: %s", event.error)
-
-            if event.node_run_result.error:
-                self.logger.error("  Details: %s", event.node_run_result.error)
-
-        elif isinstance(event, NodeRunExceptionEvent):
-            self.logger.warning("⚠️ Node exception handled: %s", event.node_id)
-            self.logger.warning("  Error: %s", event.error)
-
-        elif isinstance(event, NodeRunStreamChunkEvent):
-            # Log stream chunks at debug level to avoid spam
-            final_indicator = " (FINAL)" if event.is_final else ""
+    def _log_node_run_started_event(self, event: NodeRunStartedEvent) -> None:
+        self.node_count += 1
+        self.logger.info(
+            '▶️ Node started: %s - "%s" (type: %s)',
+            event.node_id,
+            event.node_title,
+            event.node_type,
+        )
+        if self.include_inputs and event.node_run_result.inputs:
             self.logger.debug(
-                "📝 Stream chunk from %s%s: %s",
-                event.node_id,
-                final_indicator,
-                self._truncate_value(event.chunk),
+                "  Inputs: %s",
+                self._format_dict(event.node_run_result.inputs),
             )
 
-        # Iteration events
-        elif isinstance(event, NodeRunIterationStartedEvent):
-            self.logger.info("🔁 Iteration started: %s", event.node_id)
-
-        elif isinstance(event, NodeRunIterationNextEvent):
+    def _log_node_run_succeeded_event(self, event: NodeRunSucceededEvent) -> None:
+        self.success_count += 1
+        self.logger.info("✅ Node succeeded: %s", event.node_id)
+        if self.include_outputs and event.node_run_result.outputs:
             self.logger.debug(
-                "  Iteration next: %s (index: %s)", event.node_id, event.index
+                "  Outputs: %s",
+                self._format_dict(event.node_run_result.outputs),
             )
-
-        elif isinstance(event, NodeRunIterationSucceededEvent):
-            self.logger.info("✅ Iteration succeeded: %s", event.node_id)
-            if self.include_outputs and event.outputs:
-                self.logger.debug("  Outputs: %s", self._format_dict(event.outputs))
-
-        elif isinstance(event, NodeRunIterationFailedEvent):
-            self.logger.error("❌ Iteration failed: %s", event.node_id)
-            self.logger.error("  Error: %s", event.error)
-
-        # Loop events
-        elif isinstance(event, NodeRunLoopStartedEvent):
-            self.logger.info("🔄 Loop started: %s", event.node_id)
-
-        elif isinstance(event, NodeRunLoopNextEvent):
+        if self.include_process_data and event.node_run_result.process_data:
             self.logger.debug(
-                "  Loop iteration: %s (index: %s)", event.node_id, event.index
+                "  Process data: %s",
+                self._format_dict(event.node_run_result.process_data),
             )
 
-        elif isinstance(event, NodeRunLoopSucceededEvent):
-            self.logger.info("✅ Loop succeeded: %s", event.node_id)
-            if self.include_outputs and event.outputs:
-                self.logger.debug("  Outputs: %s", self._format_dict(event.outputs))
+    def _log_node_run_failed_event(self, event: NodeRunFailedEvent) -> None:
+        self.failure_count += 1
+        self.logger.error("❌ Node failed: %s", event.node_id)
+        self.logger.error("  Error: %s", event.error)
+        if event.node_run_result.error:
+            self.logger.error("  Details: %s", event.node_run_result.error)
 
-        elif isinstance(event, NodeRunLoopFailedEvent):
-            self.logger.error("❌ Loop failed: %s", event.node_id)
-            self.logger.error("  Error: %s", event.error)
+    def _log_node_run_exception_event(self, event: NodeRunExceptionEvent) -> None:
+        self.logger.warning("⚠️ Node exception handled: %s", event.node_id)
+        self.logger.warning("  Error: %s", event.error)
 
-        else:
-            # Log unknown events at debug level
-            self.logger.debug("Event: %s", event_class)
+    def _log_node_run_stream_chunk_event(self, event: NodeRunStreamChunkEvent) -> None:
+        final_indicator = " (FINAL)" if event.is_final else ""
+        self.logger.debug(
+            "📝 Stream chunk from %s%s: %s",
+            event.node_id,
+            final_indicator,
+            self._truncate_value(event.chunk),
+        )
+
+    def _log_iteration_started_event(self, event: NodeRunIterationStartedEvent) -> None:
+        self.logger.info("🔁 Iteration started: %s", event.node_id)
+
+    def _log_iteration_next_event(self, event: NodeRunIterationNextEvent) -> None:
+        self.logger.debug(
+            "  Iteration next: %s (index: %s)",
+            event.node_id,
+            event.index,
+        )
+
+    def _log_iteration_succeeded_event(
+        self,
+        event: NodeRunIterationSucceededEvent,
+    ) -> None:
+        self.logger.info("✅ Iteration succeeded: %s", event.node_id)
+        if self.include_outputs and event.outputs:
+            self.logger.debug("  Outputs: %s", self._format_dict(event.outputs))
+
+    def _log_iteration_failed_event(self, event: NodeRunIterationFailedEvent) -> None:
+        self.logger.error("❌ Iteration failed: %s", event.node_id)
+        self.logger.error("  Error: %s", event.error)
+
+    def _log_loop_started_event(self, event: NodeRunLoopStartedEvent) -> None:
+        self.logger.info("🔄 Loop started: %s", event.node_id)
+
+    def _log_loop_next_event(self, event: NodeRunLoopNextEvent) -> None:
+        self.logger.debug(
+            "  Loop iteration: %s (index: %s)",
+            event.node_id,
+            event.index,
+        )
+
+    def _log_loop_succeeded_event(self, event: NodeRunLoopSucceededEvent) -> None:
+        self.logger.info("✅ Loop succeeded: %s", event.node_id)
+        if self.include_outputs and event.outputs:
+            self.logger.debug("  Outputs: %s", self._format_dict(event.outputs))
+
+    def _log_loop_failed_event(self, event: NodeRunLoopFailedEvent) -> None:
+        self.logger.error("❌ Loop failed: %s", event.node_id)
+        self.logger.error("  Error: %s", event.error)
 
     @override
     def on_graph_end(self, error: Exception | None) -> None:
@@ -276,7 +310,8 @@ class DebugLoggingLayer(GraphEngineLayer):
         # Log final state if available
         if self.include_outputs and self.graph_runtime_state.outputs:
             self.logger.info(
-                "Final outputs: %s", self._format_dict(self.graph_runtime_state.outputs)
+                "Final outputs: %s",
+                self._format_dict(self.graph_runtime_state.outputs),
             )
 
         self.logger.info("=" * 80)

--- a/src/graphon/graph_engine/layers/execution_limits.py
+++ b/src/graphon/graph_engine/layers/execution_limits.py
@@ -1,5 +1,4 @@
-"""
-Execution limits layer for GraphEngine.
+"""Execution limits layer for GraphEngine.
 
 This layer monitors workflow execution to enforce limits on:
 - Maximum execution steps
@@ -32,8 +31,7 @@ class LimitType(StrEnum):
 
 @final
 class ExecutionLimitsLayer(GraphEngineLayer):
-    """
-    Layer that enforces execution limits for workflows.
+    """Layer that enforces execution limits for workflows.
 
     Monitors:
     - Step count: Tracks number of node executions
@@ -43,12 +41,12 @@ class ExecutionLimitsLayer(GraphEngineLayer):
     """
 
     def __init__(self, max_steps: int, max_time: int) -> None:
-        """
-        Initialize the execution limits layer.
+        """Initialize the execution limits layer.
 
         Args:
             max_steps: Maximum number of execution steps allowed
             max_time: Maximum execution time in seconds allowed
+
         """
         super().__init__()
         self.max_steps = max_steps
@@ -77,26 +75,25 @@ class ExecutionLimitsLayer(GraphEngineLayer):
 
     @override
     def on_event(self, event: GraphEngineEvent) -> None:
-        """
-        Called for every event emitted by the engine.
+        """Called for every event emitted by the engine.
 
         Monitors execution progress and enforces limits.
         """
         if not self._execution_started or self._execution_ended or self._abort_sent:
             return
 
-        # Track step count for node execution events
-        if isinstance(event, NodeRunStartedEvent):
-            self.step_count += 1
-            self.logger.debug("Step %d started: %s", self.step_count, event.node_id)
+        match event:
+            case NodeRunStartedEvent():
+                self.step_count += 1
+                self.logger.debug("Step %d started: %s", self.step_count, event.node_id)
+            case NodeRunSucceededEvent() | NodeRunFailedEvent():
+                if self._reached_step_limitation():
+                    self._send_abort_command(LimitType.STEP_LIMIT)
 
-        # Check step limit when node execution completes
-        if isinstance(event, NodeRunSucceededEvent | NodeRunFailedEvent):
-            if self._reached_step_limitation():
-                self._send_abort_command(LimitType.STEP_LIMIT)
-
-            if self._reached_time_limitation():
-                self._send_abort_command(LimitType.TIME_LIMIT)
+                if self._reached_time_limitation():
+                    self._send_abort_command(LimitType.TIME_LIMIT)
+            case _:
+                pass
 
     @override
     def on_graph_end(self, error: Exception | None) -> None:
@@ -124,11 +121,11 @@ class ExecutionLimitsLayer(GraphEngineLayer):
         )
 
     def _send_abort_command(self, limit_type: LimitType) -> None:
-        """
-        Send abort command due to limit violation.
+        """Send abort command due to limit violation.
 
         Args:
             limit_type: Type of limit exceeded
+
         """
         if (
             not self.command_channel
@@ -138,18 +135,7 @@ class ExecutionLimitsLayer(GraphEngineLayer):
         ):
             return
 
-        # Format detailed reason message
-        if limit_type == LimitType.STEP_LIMIT:
-            reason = (
-                f"Maximum execution steps exceeded: "
-                f"{self.step_count} > {self.max_steps}"
-            )
-        elif limit_type == LimitType.TIME_LIMIT:
-            elapsed_time = time.time() - self.start_time if self.start_time else 0
-            reason = (
-                f"Maximum execution time exceeded: "
-                f"{elapsed_time:.2f}s > {self.max_time}s"
-            )
+        reason = self._build_abort_reason(limit_type)
 
         self.logger.warning("Execution limit exceeded: %s", reason)
 
@@ -165,3 +151,20 @@ class ExecutionLimitsLayer(GraphEngineLayer):
 
         except Exception:
             self.logger.exception("Failed to send abort command")
+
+    def _build_abort_reason(self, limit_type: LimitType) -> str:
+        match limit_type:
+            case LimitType.STEP_LIMIT:
+                return (
+                    f"Maximum execution steps exceeded: "
+                    f"{self.step_count} > {self.max_steps}"
+                )
+            case LimitType.TIME_LIMIT:
+                elapsed_time = time.time() - self.start_time if self.start_time else 0
+                return (
+                    f"Maximum execution time exceeded: "
+                    f"{elapsed_time:.2f}s > {self.max_time}s"
+                )
+            case _:
+                msg = f"Unsupported limit type: {limit_type}"
+                raise ValueError(msg)

--- a/src/graphon/graph_engine/manager.py
+++ b/src/graphon/graph_engine/manager.py
@@ -1,5 +1,4 @@
-"""
-GraphEngine Manager for sending control commands via Redis channel.
+"""GraphEngine Manager for sending control commands via Redis channel.
 
 This module provides a simplified interface for controlling workflow executions
 using the new Redis command channel, without requiring user permission checks.
@@ -27,8 +26,7 @@ logger = logging.getLogger(__name__)
 
 @final
 class GraphEngineManager:
-    """
-    Manager for sending control commands to GraphEngine instances.
+    """Manager for sending control commands to GraphEngine instances.
 
     This class provides a simple interface for controlling workflow executions
     by sending commands through Redis channels, without user validation.
@@ -40,27 +38,27 @@ class GraphEngineManager:
         self._redis_client = redis_client
 
     def send_stop_command(self, task_id: str, reason: str | None = None) -> None:
-        """
-        Send a stop command to a running workflow.
+        """Send a stop command to a running workflow.
 
         Args:
             task_id: The task ID of the workflow to stop
             reason: Optional reason for stopping (defaults to "User requested stop")
+
         """
         abort_command = AbortCommand(reason=reason or "User requested stop")
         self._send_command(task_id, abort_command)
 
     def send_pause_command(self, task_id: str, reason: str | None = None) -> None:
         """Send a pause command to a running workflow."""
-
         pause_command = PauseCommand(reason=reason or "User requested pause")
         self._send_command(task_id, pause_command)
 
     def send_update_variables_command(
-        self, task_id: str, updates: Sequence[VariableUpdate]
+        self,
+        task_id: str,
+        updates: Sequence[VariableUpdate],
     ) -> None:
         """Send a command to update variables in a running workflow."""
-
         if not updates:
             return
 
@@ -69,7 +67,6 @@ class GraphEngineManager:
 
     def _send_command(self, task_id: str, command: GraphEngineCommand) -> None:
         """Send a command to the workflow-specific Redis channel."""
-
         if not task_id:
             return
 

--- a/src/graphon/graph_engine/orchestration/__init__.py
+++ b/src/graphon/graph_engine/orchestration/__init__.py
@@ -1,5 +1,4 @@
-"""
-Orchestration subsystem for graph engine.
+"""Orchestration subsystem for graph engine.
 
 This package coordinates the overall execution flow between
 different subsystems.

--- a/src/graphon/graph_engine/orchestration/dispatcher.py
+++ b/src/graphon/graph_engine/orchestration/dispatcher.py
@@ -1,6 +1,4 @@
-"""
-Main dispatcher for processing events from workers.
-"""
+"""Main dispatcher for processing events from workers."""
 
 import logging
 import queue
@@ -26,8 +24,7 @@ logger = logging.getLogger(__name__)
 
 @final
 class Dispatcher:
-    """
-    Main dispatcher that processes events from the event queue.
+    """Main dispatcher that processes events from the event queue.
 
     This runs in a separate thread and coordinates event processing
     with timeout and completion detection.
@@ -46,14 +43,14 @@ class Dispatcher:
         execution_coordinator: ExecutionCoordinator,
         event_emitter: EventManager | None = None,
     ) -> None:
-        """
-        Initialize the dispatcher.
+        """Initialize the dispatcher.
 
         Args:
             event_queue: Queue of events from workers
             event_handler: Event handler registry for processing events
             execution_coordinator: Coordinator for execution flow
             event_emitter: Optional event manager to signal completion
+
         """
         self._event_queue = event_queue
         self._event_handler = event_handler
@@ -72,7 +69,9 @@ class Dispatcher:
         self._stop_event.clear()
         self._start_time = time.time()
         self._thread = threading.Thread(
-            target=self._dispatcher_loop, name="GraphDispatcher", daemon=True
+            target=self._dispatcher_loop,
+            name="GraphDispatcher",
+            daemon=True,
         )
         self._thread.start()
 
@@ -122,7 +121,7 @@ class Dispatcher:
             if self._event_emitter:
                 self._event_emitter.mark_complete()
 
-    def _process_commands(self, event: GraphNodeEventBase | None = None):
+    def _process_commands(self, event: GraphNodeEventBase | None = None) -> None:
         if event is None or isinstance(event, self._COMMAND_TRIGGER_EVENTS):
             self._execution_coordinator.process_commands()
 

--- a/src/graphon/graph_engine/orchestration/execution_coordinator.py
+++ b/src/graphon/graph_engine/orchestration/execution_coordinator.py
@@ -1,6 +1,4 @@
-"""
-Execution coordinator for managing overall workflow execution.
-"""
+"""Execution coordinator for managing overall workflow execution."""
 
 from typing import final
 
@@ -12,8 +10,7 @@ from ..worker_management import WorkerPool
 
 @final
 class ExecutionCoordinator:
-    """
-    Coordinates overall execution flow between subsystems.
+    """Coordinates overall execution flow between subsystems.
 
     This provides high-level coordination methods used by the
     dispatcher to manage execution state.
@@ -26,14 +23,14 @@ class ExecutionCoordinator:
         command_processor: CommandProcessor,
         worker_pool: WorkerPool,
     ) -> None:
-        """
-        Initialize the execution coordinator.
+        """Initialize the execution coordinator.
 
         Args:
             graph_execution: Graph execution aggregate
             state_manager: Unified state manager
             command_processor: Processor for commands
             worker_pool: Pool of workers
+
         """
         self._graph_execution = graph_execution
         self._state_manager = state_manager
@@ -69,17 +66,16 @@ class ExecutionCoordinator:
             self._graph_execution.complete()
 
     def mark_failed(self, error: Exception) -> None:
-        """
-        Mark execution as failed.
+        """Mark execution as failed.
 
         Args:
             error: The error that caused failure
+
         """
         self._graph_execution.fail(error)
 
     def handle_pause_if_needed(self) -> None:
         """If the execution has been paused, stop workers immediately."""
-
         if not self._graph_execution.is_paused:
             return
 
@@ -88,7 +84,6 @@ class ExecutionCoordinator:
 
     def handle_abort_if_needed(self) -> None:
         """If the execution has been aborted, stop workers immediately."""
-
         if not self._graph_execution.aborted:
             return
 
@@ -101,7 +96,6 @@ class ExecutionCoordinator:
         # Before pause, executing state can change concurrently, making the result
         # unreliable.
         if not self._graph_execution.is_paused:
-            raise AssertionError(
-                "has_executing_nodes should only be called after execution is paused"
-            )
+            msg = "has_executing_nodes should only be called after execution is paused"
+            raise AssertionError(msg)
         return self._state_manager.get_executing_count() > 0

--- a/src/graphon/graph_engine/ready_queue/__init__.py
+++ b/src/graphon/graph_engine/ready_queue/__init__.py
@@ -1,5 +1,4 @@
-"""
-Ready queue implementations for GraphEngine.
+"""Ready queue implementations for GraphEngine.
 
 This package contains the protocol and implementations for managing
 the queue of nodes ready for execution.

--- a/src/graphon/graph_engine/ready_queue/factory.py
+++ b/src/graphon/graph_engine/ready_queue/factory.py
@@ -1,9 +1,8 @@
-"""
-Factory for creating ReadyQueue instances from serialized state.
-"""
+"""Factory for creating ReadyQueue instances from serialized state."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from .in_memory import InMemoryReadyQueue
@@ -12,10 +11,13 @@ from .protocol import ReadyQueueState
 if TYPE_CHECKING:
     from .protocol import ReadyQueue
 
+_READY_QUEUE_BUILDERS: dict[str, tuple[Callable[[], ReadyQueue], str]] = {
+    "InMemoryReadyQueue": (InMemoryReadyQueue, "1.0"),
+}
+
 
 def create_ready_queue_from_state(state: ReadyQueueState) -> ReadyQueue:
-    """
-    Create a ReadyQueue instance from a serialized state.
+    """Create a ReadyQueue instance from a serialized state.
 
     Args:
         state: The serialized queue state (Pydantic model, dict, or JSON string),
@@ -26,12 +28,19 @@ def create_ready_queue_from_state(state: ReadyQueueState) -> ReadyQueue:
 
     Raises:
         ValueError: If the queue type is unknown or version is unsupported
+
     """
-    if state.type == "InMemoryReadyQueue":
-        if state.version != "1.0":
-            raise ValueError(f"Unsupported InMemoryReadyQueue version: {state.version}")
-        queue = InMemoryReadyQueue()
-        # Always pass as JSON string to loads()
-        queue.loads(state.model_dump_json())
-        return queue
-    raise ValueError(f"Unknown ready queue type: {state.type}")
+    ready_queue_config = _READY_QUEUE_BUILDERS.get(state.type)
+    if ready_queue_config is None:
+        msg = f"Unknown ready queue type: {state.type}"
+        raise ValueError(msg)
+
+    queue_builder, supported_version = ready_queue_config
+    if state.version != supported_version:
+        msg = f"Unsupported {state.type} version: {state.version}"
+        raise ValueError(msg)
+
+    queue = queue_builder()
+    # Always pass as JSON string to loads()
+    queue.loads(state.model_dump_json())
+    return queue

--- a/src/graphon/graph_engine/ready_queue/in_memory.py
+++ b/src/graphon/graph_engine/ready_queue/in_memory.py
@@ -1,5 +1,4 @@
-"""
-In-memory implementation of the ReadyQueue protocol.
+"""In-memory implementation of the ReadyQueue protocol.
 
 This implementation wraps Python's standard queue.Queue and adds
 serialization capabilities for state storage.
@@ -13,34 +12,32 @@ from .protocol import ReadyQueue, ReadyQueueState
 
 @final
 class InMemoryReadyQueue(ReadyQueue):
-    """
-    In-memory ready queue implementation with serialization support.
+    """In-memory ready queue implementation with serialization support.
 
     This implementation uses Python's queue.Queue internally and provides
     methods to serialize and restore the queue state.
     """
 
     def __init__(self, maxsize: int = 0) -> None:
-        """
-        Initialize the in-memory ready queue.
+        """Initialize the in-memory ready queue.
 
         Args:
             maxsize: Maximum size of the queue (0 for unlimited)
+
         """
         self._queue: queue.Queue[str] = queue.Queue(maxsize=maxsize)
 
     def put(self, item: str) -> None:
-        """
-        Add a node ID to the ready queue.
+        """Add a node ID to the ready queue.
 
         Args:
             item: The node ID to add to the queue
+
         """
         self._queue.put(item)
 
     def get(self, timeout: float | None = None) -> str:
-        """
-        Retrieve and remove a node ID from the queue.
+        """Retrieve and remove a node ID from the queue.
 
         Args:
             timeout: Maximum time to wait for an item (None for blocking)
@@ -48,16 +45,13 @@ class InMemoryReadyQueue(ReadyQueue):
         Returns:
             The node ID retrieved from the queue
 
-        Raises:
-            queue.Empty: If timeout expires and no item is available
         """
         if timeout is None:
             return self._queue.get(block=True)
         return self._queue.get(timeout=timeout)
 
     def task_done(self) -> None:
-        """
-        Indicate that a previously retrieved task is complete.
+        """Indicate that a previously retrieved task is complete.
 
         Used by worker threads to signal task completion for
         join() synchronization.
@@ -65,29 +59,29 @@ class InMemoryReadyQueue(ReadyQueue):
         self._queue.task_done()
 
     def empty(self) -> bool:
-        """
-        Check if the queue is empty.
+        """Check if the queue is empty.
 
         Returns:
             True if the queue has no items, False otherwise
+
         """
         return self._queue.empty()
 
     def qsize(self) -> int:
-        """
-        Get the approximate size of the queue.
+        """Get the approximate size of the queue.
 
         Returns:
             The approximate number of items in the queue
+
         """
         return self._queue.qsize()
 
     def dumps(self) -> str:
-        """
-        Serialize the queue state to a JSON string for storage.
+        """Serialize the queue state to a JSON string for storage.
 
         Returns:
             A JSON string containing the serialized queue state
+
         """
         # Extract all items from the queue without removing them
         items: list[str] = []
@@ -114,19 +108,24 @@ class InMemoryReadyQueue(ReadyQueue):
         return state.model_dump_json()
 
     def loads(self, data: str) -> None:
-        """
-        Restore the queue state from a JSON string.
+        """Restore the queue state from a JSON string.
 
         Args:
             data: The JSON string containing the serialized queue state to restore
+
+        Raises:
+            ValueError: If the serialized queue type or version is unsupported.
+
         """
         state = ReadyQueueState.model_validate_json(data)
 
         if state.type != "InMemoryReadyQueue":
-            raise ValueError(f"Invalid serialized data type: {state.type}")
+            msg = f"Invalid serialized data type: {state.type}"
+            raise ValueError(msg)
 
         if state.version != "1.0":
-            raise ValueError(f"Unsupported version: {state.version}")
+            msg = f"Unsupported version: {state.version}"
+            raise ValueError(msg)
 
         # Clear the current queue
         while not self._queue.empty():

--- a/src/graphon/graph_engine/ready_queue/protocol.py
+++ b/src/graphon/graph_engine/ready_queue/protocol.py
@@ -1,5 +1,4 @@
-"""
-ReadyQueue protocol for GraphEngine node execution queue.
+"""ReadyQueue protocol for GraphEngine node execution queue.
 
 This protocol defines the interface for managing the queue of nodes ready
 for execution, supporting both in-memory and persistent storage scenarios.
@@ -12,25 +11,24 @@ from pydantic import BaseModel, Field
 
 
 class ReadyQueueState(BaseModel):
-    """
-    Pydantic model for serialized ready queue state.
+    """Pydantic model for serialized ready queue state.
 
     This defines the structure of the data returned by dumps()
     and expected by loads() for ready queue serialization.
     """
 
     type: str = Field(
-        description="Queue implementation type (e.g., 'InMemoryReadyQueue')"
+        description="Queue implementation type (e.g., 'InMemoryReadyQueue')",
     )
     version: str = Field(description="Serialization format version")
     items: Sequence[str] = Field(
-        default_factory=list, description="List of node IDs in the queue"
+        default_factory=list,
+        description="List of node IDs in the queue",
     )
 
 
 class ReadyQueue(Protocol):
-    """
-    Protocol for managing nodes ready for execution in GraphEngine.
+    """Protocol for managing nodes ready for execution in GraphEngine.
 
     This protocol defines the interface that any ready queue implementation
     must provide, enabling both in-memory queues and persistent queues
@@ -38,17 +36,16 @@ class ReadyQueue(Protocol):
     """
 
     def put(self, item: str) -> None:
-        """
-        Add a node ID to the ready queue.
+        """Add a node ID to the ready queue.
 
         Args:
             item: The node ID to add to the queue
+
         """
         ...
 
     def get(self, timeout: float | None = None) -> str:
-        """
-        Retrieve and remove a node ID from the queue.
+        """Retrieve and remove a node ID from the queue.
 
         Args:
             timeout: Maximum time to wait for an item (None for blocking)
@@ -56,14 +53,11 @@ class ReadyQueue(Protocol):
         Returns:
             The node ID retrieved from the queue
 
-        Raises:
-            queue.Empty: If timeout expires and no item is available
         """
         ...
 
     def task_done(self) -> None:
-        """
-        Indicate that a previously retrieved task is complete.
+        """Indicate that a previously retrieved task is complete.
 
         Used by worker threads to signal task completion for
         join() synchronization.
@@ -71,38 +65,38 @@ class ReadyQueue(Protocol):
         ...
 
     def empty(self) -> bool:
-        """
-        Check if the queue is empty.
+        """Check if the queue is empty.
 
         Returns:
             True if the queue has no items, False otherwise
+
         """
         ...
 
     def qsize(self) -> int:
-        """
-        Get the approximate size of the queue.
+        """Get the approximate size of the queue.
 
         Returns:
             The approximate number of items in the queue
+
         """
         ...
 
     def dumps(self) -> str:
-        """
-        Serialize the queue state to a JSON string for storage.
+        """Serialize the queue state to a JSON string for storage.
 
         Returns:
             A JSON string containing the serialized queue state
             that can be persisted and later restored
+
         """
         ...
 
     def loads(self, data: str) -> None:
-        """
-        Restore the queue state from a JSON string.
+        """Restore the queue state from a JSON string.
 
         Args:
             data: The JSON string containing the serialized queue state to restore
+
         """
         ...

--- a/src/graphon/graph_engine/response_coordinator/__init__.py
+++ b/src/graphon/graph_engine/response_coordinator/__init__.py
@@ -1,5 +1,4 @@
-"""
-ResponseStreamCoordinator - Coordinates streaming output from response nodes
+"""ResponseStreamCoordinator - Coordinates streaming output from response nodes
 
 This component manages response streaming sessions and ensures ordered streaming
 of responses based on upstream node outputs and constants.

--- a/src/graphon/graph_engine/response_coordinator/coordinator.py
+++ b/src/graphon/graph_engine/response_coordinator/coordinator.py
@@ -1,5 +1,4 @@
-"""
-Main ResponseStreamCoordinator implementation.
+"""Main ResponseStreamCoordinator implementation.
 
 This module contains the public ResponseStreamCoordinator class that manages
 response streaming sessions and ensures ordered streaming of responses.
@@ -58,7 +57,7 @@ class ResponseStreamCoordinatorState(BaseModel):
     """Serialized snapshot of ResponseStreamCoordinator."""
 
     type: Literal["ResponseStreamCoordinator"] = Field(
-        default="ResponseStreamCoordinator"
+        default="ResponseStreamCoordinator",
     )
     version: str = Field(default="1.0")
     response_nodes: Sequence[str] = Field(default_factory=list)
@@ -74,19 +73,18 @@ class ResponseStreamCoordinatorState(BaseModel):
 
 @final
 class ResponseStreamCoordinator:
-    """
-    Manages response streaming sessions without relying on global state.
+    """Manages response streaming sessions without relying on global state.
 
     Ensures ordered streaming of responses based on upstream node outputs and constants.
     """
 
     def __init__(self, variable_pool: "VariablePool", graph: GraphProtocol) -> None:
-        """
-        Initialize coordinator with variable pool.
+        """Initialize coordinator with variable pool.
 
         Args:
             variable_pool: VariablePool instance for accessing node variables
             graph: Graph instance for looking up node information
+
         """
         self._variable_pool = variable_pool
         self._graph = graph
@@ -110,7 +108,8 @@ class ResponseStreamCoordinator:
 
         # Track response sessions to ensure only one per node
         self._response_sessions: dict[
-            NodeID, ResponseSession
+            NodeID,
+            ResponseSession,
         ] = {}  # node_id -> session
 
     def register(self, response_node_id: NodeID) -> None:
@@ -134,6 +133,7 @@ class ResponseStreamCoordinator:
         Args:
             node_id: The ID of the node
             execution_id: The execution ID from NodeRunStartedEvent
+
         """
         with self._lock:
             self._node_execution_ids[node_id] = execution_id
@@ -146,6 +146,7 @@ class ResponseStreamCoordinator:
 
         Returns:
             The execution ID for the node
+
         """
         with self._lock:
             if node_id not in self._node_execution_ids:
@@ -153,8 +154,7 @@ class ResponseStreamCoordinator:
             return self._node_execution_ids[node_id]
 
     def _build_paths_map(self, response_node_id: NodeID) -> list[Path]:
-        """
-        Build a paths map for a response node by finding all paths from root node
+        """Build a paths map for a response node by finding all paths from root node
         to the response node, recording branch edges along each path.
 
         Args:
@@ -162,6 +162,7 @@ class ResponseStreamCoordinator:
 
         Returns:
             List of Path objects, where each path contains branch edge IDs
+
         """
         # Get root node ID
         root_node_id = self._graph.root_node.id
@@ -208,7 +209,7 @@ class ResponseStreamCoordinator:
                 # Skip if already visited in this path
                 if next_node_id not in visited:
                     # Add edge to path and recurse
-                    new_path = current_path + [edge_id]
+                    new_path = [*current_path, edge_id]
                     find_paths(next_node_id, target_node_id, new_path, visited.copy())
 
         # Start searching from root node
@@ -223,11 +224,11 @@ class ResponseStreamCoordinator:
                 source_node = self._graph.nodes[edge.tail]
 
                 # Check if node is a branch, container, or response node
-                if source_node.execution_type in {
+                if source_node.execution_type in frozenset((
                     NodeExecutionType.BRANCH,
                     NodeExecutionType.CONTAINER,
                     NodeExecutionType.RESPONSE,
-                } or source_node.blocks_variable_output(variable_selectors):
+                )) or source_node.blocks_variable_output(variable_selectors):
                     blocking_edges.append(edge_id)
 
             # Keep the path even if it's empty
@@ -236,8 +237,7 @@ class ResponseStreamCoordinator:
         return filtered_paths
 
     def on_edge_taken(self, edge_id: str) -> Sequence[NodeRunStreamChunkEvent]:
-        """
-        Handle when an edge is taken (selected by a branch node).
+        """Handle when an edge is taken (selected by a branch node).
 
         This method updates the paths for all response nodes by removing
         the taken edge. If any response node has an empty path after removal,
@@ -248,6 +248,7 @@ class ResponseStreamCoordinator:
 
         Returns:
             List of events to emit from starting new sessions
+
         """
         events: list[NodeRunStreamChunkEvent] = []
 
@@ -277,10 +278,10 @@ class ResponseStreamCoordinator:
         return events
 
     def _active_or_queue_session(
-        self, node_id: str
+        self,
+        node_id: str,
     ) -> Sequence[NodeRunStreamChunkEvent]:
-        """
-        Start a session immediately if no active session, otherwise queue it.
+        """Start a session immediately if no active session, otherwise queue it.
         Only activates sessions that exist in the _response_sessions map.
 
         Args:
@@ -288,6 +289,7 @@ class ResponseStreamCoordinator:
 
         Returns:
             List of events from flush attempt if session started immediately
+
         """
         events: list[NodeRunStreamChunkEvent] = []
 
@@ -311,7 +313,8 @@ class ResponseStreamCoordinator:
         return events
 
     def intercept_event(
-        self, event: NodeRunStreamChunkEvent | NodeRunSucceededEvent
+        self,
+        event: NodeRunStreamChunkEvent | NodeRunSucceededEvent,
     ) -> Sequence[NodeRunStreamChunkEvent]:
         with self._lock:
             if isinstance(event, NodeRunStreamChunkEvent):
@@ -340,6 +343,10 @@ class ResponseStreamCoordinator:
 
         For selectors with special prefixes (sys, env, conversation), we use the
         active response node's information since these are not actual node IDs.
+
+        Returns:
+            A stream chunk event attributed to the correct node.
+
         """
         # Check if this is a special selector that doesn't correspond to a node
         if selector and selector[0] not in self._graph.nodes and self._active_session:
@@ -366,13 +373,18 @@ class ResponseStreamCoordinator:
         )
 
     def _process_variable_segment(
-        self, segment: VariableSegment
+        self,
+        segment: VariableSegment,
     ) -> tuple[Sequence[NodeRunStreamChunkEvent], bool]:
-        """Process a variable segment. Returns (events, is_complete).
+        """Process a variable segment.
 
         Handles both regular node selectors and special system selectors
         (sys, env, conversation).
         For special selectors, we attribute the output to the active response node.
+
+        Returns:
+            A tuple of emitted events and whether the segment is complete.
+
         """
         events: list[NodeRunStreamChunkEvent] = []
         source_selector_prefix = segment.selector[0] if segment.selector else ""
@@ -425,7 +437,7 @@ class ResponseStreamCoordinator:
             is_last_segment = bool(
                 self._active_session
                 and self._active_session.index
-                == len(self._active_session.template.segments) - 1
+                == len(self._active_session.template.segments) - 1,
             )
             events.append(
                 self._create_stream_chunk_event(
@@ -434,14 +446,15 @@ class ResponseStreamCoordinator:
                     selector=segment.selector,
                     chunk=value.markdown,
                     is_final=is_last_segment,
-                )
+                ),
             )
             is_complete = True
 
         return events, is_complete
 
     def _process_text_segment(
-        self, segment: TextSegment
+        self,
+        segment: TextSegment,
     ) -> Sequence[NodeRunStreamChunkEvent]:
         """Process a text segment. Returns (events, is_complete)."""
         assert self._active_session is not None
@@ -493,7 +506,7 @@ class ResponseStreamCoordinator:
                             continue
 
                     segment_events, is_complete = self._process_variable_segment(
-                        segment
+                        segment,
                     )
                     events.extend(segment_events)
 
@@ -517,8 +530,7 @@ class ResponseStreamCoordinator:
             return events
 
     def end_session(self, node_id: str) -> list[NodeRunStreamChunkEvent]:
-        """
-        End the active session for a response node.
+        """End the active session for a response node.
         Automatically starts the next waiting session if available.
 
         Args:
@@ -526,6 +538,7 @@ class ResponseStreamCoordinator:
 
         Returns:
             List of events from starting the next session
+
         """
         with self._lock:
             events: list[NodeRunStreamChunkEvent] = []
@@ -546,10 +559,11 @@ class ResponseStreamCoordinator:
     # ============= Internal Stream Management Methods =============
 
     def _append_stream_chunk(
-        self, selector: Sequence[str], event: NodeRunStreamChunkEvent
+        self,
+        selector: Sequence[str],
+        event: NodeRunStreamChunkEvent,
     ) -> None:
-        """
-        Append a stream chunk to the internal buffer.
+        """Append a stream chunk to the internal buffer.
 
         Args:
             selector: List of strings identifying the stream location
@@ -557,11 +571,13 @@ class ResponseStreamCoordinator:
 
         Raises:
             ValueError: If the stream is already closed
+
         """
         key = tuple(selector)
 
         if key in self._closed_streams:
-            raise ValueError(f"Stream {'.'.join(selector)} is already closed")
+            msg = f"Stream {'.'.join(selector)} is already closed"
+            raise ValueError(msg)
 
         if key not in self._stream_buffers:
             self._stream_buffers[key] = []
@@ -570,16 +586,17 @@ class ResponseStreamCoordinator:
         self._stream_buffers[key].append(event)
 
     def _pop_stream_chunk(
-        self, selector: Sequence[str]
+        self,
+        selector: Sequence[str],
     ) -> NodeRunStreamChunkEvent | None:
-        """
-        Pop the next unread stream chunk from the buffer.
+        """Pop the next unread stream chunk from the buffer.
 
         Args:
             selector: List of strings identifying the stream location
 
         Returns:
             The next event, or None if no unread events available
+
         """
         key = tuple(selector)
 
@@ -597,14 +614,14 @@ class ResponseStreamCoordinator:
         return event
 
     def _has_unread_stream(self, selector: Sequence[str]) -> bool:
-        """
-        Check if the stream has unread events.
+        """Check if the stream has unread events.
 
         Args:
             selector: List of strings identifying the stream location
 
         Returns:
             True if there are unread events, False otherwise
+
         """
         key = tuple(selector)
 
@@ -615,47 +632,46 @@ class ResponseStreamCoordinator:
         return position < len(self._stream_buffers[key])
 
     def _close_stream(self, selector: Sequence[str]) -> None:
-        """
-        Mark a stream as closed (no more chunks can be appended).
+        """Mark a stream as closed (no more chunks can be appended).
 
         Args:
             selector: List of strings identifying the stream location
+
         """
         key = tuple(selector)
         self._closed_streams.add(key)
 
     def _is_stream_closed(self, selector: Sequence[str]) -> bool:
-        """
-        Check if a stream is closed.
+        """Check if a stream is closed.
 
         Args:
             selector: List of strings identifying the stream location
 
         Returns:
             True if the stream is closed, False otherwise
+
         """
         key = tuple(selector)
         return key in self._closed_streams
 
     def _serialize_session(
-        self, session: ResponseSession | None
+        self,
+        session: ResponseSession | None,
     ) -> ResponseSessionState | None:
         """Convert an in-memory session into its serializable form."""
-
         if session is None:
             return None
         return ResponseSessionState(node_id=session.node_id, index=session.index)
 
     def _session_from_state(
-        self, session_state: ResponseSessionState
+        self,
+        session_state: ResponseSessionState,
     ) -> ResponseSession:
         """Rebuild a response session from serialized data."""
-
         node = self._graph.nodes.get(session_state.node_id)
         if node is None:
-            raise ValueError(
-                f"Unknown response node '{session_state.node_id}' in serialized state"
-            )
+            msg = f"Unknown response node '{session_state.node_id}' in serialized state"
+            raise ValueError(msg)
 
         session = ResponseSession.from_node(node)
         session.index = session_state.index
@@ -663,7 +679,6 @@ class ResponseStreamCoordinator:
 
     def dumps(self) -> str:
         """Serialize coordinator state to JSON."""
-
         with self._lock:
             state = ResponseStreamCoordinatorState(
                 response_nodes=sorted(self._response_nodes),
@@ -700,14 +715,15 @@ class ResponseStreamCoordinator:
 
     def loads(self, data: str) -> None:
         """Restore coordinator state from JSON."""
-
         state = ResponseStreamCoordinatorState.model_validate_json(data)
 
         if state.type != "ResponseStreamCoordinator":
-            raise ValueError(f"Invalid serialized data type: {state.type}")
+            msg = f"Invalid serialized data type: {state.type}"
+            raise ValueError(msg)
 
         if state.version != "1.0":
-            raise ValueError(f"Unsupported serialized version: {state.version}")
+            msg = f"Unsupported serialized version: {state.version}"
+            raise ValueError(msg)
 
         with self._lock:
             self._response_nodes = set(state.response_nodes)

--- a/src/graphon/graph_engine/response_coordinator/path.py
+++ b/src/graphon/graph_engine/response_coordinator/path.py
@@ -1,5 +1,4 @@
-"""
-Internal path representation for response coordinator.
+"""Internal path representation for response coordinator.
 
 This module contains the private Path class used internally by ResponseStreamCoordinator
 to track execution paths to response nodes.
@@ -12,8 +11,7 @@ type EdgeID = str
 
 @dataclass
 class Path:
-    """
-    Represents a path of branch edges that must be taken to reach a response node.
+    """Represents a path of branch edges that must be taken to reach a response node.
 
     Note: This is an internal class not exposed in the public API.
     """

--- a/src/graphon/graph_engine/response_coordinator/session.py
+++ b/src/graphon/graph_engine/response_coordinator/session.py
@@ -1,5 +1,4 @@
-"""
-Internal response session management for response coordinator.
+"""Internal response session management for response coordinator.
 
 This module contains the private ResponseSession class used internally
 by ResponseStreamCoordinator to manage streaming sessions.
@@ -15,8 +14,7 @@ from graphon.runtime.graph_runtime_state import NodeProtocol
 
 @dataclass
 class ResponseSession:
-    """
-    Represents an active response streaming session.
+    """Represents an active response streaming session.
 
     Note: This is an internal class not exposed in the public API.
     """
@@ -27,8 +25,7 @@ class ResponseSession:
 
     @classmethod
     def from_node(cls, node: NodeProtocol) -> ResponseSession:
-        """
-        Create a ResponseSession from a response-capable node.
+        """Create a ResponseSession from a response-capable node.
 
         The parameter is typed as `NodeProtocol` because the graph is exposed
         behind a protocol at the runtime layer. At runtime this must be a node
@@ -45,13 +42,15 @@ class ResponseSession:
         Raises:
             TypeError: If node does not implement the response-session
             streaming contract.
+
         """
         get_streaming_template = getattr(node, "get_streaming_template", None)
         if not callable(get_streaming_template):
-            raise TypeError(
+            msg = (
                 "ResponseSession.from_node requires "
                 "get_streaming_template() on response nodes"
             )
+            raise TypeError(msg)
         template = get_streaming_template()
 
         return cls(

--- a/src/graphon/graph_engine/worker.py
+++ b/src/graphon/graph_engine/worker.py
@@ -1,10 +1,10 @@
-"""
-Worker - Thread implementation for queue-based node execution
+"""Worker - Thread implementation for queue-based node execution
 
 Workers pull node IDs from the ready_queue, execute nodes, and push events
 to the event_queue for the dispatcher to process.
 """
 
+import logging
 import queue
 import threading
 import time
@@ -27,11 +27,12 @@ from graphon.nodes.base.node import Node
 
 from .ready_queue import ReadyQueue
 
+logger = logging.getLogger(__name__)
+
 
 @final
 class Worker(threading.Thread):
-    """
-    Worker thread that executes nodes from the ready queue.
+    """Worker thread that executes nodes from the ready queue.
 
     Workers continuously pull node IDs from the ready_queue, execute the
     corresponding nodes, and push the resulting events to the event_queue
@@ -47,8 +48,7 @@ class Worker(threading.Thread):
         worker_id: int = 0,
         execution_context: AbstractContextManager[object] | None = None,
     ) -> None:
-        """
-        Initialize worker thread.
+        """Initialize worker thread.
 
         Args:
             ready_queue: Ready queue containing node IDs ready for execution
@@ -57,6 +57,7 @@ class Worker(threading.Thread):
             layers: Graph engine layers for node execution hooks
             worker_id: Unique identifier for this worker
             execution_context: Optional execution context for context preservation
+
         """
         super().__init__(name=f"GraphWorker-{worker_id}", daemon=True)
         self._ready_queue = ready_queue
@@ -91,8 +92,7 @@ class Worker(threading.Thread):
 
     @override
     def run(self) -> None:
-        """
-        Main worker loop.
+        """Main worker loop.
 
         Continuously pulls node IDs from ready_queue, executes them,
         and pushes events to event_queue until stopped.
@@ -111,20 +111,26 @@ class Worker(threading.Thread):
                 self._execute_node(node)
                 self._ready_queue.task_done()
             except Exception as e:
+                logger.exception(
+                    "Worker failed while executing node %s",
+                    getattr(node, "id", node_id),
+                )
                 self._event_queue.put(
                     self._build_fallback_failure_event(
-                        node, e, started_at=self._current_node_started_at
-                    )
+                        node,
+                        e,
+                        started_at=self._current_node_started_at,
+                    ),
                 )
             finally:
                 self._current_node_started_at = None
 
     def _execute_node(self, node: Node) -> None:
-        """
-        Execute a single node and handle its events.
+        """Execute a single node and handle its events.
 
         Args:
             node: The node instance to execute
+
         """
         node.ensure_execution_id()
 
@@ -176,7 +182,11 @@ class Worker(threading.Thread):
             try:
                 layer.on_node_run_start(node)
             except Exception:
-                # Silently ignore layer errors to prevent disrupting node execution
+                logger.exception(
+                    "Layer %s failed in on_node_run_start for node %s",
+                    type(layer).__name__,
+                    node.id,
+                )
                 continue
 
     def _invoke_node_run_end_hooks(
@@ -190,14 +200,21 @@ class Worker(threading.Thread):
             try:
                 layer.on_node_run_end(node, error, result_event)
             except Exception:
-                # Silently ignore layer errors to prevent disrupting node execution
+                logger.exception(
+                    "Layer %s failed in on_node_run_end for node %s",
+                    type(layer).__name__,
+                    node.id,
+                )
                 continue
 
     def _build_fallback_failure_event(
-        self, node: Node, error: Exception, *, started_at: datetime | None = None
+        self,
+        node: Node,
+        error: Exception,
+        *,
+        started_at: datetime | None = None,
     ) -> NodeRunFailedEvent:
-        """Build a failed event when worker-level execution aborts
-        before a node emits its own result event."""
+        """Build a failure event when worker execution aborts before node output."""
         failure_time = datetime.now(UTC).replace(tzinfo=None)
         error_message = str(error)
         return NodeRunFailedEvent(

--- a/src/graphon/graph_engine/worker_management/__init__.py
+++ b/src/graphon/graph_engine/worker_management/__init__.py
@@ -1,5 +1,4 @@
-"""
-Worker management subsystem for graph engine.
+"""Worker management subsystem for graph engine.
 
 This package manages the worker pool, including creation,
 scaling, and activity tracking.

--- a/src/graphon/graph_engine/worker_management/worker_pool.py
+++ b/src/graphon/graph_engine/worker_management/worker_pool.py
@@ -1,5 +1,4 @@
-"""
-Simple worker pool that consolidates functionality.
+"""Simple worker pool that consolidates functionality.
 
 This is a simpler implementation that merges WorkerPool, ActivityTracker,
 DynamicScaler, and WorkerFactory into a single class.
@@ -24,8 +23,7 @@ logger = logging.getLogger(__name__)
 
 @final
 class WorkerPool:
-    """
-    Simple worker pool with integrated management.
+    """Simple worker pool with integrated management.
 
     This class consolidates all worker management functionality into
     a single, simpler implementation without excessive abstraction.
@@ -40,8 +38,7 @@ class WorkerPool:
         config: GraphEngineConfig,
         execution_context: AbstractContextManager[object] | None = None,
     ) -> None:
-        """
-        Initialize the simple worker pool.
+        """Initialize the simple worker pool.
 
         Args:
             ready_queue: Ready queue for nodes ready for execution
@@ -50,6 +47,7 @@ class WorkerPool:
             layers: Graph engine layers for node execution hooks
             config: GraphEngine worker pool configuration
             execution_context: Optional execution context for context preservation
+
         """
         self._ready_queue = ready_queue
         self._event_queue = event_queue
@@ -67,11 +65,11 @@ class WorkerPool:
         # No longer tracking worker states with callbacks to avoid lock contention
 
     def start(self, initial_count: int | None = None) -> None:
-        """
-        Start the worker pool.
+        """Start the worker pool.
 
         Args:
             initial_count: Number of workers to start with (auto-calculated if None)
+
         """
         with self._lock:
             if self._running:
@@ -86,11 +84,13 @@ class WorkerPool:
                     initial_count = self._config.min_workers
                 elif node_count < 50:
                     initial_count = min(
-                        self._config.min_workers + 1, self._config.max_workers
+                        self._config.min_workers + 1,
+                        self._config.max_workers,
                     )
                 else:
                     initial_count = min(
-                        self._config.min_workers + 2, self._config.max_workers
+                        self._config.min_workers + 2,
+                        self._config.max_workers,
                     )
 
                 logger.debug(
@@ -142,7 +142,7 @@ class WorkerPool:
         worker.start()
         self._workers.append(worker)
 
-    def _remove_worker(self, worker: Worker, worker_id: int) -> None:
+    def _remove_worker(self, worker: Worker) -> None:
         """Remove a specific worker from the pool."""
         # Stop the worker
         worker.stop()
@@ -156,8 +156,7 @@ class WorkerPool:
             self._workers.remove(worker)
 
     def _try_scale_up(self, queue_depth: int, current_count: int) -> bool:
-        """
-        Try to scale up workers if needed.
+        """Try to scale up workers if needed.
 
         Args:
             queue_depth: Current queue depth
@@ -165,6 +164,7 @@ class WorkerPool:
 
         Returns:
             True if scaled up, False otherwise
+
         """
         if (
             queue_depth > self._config.scale_up_threshold
@@ -184,10 +184,13 @@ class WorkerPool:
         return False
 
     def _try_scale_down(
-        self, queue_depth: int, current_count: int, active_count: int, idle_count: int
+        self,
+        queue_depth: int,
+        current_count: int,
+        active_count: int,
+        idle_count: int,
     ) -> bool:
-        """
-        Try to scale down workers if we have excess capacity.
+        """Try to scale down workers if we have excess capacity.
 
         Args:
             queue_depth: Current queue depth
@@ -197,6 +200,7 @@ class WorkerPool:
 
         Returns:
             True if scaled down, False otherwise
+
         """
         # Skip if we're at minimum or have no idle workers
         if current_count <= self._config.min_workers or idle_count == 0:
@@ -235,7 +239,8 @@ class WorkerPool:
         if workers_to_remove:
             old_count = current_count
             for worker, worker_id in workers_to_remove:
-                self._remove_worker(worker, worker_id)
+                _ = worker_id
+                self._remove_worker(worker)
 
             logger.debug(
                 "Scaled down workers: %d -> %d (removed %d idle workers after %.1fs, "
@@ -277,11 +282,11 @@ class WorkerPool:
             return len(self._workers)
 
     def get_status(self) -> dict[str, int]:
-        """
-        Get pool status information.
+        """Get pool status information.
 
         Returns:
             Dictionary with status information
+
         """
         with self._lock:
             return {

--- a/src/graphon/graph_events/graph.py
+++ b/src/graphon/graph_events/graph.py
@@ -51,7 +51,8 @@ class GraphRunPausedEvent(BaseGraphEvent):
     """Event emitted when a graph run is paused by user command."""
 
     reasons: list[PauseReason] = Field(
-        description="reason for pause", default_factory=list
+        description="reason for pause",
+        default_factory=list,
     )
     outputs: dict[str, object] = Field(
         default_factory=dict,

--- a/src/graphon/graph_events/node.py
+++ b/src/graphon/graph_events/node.py
@@ -31,13 +31,15 @@ class NodeRunStreamChunkEvent(GraphNodeEventBase):
     )
     chunk: str = Field(..., description="the actual chunk content")
     is_final: bool = Field(
-        default=False, description="indicates if this is the last chunk"
+        default=False,
+        description="indicates if this is the last chunk",
     )
 
 
 class NodeRunRetrieverResourceEvent(GraphNodeEventBase):
     retriever_resources: Sequence[Mapping[str, Any]] = Field(
-        ..., description="retriever resources"
+        ...,
+        description="retriever resources",
     )
     context: str = Field(..., description="context")
 
@@ -49,7 +51,8 @@ class NodeRunSucceededEvent(GraphNodeEventBase):
 
 class NodeRunVariableUpdatedEvent(GraphNodeEventBase):
     """Request that the engine apply a variable update before downstream
-    observers continue."""
+    observers continue.
+    """
 
     variable: Variable = Field(..., description="Updated variable payload to apply.")
 
@@ -69,7 +72,8 @@ class NodeRunExceptionEvent(GraphNodeEventBase):
 class NodeRunRetryEvent(NodeRunStartedEvent):
     error: str = Field(..., description="error")
     retry_index: int = Field(
-        ..., description="which retry attempt is about to be performed"
+        ...,
+        description="which retry attempt is about to be performed",
     )
 
 
@@ -78,13 +82,16 @@ class NodeRunHumanInputFormFilledEvent(GraphNodeEventBase):
 
     node_title: str = Field(..., description="HumanInput node title")
     rendered_content: str = Field(
-        ..., description="Markdown content rendered with user inputs."
+        ...,
+        description="Markdown content rendered with user inputs.",
     )
     action_id: str = Field(
-        ..., description="User action identifier chosen in the form."
+        ...,
+        description="User action identifier chosen in the form.",
     )
     action_text: str = Field(
-        ..., description="Display text of the chosen action button."
+        ...,
+        description="Display text of the chosen action button.",
     )
 
 
@@ -100,8 +107,7 @@ class NodeRunPauseRequestedEvent(GraphNodeEventBase):
 
 
 def is_node_result_event(event: GraphNodeEventBase) -> bool:
-    """
-    Check if an event is a final result event from node execution.
+    """Check if an event is a final result event from node execution.
 
     A result event indicates the completion of a node execution and contains
     runtime information such as inputs, outputs, or error details.
@@ -112,6 +118,7 @@ def is_node_result_event(event: GraphNodeEventBase) -> bool:
     Returns:
         True if the event is a node result event
         (succeeded/failed/paused), False otherwise
+
     """
     return isinstance(
         event,

--- a/src/graphon/http/client.py
+++ b/src/graphon/http/client.py
@@ -51,7 +51,12 @@ class HttpxHttpClient(HttpClientProtocol):
         return self._request("PATCH", url, max_retries=max_retries, **kwargs)
 
     def _request(
-        self, method: str, url: str, *, max_retries: int = 0, **kwargs: Any
+        self,
+        method: str,
+        url: str,
+        *,
+        max_retries: int = 0,
+        **kwargs: Any,
     ) -> HttpResponse:
         request_kwargs = self._normalize_request_kwargs(kwargs)
         last_error: httpx.RequestError | None = None
@@ -66,12 +71,12 @@ class HttpxHttpClient(HttpClientProtocol):
                     break
 
         if last_error is None:
-            raise RuntimeError("HTTP request retry loop exited without a result")
+            msg = "HTTP request retry loop exited without a result"
+            raise RuntimeError(msg)
         if max_retries == 0:
             raise last_error
-        raise HttpClientMaxRetriesExceededError(
-            f"Request failed after {max_retries + 1} attempt(s): {method} {url}"
-        ) from last_error
+        msg = f"Request failed after {max_retries + 1} attempt(s): {method} {url}"
+        raise HttpClientMaxRetriesExceededError(msg) from last_error
 
     @staticmethod
     def _normalize_request_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -84,9 +89,8 @@ class HttpxHttpClient(HttpClientProtocol):
         timeout = request_kwargs.get("timeout")
         if isinstance(timeout, Sequence) and not isinstance(timeout, str):
             if len(timeout) != 3:
-                raise ValueError(
-                    "timeout sequence must contain connect, read, and write values"
-                )
+                msg = "timeout sequence must contain connect, read, and write values"
+                raise ValueError(msg)
             connect, read, write = timeout
             request_kwargs["timeout"] = httpx.Timeout(
                 timeout=None,

--- a/src/graphon/http/protocols.py
+++ b/src/graphon/http/protocols.py
@@ -39,9 +39,15 @@ class HttpClientProtocol(Protocol):
     def put(self, url: str, max_retries: int = ..., **kwargs: Any) -> HttpResponse: ...
 
     def delete(
-        self, url: str, max_retries: int = ..., **kwargs: Any
+        self,
+        url: str,
+        max_retries: int = ...,
+        **kwargs: Any,
     ) -> HttpResponse: ...
 
     def patch(
-        self, url: str, max_retries: int = ..., **kwargs: Any
+        self,
+        url: str,
+        max_retries: int = ...,
+        **kwargs: Any,
     ) -> HttpResponse: ...

--- a/src/graphon/http/response.py
+++ b/src/graphon/http/response.py
@@ -87,9 +87,10 @@ class HttpResponse:
         if detected_encoding and detected_encoding.encoding:
             try:
                 self._cached_text = self.content.decode(detected_encoding.encoding)
-                return self._cached_text
             except (UnicodeDecodeError, TypeError, LookupError):
                 pass
+            else:
+                return self._cached_text
 
         if self._fallback_text is not None:
             self._cached_text = self._fallback_text

--- a/src/graphon/model_runtime/callbacks/base_callback.py
+++ b/src/graphon/model_runtime/callbacks/base_callback.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
+from sys import stdout
 
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
 from graphon.model_runtime.entities.message_entities import (
     PromptMessage,
     PromptMessageTool,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 _TEXT_COLOR_MAPPING = {
     "blue": "36;1",
@@ -18,8 +19,7 @@ _TEXT_COLOR_MAPPING = {
 
 
 class Callback(ABC):
-    """
-    Base class for callbacks.
+    """Base class for callbacks.
     Only for LLM.
     """
 
@@ -39,8 +39,7 @@ class Callback(ABC):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        Before invoke callback
+        """Before invoke callback
 
         :param llm_instance: LLM instance
         :param model: model name
@@ -70,8 +69,7 @@ class Callback(ABC):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        On new chunk callback
+        """On new chunk callback
 
         :param llm_instance: LLM instance
         :param chunk: chunk
@@ -102,8 +100,7 @@ class Callback(ABC):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        After invoke callback
+        """After invoke callback
 
         :param llm_instance: LLM instance
         :param result: result
@@ -134,8 +131,7 @@ class Callback(ABC):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        Invoke error callback
+        """Invoke error callback
 
         :param llm_instance: LLM instance
         :param ex: exception
@@ -154,7 +150,7 @@ class Callback(ABC):
     def print_text(self, text: str, color: str | None = None, end: str = ""):
         """Print text with highlighting and no end characters."""
         text_to_print = self._get_colored_text(text, color) if color else text
-        print(text_to_print, end=end)
+        stdout.write(text_to_print + end)
 
     def _get_colored_text(self, text: str, color: str) -> str:
         """Get colored text."""

--- a/src/graphon/model_runtime/callbacks/logging_callback.py
+++ b/src/graphon/model_runtime/callbacks/logging_callback.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 from collections.abc import Mapping, Sequence
+from typing import override
 
 from graphon.model_runtime.callbacks.base_callback import Callback
 from graphon.model_runtime.entities.llm_entities import LLMResult, LLMResultChunk
@@ -9,12 +10,13 @@ from graphon.model_runtime.entities.message_entities import (
     PromptMessage,
     PromptMessageTool,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
 
 
 class LoggingCallback(Callback):
+    @override
     def on_before_invoke(
         self,
         llm_instance: AIModel,
@@ -28,8 +30,7 @@ class LoggingCallback(Callback):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        Before invoke callback
+        """Before invoke callback
 
         :param llm_instance: LLM instance
         :param model: model name
@@ -62,7 +63,8 @@ class LoggingCallback(Callback):
 
         if invocation_context:
             self.print_text(
-                f"Invocation context: {dict(invocation_context)}\n", color="blue"
+                f"Invocation context: {dict(invocation_context)}\n",
+                color="blue",
             )
 
         self.print_text("Prompt messages:\n", color="blue")
@@ -76,6 +78,7 @@ class LoggingCallback(Callback):
         if stream:
             self.print_text("\n[on_llm_new_chunk]")
 
+    @override
     def on_new_chunk(
         self,
         llm_instance: AIModel,
@@ -90,8 +93,7 @@ class LoggingCallback(Callback):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        On new chunk callback
+        """On new chunk callback
 
         :param llm_instance: LLM instance
         :param chunk: chunk
@@ -109,6 +111,7 @@ class LoggingCallback(Callback):
             sys.stdout.write(chunk.delta.message.content)
             sys.stdout.flush()
 
+    @override
     def on_after_invoke(
         self,
         llm_instance: AIModel,
@@ -123,8 +126,7 @@ class LoggingCallback(Callback):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        After invoke callback
+        """After invoke callback
 
         :param llm_instance: LLM instance
         :param result: result
@@ -147,15 +149,18 @@ class LoggingCallback(Callback):
                 self.print_text(f"\t{tool_call.id}\n", color="yellow")
                 self.print_text(f"\t{tool_call.function.name}\n", color="yellow")
                 self.print_text(
-                    f"\t{json.dumps(tool_call.function.arguments)}\n", color="yellow"
+                    f"\t{json.dumps(tool_call.function.arguments)}\n",
+                    color="yellow",
                 )
 
         self.print_text(f"Model: {result.model}\n", color="yellow")
         self.print_text(f"Usage: {result.usage}\n", color="yellow")
         self.print_text(
-            f"System Fingerprint: {result.system_fingerprint}\n", color="yellow"
+            f"System Fingerprint: {result.system_fingerprint}\n",
+            color="yellow",
         )
 
+    @override
     def on_invoke_error(
         self,
         llm_instance: AIModel,
@@ -170,8 +175,7 @@ class LoggingCallback(Callback):
         user: str | None = None,
         invocation_context: Mapping[str, object] | None = None,
     ):
-        """
-        Invoke error callback
+        """Invoke error callback
 
         :param llm_instance: LLM instance
         :param ex: exception
@@ -186,4 +190,4 @@ class LoggingCallback(Callback):
         """
         _ = user, invocation_context
         self.print_text("\n[on_llm_invoke_error]\n", color="red")
-        logger.exception(ex)
+        logger.error("LLM invoke failed: %s", ex, exc_info=ex)

--- a/src/graphon/model_runtime/entities/common_entities.py
+++ b/src/graphon/model_runtime/entities/common_entities.py
@@ -1,16 +1,18 @@
-from pydantic import BaseModel, model_validator
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class I18nObject(BaseModel):
-    """
-    Model class for i18n object.
-    """
+    """Model class for i18n object."""
 
-    zh_Hans: str | None = None
-    en_US: str
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+    zh_hans: str | None = Field(default=None, alias="zh_Hans")
+    en_us: str = Field(alias="en_US")
 
     @model_validator(mode="after")
-    def _(self):
-        if not self.zh_Hans:
-            self.zh_Hans = self.en_US
+    def _fill_missing_zh_hans(self) -> Self:
+        if not self.zh_hans:
+            self.zh_hans = self.en_us
         return self

--- a/src/graphon/model_runtime/entities/defaults.py
+++ b/src/graphon/model_runtime/entities/defaults.py
@@ -16,7 +16,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
             ),
             "zh_Hans": (
                 "温度控制随机性。较低的温度会导致较少的随机完成。"
-                "随着温度接近零，模型将变得确定性和重复性。"
+                "随着温度接近零，模型将变得确定性和重复性。"  # noqa: RUF001
                 "较高的温度会导致更多的随机完成。"
             ),
         },
@@ -38,7 +38,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
                 "likelihood-weighted options are considered."
             ),
             "zh_Hans": (
-                "通过核心采样控制多样性：0.5 表示考虑了一半的所有可能性加权选项。"
+                "通过核心采样控制多样性：0.5 表示考虑了一半的所有可能性加权选项。"  # noqa: RUF001
             ),
         },
         "required": False,
@@ -116,7 +116,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
                 "If the generated results are truncated, you can increase this "
                 "parameter."
             ),
-            "zh_Hans": "指定生成结果长度的上限。如果生成结果截断，可以调大该参数。",
+            "zh_Hans": "指定生成结果长度的上限。如果生成结果截断，可以调大该参数。",  # noqa: RUF001
         },
         "required": False,
         "default": 64,
@@ -136,7 +136,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
                 "block as possible, such as JSON, XML, etc."
             ),
             "zh_Hans": (
-                "设置一个返回格式，确保 llm 的输出尽可能是有效的代码块，如 "
+                "设置一个返回格式，确保 llm 的输出尽可能是有效的代码块，如 "  # noqa: RUF001
                 "JSON、XML 等。"
             ),
         },
@@ -150,7 +150,7 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
         "type": "text",
         "help": {
             "en_US": "Set a response json schema will ensure LLM to adhere it.",
-            "zh_Hans": "设置返回的 json schema，llm 将按照它返回",
+            "zh_Hans": "设置返回的 json schema，llm 将按照它返回",  # noqa: RUF001
         },
         "required": False,
     },

--- a/src/graphon/model_runtime/entities/llm_entities.py
+++ b/src/graphon/model_runtime/entities/llm_entities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from enum import StrEnum
-from typing import Any, TypedDict
+from typing import Any, Self, TypedDict
 
 from pydantic import BaseModel, Field
 
@@ -15,17 +15,14 @@ from graphon.model_runtime.entities.model_entities import ModelUsage, PriceInfo
 
 
 class LLMMode(StrEnum):
-    """
-    Enum class for large language model mode.
-    """
+    """Enum class for large language model mode."""
 
     COMPLETION = "completion"
     CHAT = "chat"
 
 
 class LLMUsageMetadata(TypedDict, total=False):
-    """
-    TypedDict for LLM usage metadata.
+    """TypedDict for LLM usage metadata.
     All fields are optional.
     """
 
@@ -46,9 +43,7 @@ class LLMUsageMetadata(TypedDict, total=False):
 
 
 class LLMUsage(ModelUsage):
-    """
-    Model class for llm usage.
-    """
+    """Model class for llm usage."""
 
     prompt_tokens: int
     prompt_unit_price: Decimal
@@ -66,7 +61,7 @@ class LLMUsage(ModelUsage):
     time_to_generate: float | None = None
 
     @classmethod
-    def empty_usage(cls):
+    def empty_usage(cls) -> Self:
         return cls(
             prompt_tokens=0,
             prompt_unit_price=Decimal("0.0"),
@@ -86,14 +81,14 @@ class LLMUsage(ModelUsage):
 
     @classmethod
     def from_metadata(cls, metadata: LLMUsageMetadata) -> LLMUsage:
-        """
-        Create LLMUsage instance from metadata dictionary with default values.
+        """Create LLMUsage instance from metadata dictionary with default values.
 
         Args:
             metadata: TypedDict containing usage metadata
 
         Returns:
             LLMUsage instance with values from metadata or defaults
+
         """
         prompt_tokens = metadata.get("prompt_tokens", 0)
         completion_tokens = metadata.get("completion_tokens", 0)
@@ -110,13 +105,13 @@ class LLMUsage(ModelUsage):
             total_tokens=total_tokens,
             prompt_unit_price=Decimal(str(metadata.get("prompt_unit_price", 0))),
             completion_unit_price=Decimal(
-                str(metadata.get("completion_unit_price", 0))
+                str(metadata.get("completion_unit_price", 0)),
             ),
             total_price=Decimal(str(metadata.get("total_price", 0))),
             currency=metadata.get("currency", "USD"),
             prompt_price_unit=Decimal(str(metadata.get("prompt_price_unit", 0))),
             completion_price_unit=Decimal(
-                str(metadata.get("completion_price_unit", 0))
+                str(metadata.get("completion_price_unit", 0)),
             ),
             prompt_price=Decimal(str(metadata.get("prompt_price", 0))),
             completion_price=Decimal(str(metadata.get("completion_price", 0))),
@@ -126,11 +121,13 @@ class LLMUsage(ModelUsage):
         )
 
     def plus(self, other: LLMUsage) -> LLMUsage:
-        """
-        Add two LLMUsage instances together.
+        """Add two LLMUsage instances together.
 
         :param other: Another LLMUsage instance to add
-        :return: A new LLMUsage instance with summed values
+
+        Returns:
+            A new `LLMUsage` instance with summed counters and pricing data.
+
         """
         if self.total_tokens == 0:
             return other
@@ -152,19 +149,19 @@ class LLMUsage(ModelUsage):
         )
 
     def __add__(self, other: LLMUsage) -> LLMUsage:
-        """
-        Overload the + operator to add two LLMUsage instances.
+        """Overload the + operator to add two LLMUsage instances.
 
         :param other: Another LLMUsage instance to add
-        :return: A new LLMUsage instance with summed values
+
+        Returns:
+            A new `LLMUsage` instance with summed counters and pricing data.
+
         """
         return self.plus(other)
 
 
 class LLMResult(BaseModel):
-    """
-    Model class for llm result.
-    """
+    """Model class for llm result."""
 
     id: str | None = None
     model: str
@@ -176,23 +173,17 @@ class LLMResult(BaseModel):
 
 
 class LLMStructuredOutput(BaseModel):
-    """
-    Model class for llm structured output.
-    """
+    """Model class for llm structured output."""
 
     structured_output: Mapping[str, Any] | None = None
 
 
 class LLMResultWithStructuredOutput(LLMResult, LLMStructuredOutput):
-    """
-    Model class for llm result with structured output.
-    """
+    """Model class for llm result with structured output."""
 
 
 class LLMResultChunkDelta(BaseModel):
-    """
-    Model class for llm result chunk delta.
-    """
+    """Model class for llm result chunk delta."""
 
     index: int
     message: AssistantPromptMessage
@@ -201,9 +192,7 @@ class LLMResultChunkDelta(BaseModel):
 
 
 class LLMResultChunk(BaseModel):
-    """
-    Model class for llm result chunk.
-    """
+    """Model class for llm result chunk."""
 
     model: str
     prompt_messages: Sequence[PromptMessage] = Field(default_factory=list)
@@ -212,14 +201,10 @@ class LLMResultChunk(BaseModel):
 
 
 class LLMResultChunkWithStructuredOutput(LLMResultChunk, LLMStructuredOutput):
-    """
-    Model class for llm result chunk with structured output.
-    """
+    """Model class for llm result chunk with structured output."""
 
 
 class NumTokensResult(PriceInfo):
-    """
-    Model class for number of tokens result.
-    """
+    """Model class for number of tokens result."""
 
     tokens: int

--- a/src/graphon/model_runtime/entities/message_entities.py
+++ b/src/graphon/model_runtime/entities/message_entities.py
@@ -9,9 +9,7 @@ from pydantic import BaseModel, Field, field_serializer, field_validator
 
 
 class PromptMessageRole(StrEnum):
-    """
-    Enum class for prompt message.
-    """
+    """Enum class for prompt message."""
 
     SYSTEM = auto()
     USER = auto()
@@ -20,19 +18,20 @@ class PromptMessageRole(StrEnum):
 
     @classmethod
     def value_of(cls, value: str) -> Self:
-        """
-        Get value of given mode.
+        """Get the enum member for a prompt message role.
 
-        :param value: mode value
-        :return: mode
+        Args:
+            value: Prompt message role value.
+
+        Returns:
+            The matching prompt message role.
+
         """
         return cls(value)
 
 
 class PromptMessageTool(BaseModel):
-    """
-    Model class for prompt message tool.
-    """
+    """Model class for prompt message tool."""
 
     name: str
     description: str
@@ -40,18 +39,14 @@ class PromptMessageTool(BaseModel):
 
 
 class PromptMessageFunction(BaseModel):
-    """
-    Model class for prompt message function.
-    """
+    """Model class for prompt message function."""
 
     type: str = "function"
     function: PromptMessageTool
 
 
 class PromptMessageContentType(StrEnum):
-    """
-    Enum class for prompt message content type.
-    """
+    """Enum class for prompt message content type."""
 
     TEXT = auto()
     IMAGE = auto()
@@ -61,30 +56,25 @@ class PromptMessageContentType(StrEnum):
 
 
 class PromptMessageContent(ABC, BaseModel):
-    """
-    Model class for prompt message content.
-    """
+    """Model class for prompt message content."""
 
     type: PromptMessageContentType
 
 
 class TextPromptMessageContent(PromptMessageContent):
-    """
-    Model class for text prompt message content.
-    """
+    """Model class for text prompt message content."""
 
     type: Literal[PromptMessageContentType.TEXT] = PromptMessageContentType.TEXT  # type: ignore
     data: str
 
 
 class MultiModalPromptMessageContent(PromptMessageContent):
-    """
-    Model class for multi-modal prompt message content.
-    """
+    """Model class for multi-modal prompt message content."""
 
     format: str = Field(default=..., description="the format of multi-modal file")
     base64_data: str = Field(
-        default="", description="the base64 data of multi-modal file"
+        default="",
+        description="the base64 data of multi-modal file",
     )
     url: str = Field(default="", description="the url of multi-modal file")
     mime_type: str = Field(default=..., description="the mime type of multi-modal file")
@@ -104,11 +94,11 @@ class AudioPromptMessageContent(MultiModalPromptMessageContent):
 
 
 class ImagePromptMessageContent(MultiModalPromptMessageContent):
-    """
-    Model class for image prompt message content.
-    """
+    """Model class for image prompt message content."""
 
     class DETAIL(StrEnum):
+        """Supported image detail levels."""
+
         LOW = auto()
         HIGH = auto()
 
@@ -139,102 +129,115 @@ CONTENT_TYPE_MAPPING: Mapping[PromptMessageContentType, type[PromptMessageConten
 }
 
 
+def _get_text_prompt_message_data(item: PromptMessageContent) -> str:
+    match item:
+        case TextPromptMessageContent():
+            result = item.data
+        case _:
+            result = ""
+    return result
+
+
+def _normalize_prompt_message_content(
+    prompt: PromptMessageContent | dict[str, Any],
+) -> PromptMessageContent:
+    match prompt:
+        case TextPromptMessageContent() | MultiModalPromptMessageContent():
+            result = prompt
+        case PromptMessageContent():
+            result = CONTENT_TYPE_MAPPING[prompt.type].model_validate(
+                prompt.model_dump(),
+            )
+        case {"type": prompt_type, **rest}:
+            _ = rest
+            result = CONTENT_TYPE_MAPPING[prompt_type].model_validate(prompt)
+        case _:
+            msg = f"invalid prompt message {prompt}"
+            raise ValueError(msg)
+    return result
+
+
+def _serialize_prompt_message_content_item(
+    item: PromptMessageContent | dict[str, Any],
+) -> dict[str, Any] | PromptMessageContent:
+    match item:
+        case PromptMessageContent():
+            result = item.model_dump()
+        case _:
+            result = item
+    return result
+
+
 class PromptMessage(ABC, BaseModel):
-    """
-    Model class for prompt message.
-    """
+    """Model class for prompt message."""
 
     role: PromptMessageRole
     content: str | list[PromptMessageContentUnionTypes] | None = None
     name: str | None = None
 
     def is_empty(self) -> bool:
-        """
-        Check if prompt message is empty.
-
-        :return: True if prompt message is empty, False otherwise
-        """
+        """Check whether the prompt message has any content."""
         return not self.content
 
     def get_text_content(self) -> str:
-        """
-        Get text content from prompt message.
-
-        :return: Text content as string, empty string if no text content
-        """
-        if isinstance(self.content, str):
-            return self.content
-        if isinstance(self.content, list):
-            return "".join(
-                item.data
-                for item in self.content
-                if isinstance(item, TextPromptMessageContent)
-            )
-        return ""
+        """Extract text-only content from the prompt message."""
+        match self.content:
+            case str():
+                result = self.content
+            case list():
+                result = "".join(
+                    _get_text_prompt_message_data(item) for item in self.content
+                )
+            case _:
+                result = ""
+        return result
 
     @field_validator("content", mode="before")
     @classmethod
-    def validate_content(cls, v):
-        if isinstance(v, list):
-            prompts = []
-            for prompt in v:
-                if isinstance(prompt, PromptMessageContent):
-                    if not isinstance(
-                        prompt,
-                        TextPromptMessageContent | MultiModalPromptMessageContent,
-                    ):
-                        prompt = CONTENT_TYPE_MAPPING[prompt.type].model_validate(
-                            prompt.model_dump()
-                        )
-                elif isinstance(prompt, dict):
-                    prompt = CONTENT_TYPE_MAPPING[prompt["type"]].model_validate(prompt)
-                else:
-                    raise ValueError(f"invalid prompt message {prompt}")
-                prompts.append(prompt)
-            return prompts
-        return v
+    def validate_content(cls, v: Any) -> Any:
+        match v:
+            case list():
+                result = [_normalize_prompt_message_content(prompt) for prompt in v]
+            case _:
+                result = v
+        return result
 
     @field_serializer("content")
     def serialize_content(
-        self, content: str | Sequence[PromptMessageContent] | None
+        self,
+        content: str | Sequence[PromptMessageContent] | None,
     ) -> (
         str
         | list[dict[str, Any] | PromptMessageContent]
         | Sequence[PromptMessageContent]
         | None
     ):
-        if content is None or isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            return [
-                item.model_dump() if hasattr(item, "model_dump") else item
-                for item in content
-            ]
-        return content
+        match content:
+            case None | str():
+                result = content
+            case list():
+                result = [
+                    _serialize_prompt_message_content_item(item) for item in content
+                ]
+            case _:
+                result = content
+        return result
 
 
 class UserPromptMessage(PromptMessage):
-    """
-    Model class for user prompt message.
-    """
+    """Model class for user prompt message."""
 
     role: PromptMessageRole = PromptMessageRole.USER
 
 
 class AssistantPromptMessage(PromptMessage):
-    """
-    Model class for assistant prompt message.
-    """
+    """Model class for assistant prompt message."""
 
     class ToolCall(BaseModel):
-        """
-        Model class for assistant prompt message tool call.
-        """
+        """Model class for assistant prompt message tool call."""
 
         class ToolCallFunction(BaseModel):
-            """
-            Model class for assistant prompt message tool call function.
-            """
+            """Model class for assistant prompt message tool call function."""
 
             name: str
             arguments: str
@@ -245,43 +248,34 @@ class AssistantPromptMessage(PromptMessage):
 
         @field_validator("id", mode="before")
         @classmethod
-        def transform_id_to_str(cls, value) -> str:
-            if not isinstance(value, str):
-                return str(value)
-            return value
+        def transform_id_to_str(cls, value: Any) -> str:
+            match value:
+                case str():
+                    result = value
+                case _:
+                    result = str(value)
+            return result
 
     role: PromptMessageRole = PromptMessageRole.ASSISTANT
     tool_calls: list[ToolCall] = []
 
     def is_empty(self) -> bool:
-        """
-        Check if prompt message is empty.
-
-        :return: True if prompt message is empty, False otherwise
-        """
+        """Check whether the assistant message has no content or tool calls."""
         return super().is_empty() and not self.tool_calls
 
 
 class SystemPromptMessage(PromptMessage):
-    """
-    Model class for system prompt message.
-    """
+    """Model class for system prompt message."""
 
     role: PromptMessageRole = PromptMessageRole.SYSTEM
 
 
 class ToolPromptMessage(PromptMessage):
-    """
-    Model class for tool prompt message.
-    """
+    """Model class for tool prompt message."""
 
     role: PromptMessageRole = PromptMessageRole.TOOL
     tool_call_id: str
 
     def is_empty(self) -> bool:
-        """
-        Check if prompt message is empty.
-
-        :return: True if prompt message is empty, False otherwise
-        """
+        """Check whether the tool message has no content or tool call id."""
         return super().is_empty() and not self.tool_call_id

--- a/src/graphon/model_runtime/entities/model_entities.py
+++ b/src/graphon/model_runtime/entities/model_entities.py
@@ -7,12 +7,11 @@ from typing import Any, Self
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from graphon.model_runtime.entities.common_entities import I18nObject
+from graphon.model_runtime.entities.message_entities import PromptMessageContentType
 
 
 class ModelType(StrEnum):
-    """
-    Enum class for model type.
-    """
+    """Enum class for model type."""
 
     LLM = auto()
     TEXT_EMBEDDING = "text-embedding"
@@ -23,59 +22,60 @@ class ModelType(StrEnum):
 
     @classmethod
     def value_of(cls, origin_model_type: str) -> ModelType:
-        """
-        Get model type from origin model type.
-
-        :return: model type
-        """
-        if origin_model_type in {"text-generation", cls.LLM}:
-            return cls.LLM
-        if origin_model_type in {"embeddings", cls.TEXT_EMBEDDING}:
-            return cls.TEXT_EMBEDDING
-        if origin_model_type in {"reranking", cls.RERANK}:
-            return cls.RERANK
-        if origin_model_type in {"speech2text", cls.SPEECH2TEXT}:
-            return cls.SPEECH2TEXT
-        if origin_model_type in {"tts", cls.TTS}:
-            return cls.TTS
-        if origin_model_type == cls.MODERATION:
-            return cls.MODERATION
-        raise ValueError(f"invalid origin model type {origin_model_type}")
+        """Map a provider-native model type string to a `ModelType`."""
+        return _normalize_origin_model_type(origin_model_type)
 
     def to_origin_model_type(self) -> str:
-        """
-        Get origin model type from model type.
+        """Map `ModelType` back to the provider-native model type string."""
+        origin_model_type = _ORIGIN_MODEL_TYPE_BY_MODEL_TYPE.get(self)
+        if origin_model_type is None:
+            msg = f"invalid model type {self}"
+            raise ValueError(msg)
+        return origin_model_type
 
-        :return: origin model type
-        """
-        if self == self.LLM:
-            return "text-generation"
-        if self == self.TEXT_EMBEDDING:
-            return "embeddings"
-        if self == self.RERANK:
-            return "reranking"
-        if self == self.SPEECH2TEXT:
-            return "speech2text"
-        if self == self.TTS:
-            return "tts"
-        if self == self.MODERATION:
-            return "moderation"
-        raise ValueError(f"invalid model type {self}")
+
+_ORIGIN_MODEL_TYPE_BY_MODEL_TYPE: dict[ModelType, str] = {
+    ModelType.LLM: "text-generation",
+    ModelType.TEXT_EMBEDDING: "embeddings",
+    ModelType.RERANK: "reranking",
+    ModelType.SPEECH2TEXT: "speech2text",
+    ModelType.MODERATION: "moderation",
+    ModelType.TTS: "tts",
+}
+
+
+def _normalize_origin_model_type(origin_model_type: str) -> ModelType:
+    match origin_model_type:
+        case "text-generation":
+            normalized_model_type = ModelType.LLM
+        case "embeddings":
+            normalized_model_type = ModelType.TEXT_EMBEDDING
+        case "reranking":
+            normalized_model_type = ModelType.RERANK
+        case "speech2text":
+            normalized_model_type = ModelType.SPEECH2TEXT
+        case "moderation":
+            normalized_model_type = ModelType.MODERATION
+        case "tts":
+            normalized_model_type = ModelType.TTS
+        case _:
+            try:
+                normalized_model_type = ModelType(origin_model_type)
+            except ValueError as error:
+                msg = f"invalid origin model type {origin_model_type}"
+                raise ValueError(msg) from error
+    return normalized_model_type
 
 
 class FetchFrom(StrEnum):
-    """
-    Enum class for fetch from.
-    """
+    """Enum class for fetch from."""
 
     PREDEFINED_MODEL = "predefined-model"
     CUSTOMIZABLE_MODEL = "customizable-model"
 
 
 class ModelFeature(StrEnum):
-    """
-    Enum class for llm feature.
-    """
+    """Enum class for llm feature."""
 
     TOOL_CALL = "tool-call"
     MULTI_TOOL_CALL = "multi-tool-call"
@@ -88,10 +88,19 @@ class ModelFeature(StrEnum):
     STRUCTURED_OUTPUT = "structured-output"
 
 
+_REQUIRED_MODEL_FEATURE_BY_CONTENT_TYPE: dict[
+    PromptMessageContentType,
+    ModelFeature,
+] = {
+    PromptMessageContentType.IMAGE: ModelFeature.VISION,
+    PromptMessageContentType.DOCUMENT: ModelFeature.DOCUMENT,
+    PromptMessageContentType.VIDEO: ModelFeature.VIDEO,
+    PromptMessageContentType.AUDIO: ModelFeature.AUDIO,
+}
+
+
 class DefaultParameterName(StrEnum):
-    """
-    Enum class for parameter template variable.
-    """
+    """Enum class for parameter template variable."""
 
     TEMPERATURE = auto()
     TOP_P = auto()
@@ -104,19 +113,20 @@ class DefaultParameterName(StrEnum):
 
     @classmethod
     def value_of(cls, value: Any) -> Self:
-        """
-        Get parameter name from value.
+        """Get the enum member for a default parameter name.
 
-        :param value: parameter value
-        :return: parameter name
+        Args:
+            value: Raw parameter name value.
+
+        Returns:
+            The matching default parameter name.
+
         """
         return cls(value)
 
 
 class ParameterType(StrEnum):
-    """
-    Enum class for parameter type.
-    """
+    """Enum class for parameter type."""
 
     FLOAT = auto()
     INT = auto()
@@ -126,9 +136,7 @@ class ParameterType(StrEnum):
 
 
 class ModelPropertyKey(StrEnum):
-    """
-    Enum class for model property key.
-    """
+    """Enum class for model property key."""
 
     MODE = auto()
     CONTEXT_SIZE = auto()
@@ -144,9 +152,7 @@ class ModelPropertyKey(StrEnum):
 
 
 class ProviderModel(BaseModel):
-    """
-    Model class for provider model.
-    """
+    """Model class for provider model."""
 
     model: str
     label: I18nObject
@@ -166,9 +172,7 @@ class ProviderModel(BaseModel):
 
 
 class ParameterRule(BaseModel):
-    """
-    Model class for parameter rule.
-    """
+    """Model class for parameter rule."""
 
     name: str
     use_template: str | None = None
@@ -184,9 +188,7 @@ class ParameterRule(BaseModel):
 
 
 class PriceConfig(BaseModel):
-    """
-    Model class for pricing info.
-    """
+    """Model class for pricing info."""
 
     input: Decimal
     output: Decimal | None = None
@@ -195,12 +197,20 @@ class PriceConfig(BaseModel):
 
 
 class AIModelEntity(ProviderModel):
-    """
-    Model class for AI model.
-    """
+    """Model class for AI model."""
 
     parameter_rules: list[ParameterRule] = []
     pricing: PriceConfig | None = None
+
+    def supports_prompt_content_type(
+        self,
+        content_type: PromptMessageContentType,
+    ) -> bool:
+        if not self.features:
+            return content_type == PromptMessageContentType.TEXT
+
+        required_feature = _REQUIRED_MODEL_FEATURE_BY_CONTENT_TYPE.get(content_type)
+        return required_feature is None or required_feature in self.features
 
     @model_validator(mode="after")
     def validate_model(self):
@@ -227,18 +237,14 @@ class ModelUsage(BaseModel):
 
 
 class PriceType(StrEnum):
-    """
-    Enum class for price type.
-    """
+    """Enum class for price type."""
 
     INPUT = auto()
     OUTPUT = auto()
 
 
 class PriceInfo(BaseModel):
-    """
-    Model class for price info.
-    """
+    """Model class for price info."""
 
     unit_price: Decimal
     unit: Decimal

--- a/src/graphon/model_runtime/entities/provider_entities.py
+++ b/src/graphon/model_runtime/entities/provider_entities.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from enum import StrEnum, auto
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -8,18 +9,14 @@ from graphon.model_runtime.entities.model_entities import AIModelEntity, ModelTy
 
 
 class ConfigurateMethod(StrEnum):
-    """
-    Enum class for configurate method of provider model.
-    """
+    """Enum class for configurate method of provider model."""
 
     PREDEFINED_MODEL = "predefined-model"
     CUSTOMIZABLE_MODEL = "customizable-model"
 
 
 class FormType(StrEnum):
-    """
-    Enum class for form type.
-    """
+    """Enum class for form type."""
 
     TEXT_INPUT = "text-input"
     SECRET_INPUT = "secret-input"
@@ -29,34 +26,28 @@ class FormType(StrEnum):
 
 
 class FormShowOnObject(BaseModel):
-    """
-    Model class for form show on.
-    """
+    """Model class for form show on."""
 
     variable: str
     value: str
 
 
 class FormOption(BaseModel):
-    """
-    Model class for form option.
-    """
+    """Model class for form option."""
 
     label: I18nObject
     value: str
     show_on: list[FormShowOnObject] = []
 
     @model_validator(mode="after")
-    def _(self):
+    def _(self) -> Self:
         if not self.label:
-            self.label = I18nObject(en_US=self.value)
+            self.label = I18nObject(en_us=self.value)
         return self
 
 
 class CredentialFormSchema(BaseModel):
-    """
-    Model class for credential form schema.
-    """
+    """Model class for credential form schema."""
 
     variable: str
     label: I18nObject
@@ -70,9 +61,7 @@ class CredentialFormSchema(BaseModel):
 
 
 class ProviderCredentialSchema(BaseModel):
-    """
-    Model class for provider credential schema.
-    """
+    """Model class for provider credential schema."""
 
     credential_form_schemas: list[CredentialFormSchema]
 
@@ -83,17 +72,14 @@ class FieldModelSchema(BaseModel):
 
 
 class ModelCredentialSchema(BaseModel):
-    """
-    Model class for model credential schema.
-    """
+    """Model class for model credential schema."""
 
     model: FieldModelSchema
     credential_form_schemas: list[CredentialFormSchema]
 
 
 class SimpleProviderEntity(BaseModel):
-    """
-    Simplified provider schema exposed to callers.
+    """Simplified provider schema exposed to callers.
 
     `provider` is the canonical runtime identifier. `provider_name` is an optional
     compatibility alias for short-name lookups and is empty when no alias exists.
@@ -109,17 +95,14 @@ class SimpleProviderEntity(BaseModel):
 
 
 class ProviderHelpEntity(BaseModel):
-    """
-    Model class for provider help.
-    """
+    """Model class for provider help."""
 
     title: I18nObject
     url: I18nObject
 
 
 class ProviderEntity(BaseModel):
-    """
-    Runtime-native provider schema.
+    """Runtime-native provider schema.
 
     `provider` is the canonical runtime identifier. `provider_name` is a
     compatibility alias for callers that still resolve providers by short name and
@@ -148,18 +131,14 @@ class ProviderEntity(BaseModel):
 
     @field_validator("models", mode="before")
     @classmethod
-    def validate_models(cls, v):
+    def validate_models(cls, v: Any) -> Any:
         # returns EmptyList if v is empty
         if not v:
             return []
         return v
 
     def to_simple_provider(self) -> SimpleProviderEntity:
-        """
-        Convert to simple provider.
-
-        :return: simple provider
-        """
+        """Convert the full provider entity into its simplified public form."""
         return SimpleProviderEntity(
             provider=self.provider,
             provider_name=self.provider_name,
@@ -171,9 +150,7 @@ class ProviderEntity(BaseModel):
 
 
 class ProviderConfig(BaseModel):
-    """
-    Model class for provider config.
-    """
+    """Model class for provider config."""
 
     provider: str
     credentials: dict

--- a/src/graphon/model_runtime/entities/rerank_entities.py
+++ b/src/graphon/model_runtime/entities/rerank_entities.py
@@ -9,9 +9,7 @@ class MultimodalRerankInput(TypedDict):
 
 
 class RerankDocument(BaseModel):
-    """
-    Model class for rerank document.
-    """
+    """Model class for rerank document."""
 
     index: int
     text: str
@@ -19,9 +17,7 @@ class RerankDocument(BaseModel):
 
 
 class RerankResult(BaseModel):
-    """
-    Model class for rerank result.
-    """
+    """Model class for rerank result."""
 
     model: str
     docs: list[RerankDocument]

--- a/src/graphon/model_runtime/entities/text_embedding_entities.py
+++ b/src/graphon/model_runtime/entities/text_embedding_entities.py
@@ -14,9 +14,7 @@ class EmbeddingInputType(StrEnum):
 
 
 class EmbeddingUsage(ModelUsage):
-    """
-    Model class for embedding usage.
-    """
+    """Model class for embedding usage."""
 
     tokens: int
     total_tokens: int
@@ -28,9 +26,7 @@ class EmbeddingUsage(ModelUsage):
 
 
 class EmbeddingResult(BaseModel):
-    """
-    Model class for text embedding result.
-    """
+    """Model class for text embedding result."""
 
     model: str
     embeddings: list[list[float]]
@@ -38,9 +34,7 @@ class EmbeddingResult(BaseModel):
 
 
 class FileEmbeddingResult(BaseModel):
-    """
-    Model class for file embedding result.
-    """
+    """Model class for file embedding result."""
 
     model: str
     embeddings: list[list[float]]

--- a/src/graphon/model_runtime/errors/invoke.py
+++ b/src/graphon/model_runtime/errors/invoke.py
@@ -3,11 +3,11 @@ class InvokeError(ValueError):
 
     description: str | None = None
 
-    def __init__(self, description: str | None = None):
+    def __init__(self, description: str | None = None) -> None:
         if description is not None:
             self.description = description
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.description or self.__class__.__name__
 
 

--- a/src/graphon/model_runtime/errors/validate.py
+++ b/src/graphon/model_runtime/errors/validate.py
@@ -1,4 +1,2 @@
 class CredentialsValidateFailedError(ValueError):
-    """
-    Credentials validate failed error
-    """
+    """Credentials validate failed error"""

--- a/src/graphon/model_runtime/model_providers/base/ai_model.py
+++ b/src/graphon/model_runtime/model_providers/base/ai_model.py
@@ -1,4 +1,5 @@
 import decimal
+from typing import Any
 
 from graphon.model_runtime.entities.common_entities import I18nObject
 from graphon.model_runtime.entities.defaults import PARAMETER_RULE_TEMPLATE
@@ -23,8 +24,7 @@ from graphon.model_runtime.runtime import ModelRuntime
 
 
 class AIModel:
-    """
-    Runtime-facing base class for all model providers.
+    """Runtime-facing base class for all model providers.
 
     This stays a regular Python class because instances hold live collaborators
     such as the provider schema and runtime adapter rather than user input that
@@ -45,9 +45,8 @@ class AIModel:
         started_at: float = 0,
     ) -> None:
         if getattr(type(self), "model_type", None) is None:
-            raise TypeError(
-                "AIModel subclasses must define model_type as a class attribute"
-            )
+            msg = "AIModel subclasses must define model_type as a class attribute"
+            raise TypeError(msg)
 
         self.model_type = type(self).model_type
         self.provider_schema = provider_schema
@@ -60,12 +59,11 @@ class AIModel:
 
     @property
     def provider_display_name(self) -> str:
-        return self.provider_schema.label.en_US
+        return self.provider_schema.label.en_us
 
     @property
     def _invoke_error_mapping(self) -> dict[type[Exception], list[type[Exception]]]:
-        """
-        Map model invoke error to unified error.
+        """Map model invoke error to unified error.
 
         The key is the error type thrown to the caller, and the value contains
         runtime-facing exception types that should be normalized to it.
@@ -80,12 +78,7 @@ class AIModel:
         }
 
     def _transform_invoke_error(self, error: Exception) -> Exception:
-        """
-        Transform invoke error to unified error
-
-        :param error: model invoke error
-        :return: unified error
-        """
+        """Normalize provider/runtime exceptions into graphon-facing invoke errors."""
         for invoke_error, model_errors in self._invoke_error_mapping.items():
             if isinstance(error, tuple(model_errors)):
                 if invoke_error == InvokeAuthorizationError:
@@ -93,7 +86,7 @@ class AIModel:
                         description=(
                             f"[{self.provider_display_name}] Incorrect model "
                             "credentials provided, please check and try again."
-                        )
+                        ),
                     )
                 if isinstance(invoke_error, InvokeError):
                     return InvokeError(
@@ -101,26 +94,22 @@ class AIModel:
                             f"[{self.provider_display_name}] "
                             f"{invoke_error.description}, "
                             f"{error!s}"
-                        )
+                        ),
                     )
                 return error
 
         return InvokeError(
-            description=f"[{self.provider_display_name}] Error: {error!s}"
+            description=f"[{self.provider_display_name}] Error: {error!s}",
         )
 
     def get_price(
-        self, model: str, credentials: dict, price_type: PriceType, tokens: int
+        self,
+        model: str,
+        credentials: dict,
+        price_type: PriceType,
+        tokens: int,
     ) -> PriceInfo:
-        """
-        Get price for given model and tokens
-
-        :param model: model name
-        :param credentials: model credentials
-        :param price_type: price type
-        :param tokens: number of tokens
-        :return: price info
-        """
+        """Calculate pricing metadata for a token count on a given model."""
         # get model schema
         model_schema = self.get_model_schema(model, credentials)
 
@@ -147,10 +136,12 @@ class AIModel:
 
         # calculate total amount
         if not price_config:
-            raise ValueError(f"Price config not found for model {model}")
+            msg = f"Price config not found for model {model}"
+            raise ValueError(msg)
         total_amount = tokens * unit_price * price_config.unit
         total_amount = total_amount.quantize(
-            decimal.Decimal("0.0000001"), rounding=decimal.ROUND_HALF_UP
+            decimal.Decimal("0.0000001"),
+            rounding=decimal.ROUND_HALF_UP,
         )
 
         return PriceInfo(
@@ -161,15 +152,11 @@ class AIModel:
         )
 
     def get_model_schema(
-        self, model: str, credentials: dict | None = None
+        self,
+        model: str,
+        credentials: dict | None = None,
     ) -> AIModelEntity | None:
-        """
-        Get model schema by model name and credentials
-
-        :param model: model name
-        :param credentials: model credentials
-        :return: model schema
-        """
+        """Fetch the resolved model schema for a model and credential set."""
         return self.model_runtime.get_model_schema(
             provider=self.provider,
             model_type=self.model_type,
@@ -178,16 +165,11 @@ class AIModel:
         )
 
     def get_customizable_model_schema_from_credentials(
-        self, model: str, credentials: dict
+        self,
+        model: str,
+        credentials: dict,
     ) -> AIModelEntity | None:
-        """
-        Get customizable model schema from credentials
-
-        :param model: model name
-        :param credentials: model credentials
-        :return: model schema
-        """
-
+        """Resolve and hydrate a customizable model schema from credentials."""
         # get customizable model schema
         schema = self.get_customizable_model_schema(model, credentials)
         if not schema:
@@ -199,11 +181,11 @@ class AIModel:
             if parameter_rule.use_template:
                 try:
                     default_parameter_name = DefaultParameterName.value_of(
-                        parameter_rule.use_template
+                        parameter_rule.use_template,
                     )
                     default_parameter_rule = (
                         self._get_default_parameter_rule_variable_map(
-                            default_parameter_name
+                            default_parameter_name,
                         )
                     )
                     if not parameter_rule.max and "max" in default_parameter_rule:
@@ -227,28 +209,28 @@ class AIModel:
                         parameter_rule.required = default_parameter_rule["required"]
                     if not parameter_rule.help and "help" in default_parameter_rule:
                         parameter_rule.help = I18nObject(
-                            en_US=default_parameter_rule["help"]["en_US"],
+                            en_us=default_parameter_rule["help"]["en_US"],
                         )
                     if (
                         parameter_rule.help
-                        and not parameter_rule.help.en_US
+                        and not parameter_rule.help.en_us
                         and (
                             "help" in default_parameter_rule
                             and "en_US" in default_parameter_rule["help"]
                         )
                     ):
-                        parameter_rule.help.en_US = default_parameter_rule["help"][
+                        parameter_rule.help.en_us = default_parameter_rule["help"][
                             "en_US"
                         ]
                     if (
                         parameter_rule.help
-                        and not parameter_rule.help.zh_Hans
+                        and not parameter_rule.help.zh_hans
                         and (
                             "help" in default_parameter_rule
                             and "zh_Hans" in default_parameter_rule["help"]
                         )
                     ):
-                        parameter_rule.help.zh_Hans = default_parameter_rule[
+                        parameter_rule.help.zh_hans = default_parameter_rule[
                             "help"
                         ].get("zh_Hans", default_parameter_rule["help"]["en_US"])
                 except ValueError:
@@ -261,27 +243,24 @@ class AIModel:
         return schema
 
     def get_customizable_model_schema(
-        self, model: str, credentials: dict
+        self,
+        model: str,
+        credentials: dict,
     ) -> AIModelEntity | None:
-        """
-        Get customizable model schema
-
-        :param model: model name
-        :param credentials: model credentials
-        :return: model schema
-        """
+        """Return the provider-specific customizable model schema, if supported."""
+        _ = model
+        _ = credentials
         return None
 
-    def _get_default_parameter_rule_variable_map(self, name: DefaultParameterName):
-        """
-        Get default parameter rule for given name
-
-        :param name: parameter name
-        :return: parameter rule
-        """
+    def _get_default_parameter_rule_variable_map(
+        self,
+        name: DefaultParameterName,
+    ) -> dict[str, Any]:
+        """Look up the default parameter rule template for a named parameter."""
         default_parameter_rule = PARAMETER_RULE_TEMPLATE.get(name)
 
         if not default_parameter_rule:
-            raise Exception(f"Invalid model parameter rule name {name}")
+            msg = f"Invalid model parameter rule name {name}"
+            raise ValueError(msg)
 
         return default_parameter_rule

--- a/src/graphon/model_runtime/model_providers/base/large_language_model.py
+++ b/src/graphon/model_runtime/model_providers/base/large_language_model.py
@@ -21,13 +21,9 @@ from graphon.model_runtime.entities.model_entities import (
     ModelType,
     PriceType,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
-
-
-def _gen_tool_call_id() -> str:
-    return f"chatcmpl-tool-{uuid.uuid4().hex!s}"
 
 
 def _run_callbacks(
@@ -53,21 +49,32 @@ def _run_callbacks(
             )
 
 
+def generate_tool_call_id() -> str:
+    return f"chatcmpl-tool-{uuid.uuid4().hex!s}"
+
+
 def _get_or_create_tool_call(
     existing_tools_calls: list[AssistantPromptMessage.ToolCall],
     tool_call_id: str,
 ) -> AssistantPromptMessage.ToolCall:
-    """
-    Get or create a tool call by ID.
+    """Get or create a tool call by ID.
 
     If `tool_call_id` is empty, returns the most recently created tool call.
+
+    Returns:
+        The existing or newly created tool call that should receive the delta.
+
+    Raises:
+        ValueError: If `tool_call_id` is empty and there is no prior tool call to reuse.
+
     """
     if not tool_call_id:
         if not existing_tools_calls:
-            raise ValueError(
+            msg = (
                 "tool_call_id is empty but no existing tool call is "
                 "available to apply the delta"
             )
+            raise ValueError(msg)
         return existing_tools_calls[-1]
 
     tool_call = next(
@@ -83,7 +90,8 @@ def _get_or_create_tool_call(
             id=tool_call_id,
             type="function",
             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                name="", arguments=""
+                name="",
+                arguments="",
             ),
         )
         existing_tools_calls.append(tool_call)
@@ -110,16 +118,14 @@ def _build_llm_result_from_chunks(
     prompt_messages: Sequence[PromptMessage],
     chunks: Iterator[LLMResultChunk],
 ) -> LLMResult:
-    """
-    Build a single `LLMResult` by accumulating all returned chunks.
+    """Build a single `LLMResult` by accumulating all returned chunks.
 
-    Some models only support streaming output (e.g. Qwen3 open-source edition)
-    and the plugin side may still implement the response via a chunked stream,
-    so all chunks must be consumed and concatenated into a single ``LLMResult``.
+    Some models only support streaming output and the runtime may still return
+    an iterator in non-stream mode, so all chunks must be consumed and merged.
 
-    The ``usage`` is taken from the last chunk that carries it, which is the
-    typical convention for streaming responses (the final chunk contains the
-    aggregated token counts).
+    Returns:
+        A normalized `LLMResult` assembled from the consumed chunks.
+
     """
     content = ""
     content_list: list[PromptMessageContentUnionTypes] = []
@@ -135,7 +141,7 @@ def _build_llm_result_from_chunks(
                 content_list.extend(chunk.delta.message.content)
 
             if chunk.delta.message.tool_calls:
-                _increase_tool_call(chunk.delta.message.tool_calls, tools_calls)
+                merge_tool_call_deltas(chunk.delta.message.tool_calls, tools_calls)
 
             if chunk.delta.usage:
                 usage = chunk.delta.usage
@@ -145,8 +151,6 @@ def _build_llm_result_from_chunks(
         logger.exception("Error while consuming non-stream plugin chunk iterator.")
         raise
     finally:
-        # Drain any remaining chunks to release underlying streaming
-        # resources (e.g. HTTP connections).
         close = getattr(chunks, "close", None)
         if callable(close):
             close()
@@ -161,6 +165,42 @@ def _build_llm_result_from_chunks(
         usage=usage,
         system_fingerprint=system_fingerprint,
     )
+
+
+def normalize_non_stream_runtime_result(
+    model: str,
+    prompt_messages: Sequence[PromptMessage],
+    result: LLMResult | Iterator[LLMResultChunk],
+) -> LLMResult:
+    if isinstance(result, LLMResult):
+        return result
+    return _build_llm_result_from_chunks(
+        model=model,
+        prompt_messages=prompt_messages,
+        chunks=result,
+    )
+
+
+def merge_tool_call_deltas(
+    new_tool_calls: list[AssistantPromptMessage.ToolCall],
+    existing_tools_calls: list[AssistantPromptMessage.ToolCall],
+    *,
+    id_generator: Callable[[], str] | None = None,
+) -> None:
+    """Merge incremental tool call deltas into existing tool calls.
+
+    :param new_tool_calls: List of new tool call deltas to be merged.
+    :param existing_tools_calls: List of existing tool calls modified in place.
+    :param id_generator: Optional callable for generating IDs in tests/callers.
+    """
+    generator = generate_tool_call_id if id_generator is None else id_generator
+
+    for new_tool_call in new_tool_calls:
+        if new_tool_call.function.name and not new_tool_call.id:
+            new_tool_call.id = generator()
+
+        tool_call = _get_or_create_tool_call(existing_tools_calls, new_tool_call.id)
+        _merge_tool_call_delta(tool_call, new_tool_call)
 
 
 def _invoke_llm_via_runtime(
@@ -187,42 +227,8 @@ def _invoke_llm_via_runtime(
     )
 
 
-def _normalize_non_stream_runtime_result(
-    model: str,
-    prompt_messages: Sequence[PromptMessage],
-    result: LLMResult | Iterator[LLMResultChunk],
-) -> LLMResult:
-    if isinstance(result, LLMResult):
-        return result
-    return _build_llm_result_from_chunks(
-        model=model, prompt_messages=prompt_messages, chunks=result
-    )
-
-
-def _increase_tool_call(
-    new_tool_calls: list[AssistantPromptMessage.ToolCall],
-    existing_tools_calls: list[AssistantPromptMessage.ToolCall],
-):
-    """
-    Merge incremental tool call updates into existing tool calls.
-
-    :param new_tool_calls: List of new tool call deltas to be merged.
-    :param existing_tools_calls: List of existing tool calls to be modified IN-PLACE.
-    """
-
-    for new_tool_call in new_tool_calls:
-        # generate ID for tool calls with function name but no ID to track them
-        if new_tool_call.function.name and not new_tool_call.id:
-            new_tool_call.id = _gen_tool_call_id()
-
-        tool_call = _get_or_create_tool_call(existing_tools_calls, new_tool_call.id)
-        _merge_tool_call_delta(tool_call, new_tool_call)
-
-
 class LargeLanguageModel(AIModel):
-    """
-    Model class for large language model.
-    """
+    """Model class for large language model."""
 
     model_type: ModelType = ModelType.LLM
 
@@ -237,19 +243,7 @@ class LargeLanguageModel(AIModel):
         stream: bool = True,
         callbacks: list[Callback] | None = None,
     ) -> LLMResult | Generator[LLMResultChunk, None, None]:
-        """
-        Invoke large language model
-
-        :param model: model name
-        :param credentials: model credentials
-        :param prompt_messages: prompt messages
-        :param model_parameters: model parameters
-        :param tools: tools for tool calling
-        :param stop: stop words
-        :param stream: is stream response
-        :param callbacks: callbacks
-        :return: full response or stream response chunk generator result
-        """
+        """Invoke the large language model and optionally stream result chunks."""
         # validate and filter model parameters
         if model_parameters is None:
             model_parameters = {}
@@ -289,8 +283,10 @@ class LargeLanguageModel(AIModel):
             )
 
             if not stream:
-                result = _normalize_non_stream_runtime_result(
-                    model=model, prompt_messages=prompt_messages, result=result
+                result = normalize_non_stream_runtime_result(
+                    model=model,
+                    prompt_messages=prompt_messages,
+                    result=result,
                 )
         except Exception as e:
             self._trigger_invoke_error_callbacks(
@@ -306,7 +302,7 @@ class LargeLanguageModel(AIModel):
             )
 
             # TODO
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e
 
         if stream and not isinstance(result, LLMResult):
             return self._invoke_result_generator(
@@ -337,7 +333,8 @@ class LargeLanguageModel(AIModel):
             # To ensure compatibility, we add the prompt_messages back here.
             result.prompt_messages = prompt_messages
             return result
-        raise NotImplementedError("unsupported invoke result type", type(result))
+        msg = "unsupported invoke result type"
+        raise NotImplementedError(msg, type(result))
 
     def _invoke_result_generator(
         self,
@@ -352,12 +349,7 @@ class LargeLanguageModel(AIModel):
         invocation_context: Mapping[str, object] | None = None,
         callbacks: list[Callback] | None = None,
     ) -> Generator[LLMResultChunk, None, None]:
-        """
-        Invoke result generator
-
-        :param result: result generator
-        :return: result generator
-        """
+        """Stream runtime result chunks through callbacks and bookkeeping hooks."""
         callbacks = callbacks or []
         message_content: list[PromptMessageContentUnionTypes] = []
         usage = None
@@ -366,7 +358,7 @@ class LargeLanguageModel(AIModel):
 
         def _update_message_content(
             content: str | list[PromptMessageContentUnionTypes] | None,
-        ):
+        ) -> None:
             if not content:
                 return
             if isinstance(content, list):
@@ -407,7 +399,7 @@ class LargeLanguageModel(AIModel):
                 if chunk.system_fingerprint:
                     system_fingerprint = chunk.system_fingerprint
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e
 
         assistant_message = AssistantPromptMessage(content=message_content)
         self._trigger_after_invoke_callbacks(
@@ -436,15 +428,7 @@ class LargeLanguageModel(AIModel):
         prompt_messages: list[PromptMessage],
         tools: list[PromptMessageTool] | None = None,
     ) -> int:
-        """
-        Get number of tokens for given prompt messages
-
-        :param model: model name
-        :param credentials: model credentials
-        :param prompt_messages: prompt messages
-        :param tools: tools for tool calling
-        :return:
-        """
+        """Count prompt tokens for the given messages and optional tools."""
         return self.model_runtime.get_llm_num_tokens(
             provider=self.provider,
             model_type=self.model_type,
@@ -455,17 +439,13 @@ class LargeLanguageModel(AIModel):
         )
 
     def calc_response_usage(
-        self, model: str, credentials: dict, prompt_tokens: int, completion_tokens: int
+        self,
+        model: str,
+        credentials: dict,
+        prompt_tokens: int,
+        completion_tokens: int,
     ) -> LLMUsage:
-        """
-        Calculate response usage
-
-        :param model: model name
-        :param credentials: model credentials
-        :param prompt_tokens: prompt tokens
-        :param completion_tokens: completion tokens
-        :return: usage
-        """
+        """Calculate unified usage and pricing metadata for a response."""
         # get prompt price info
         prompt_price_info = self.get_price(
             model=model,
@@ -483,7 +463,7 @@ class LargeLanguageModel(AIModel):
         )
 
         # transform usage
-        usage = LLMUsage(
+        return LLMUsage(
             prompt_tokens=prompt_tokens,
             prompt_unit_price=prompt_price_info.unit_price,
             prompt_price_unit=prompt_price_info.unit,
@@ -499,8 +479,6 @@ class LargeLanguageModel(AIModel):
             latency=time.perf_counter() - self.started_at,
         )
 
-        return usage
-
     def _trigger_before_invoke_callbacks(
         self,
         model: str,
@@ -512,9 +490,8 @@ class LargeLanguageModel(AIModel):
         stream: bool = True,
         invocation_context: Mapping[str, object] | None = None,
         callbacks: list[Callback] | None = None,
-    ):
-        """
-        Trigger before invoke callbacks
+    ) -> None:
+        """Trigger before invoke callbacks
 
         :param model: model name
         :param credentials: model credentials
@@ -554,9 +531,8 @@ class LargeLanguageModel(AIModel):
         stream: bool = True,
         invocation_context: Mapping[str, object] | None = None,
         callbacks: list[Callback] | None = None,
-    ):
-        """
-        Trigger new chunk callbacks
+    ) -> None:
+        """Trigger new chunk callbacks
 
         :param chunk: chunk
         :param model: model name
@@ -597,9 +573,8 @@ class LargeLanguageModel(AIModel):
         stream: bool = True,
         invocation_context: Mapping[str, object] | None = None,
         callbacks: list[Callback] | None = None,
-    ):
-        """
-        Trigger after invoke callbacks
+    ) -> None:
+        """Trigger after invoke callbacks
 
         :param model: model name
         :param result: result
@@ -641,9 +616,8 @@ class LargeLanguageModel(AIModel):
         stream: bool = True,
         invocation_context: Mapping[str, object] | None = None,
         callbacks: list[Callback] | None = None,
-    ):
-        """
-        Trigger invoke error callbacks
+    ) -> None:
+        """Trigger invoke error callbacks
 
         :param model: model name
         :param ex: exception

--- a/src/graphon/model_runtime/model_providers/base/moderation_model.py
+++ b/src/graphon/model_runtime/model_providers/base/moderation_model.py
@@ -1,25 +1,16 @@
 import time
 
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 
 class ModerationModel(AIModel):
-    """
-    Model class for moderation model.
-    """
+    """Model class for moderation model."""
 
     model_type: ModelType = ModelType.MODERATION
 
     def invoke(self, model: str, credentials: dict, text: str) -> bool:
-        """
-        Invoke moderation model
-
-        :param model: model name
-        :param credentials: model credentials
-        :param text: text to moderate
-        :return: false if text is safe, true otherwise
-        """
+        """Invoke the moderation model and return whether the text is unsafe."""
         self.started_at = time.perf_counter()
 
         try:
@@ -30,4 +21,4 @@ class ModerationModel(AIModel):
                 text=text,
             )
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e

--- a/src/graphon/model_runtime/model_providers/base/rerank_model.py
+++ b/src/graphon/model_runtime/model_providers/base/rerank_model.py
@@ -3,13 +3,11 @@ from graphon.model_runtime.entities.rerank_entities import (
     MultimodalRerankInput,
     RerankResult,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 
 class RerankModel(AIModel):
-    """
-    Base Model class for rerank model.
-    """
+    """Base Model class for rerank model."""
 
     model_type: ModelType = ModelType.RERANK
 
@@ -22,17 +20,7 @@ class RerankModel(AIModel):
         score_threshold: float | None = None,
         top_n: int | None = None,
     ) -> RerankResult:
-        """
-        Invoke rerank model
-
-        :param model: model name
-        :param credentials: model credentials
-        :param query: search query
-        :param docs: docs for reranking
-        :param score_threshold: score threshold
-        :param top_n: top n
-        :return: rerank result
-        """
+        """Invoke the rerank model for text inputs."""
         try:
             return self.model_runtime.invoke_rerank(
                 provider=self.provider,
@@ -44,7 +32,7 @@ class RerankModel(AIModel):
                 top_n=top_n,
             )
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e
 
     def invoke_multimodal_rerank(
         self,
@@ -55,16 +43,7 @@ class RerankModel(AIModel):
         score_threshold: float | None = None,
         top_n: int | None = None,
     ) -> RerankResult:
-        """
-        Invoke multimodal rerank model
-        :param model: model name
-        :param credentials: model credentials
-        :param query: search query
-        :param docs: docs for reranking
-        :param score_threshold: score threshold
-        :param top_n: top n
-        :return: rerank result
-        """
+        """Invoke the rerank model for multimodal inputs."""
         try:
             return self.model_runtime.invoke_multimodal_rerank(
                 provider=self.provider,
@@ -76,4 +55,4 @@ class RerankModel(AIModel):
                 top_n=top_n,
             )
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e

--- a/src/graphon/model_runtime/model_providers/base/speech2text_model.py
+++ b/src/graphon/model_runtime/model_providers/base/speech2text_model.py
@@ -1,25 +1,16 @@
 from typing import IO
 
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 
 class Speech2TextModel(AIModel):
-    """
-    Model class for speech2text model.
-    """
+    """Model class for speech2text model."""
 
     model_type: ModelType = ModelType.SPEECH2TEXT
 
     def invoke(self, model: str, credentials: dict, file: IO[bytes]) -> str:
-        """
-        Invoke speech to text model
-
-        :param model: model name
-        :param credentials: model credentials
-        :param file: audio file
-        :return: text for given audio file
-        """
+        """Invoke the speech-to-text model and return the transcribed text."""
         try:
             return self.model_runtime.invoke_speech_to_text(
                 provider=self.provider,
@@ -28,4 +19,4 @@ class Speech2TextModel(AIModel):
                 file=file,
             )
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e

--- a/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
+++ b/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
@@ -3,13 +3,11 @@ from graphon.model_runtime.entities.text_embedding_entities import (
     EmbeddingInputType,
     EmbeddingResult,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 
 class TextEmbeddingModel(AIModel):
-    """
-    Model class for text embedding model.
-    """
+    """Model class for text embedding model."""
 
     model_type: ModelType = ModelType.TEXT_EMBEDDING
 
@@ -21,16 +19,11 @@ class TextEmbeddingModel(AIModel):
         multimodel_documents: list[dict] | None = None,
         input_type: EmbeddingInputType = EmbeddingInputType.DOCUMENT,
     ) -> EmbeddingResult:
-        """
-        Invoke text embedding model
+        """Invoke text or multimodal embedding generation for the provided inputs."""
+        if not texts and not multimodel_documents:
+            msg = "No texts or files provided"
+            raise ValueError(msg)
 
-        :param model: model name
-        :param credentials: model credentials
-        :param texts: texts to embed
-        :param files: files to embed
-        :param input_type: input type
-        :return: embeddings result
-        """
         try:
             if texts:
                 return self.model_runtime.invoke_text_embedding(
@@ -48,21 +41,16 @@ class TextEmbeddingModel(AIModel):
                     documents=multimodel_documents,
                     input_type=input_type,
                 )
-            raise ValueError("No texts or files provided")
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e
 
     def get_num_tokens(
-        self, model: str, credentials: dict, texts: list[str]
+        self,
+        model: str,
+        credentials: dict,
+        texts: list[str],
     ) -> list[int]:
-        """
-        Get number of tokens for given prompt messages
-
-        :param model: model name
-        :param credentials: model credentials
-        :param texts: texts to embed
-        :return:
-        """
+        """Count tokens for each text input sent to the embedding model."""
         return self.model_runtime.get_text_embedding_num_tokens(
             provider=self.provider,
             model=model,
@@ -71,13 +59,7 @@ class TextEmbeddingModel(AIModel):
         )
 
     def _get_context_size(self, model: str, credentials: dict) -> int:
-        """
-        Get context size for given embedding model
-
-        :param model: model name
-        :param credentials: model credentials
-        :return: context size
-        """
+        """Get the embedding model context size, falling back to the default."""
         model_schema = self.get_model_schema(model, credentials)
 
         if (
@@ -92,13 +74,7 @@ class TextEmbeddingModel(AIModel):
         return 1000
 
     def _get_max_chunks(self, model: str, credentials: dict) -> int:
-        """
-        Get max chunks for given embedding model
-
-        :param model: model name
-        :param credentials: model credentials
-        :return: max chunks
-        """
+        """Get the maximum chunk count supported by the embedding model."""
         model_schema = self.get_model_schema(model, credentials)
 
         if (

--- a/src/graphon/model_runtime/model_providers/base/tokenizers/gpt2_tokenizer.py
+++ b/src/graphon/model_runtime/model_providers/base/tokenizers/gpt2_tokenizer.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from threading import Lock
 from typing import Any
 
@@ -8,14 +9,25 @@ _tokenizer: Any | None = None
 _lock = Lock()
 
 
+def _try_load_tiktoken_encoder() -> Any | None:
+    try:
+        import tiktoken  # noqa: PLC0415
+
+        return tiktoken.get_encoding("gpt2")
+    except Exception:
+        logger.debug(
+            "Failed to initialize tiktoken GPT-2 tokenizer; falling back",
+            exc_info=True,
+        )
+        return None
+
+
 class GPT2Tokenizer:
     @staticmethod
     def _get_num_tokens_by_gpt2(text: str) -> int:
-        """
-        use gpt2 tokenizer to get num tokens
-        """
-        _tokenizer = GPT2Tokenizer.get_encoder()
-        tokens = _tokenizer.encode(text)  # type: ignore
+        """Use gpt2 tokenizer to get num tokens"""
+        tokenizer = GPT2Tokenizer.get_encoder()
+        tokens = tokenizer.encode(text)  # type: ignore
         return len(tokens)
 
     @staticmethod
@@ -30,31 +42,23 @@ class GPT2Tokenizer:
 
     @staticmethod
     def get_encoder():
-        global _tokenizer, _lock
+        global _tokenizer
         if _tokenizer is not None:
             return _tokenizer
         with _lock:
             if _tokenizer is None:
                 # Try to use tiktoken to get the tokenizer because it is faster
                 #
-                try:
-                    import tiktoken
+                _tokenizer = _try_load_tiktoken_encoder()
+                if _tokenizer is None:
+                    import transformers  # noqa: PLC0415
 
-                    _tokenizer = tiktoken.get_encoding("gpt2")
-                except Exception:
-                    from os.path import abspath, dirname, join
-
-                    from transformers import (
-                        GPT2Tokenizer as TransformerGPT2Tokenizer,
-                    )
-
-                    base_path = abspath(__file__)
-                    gpt2_tokenizer_path = join(dirname(base_path), "gpt2")
-                    _tokenizer = TransformerGPT2Tokenizer.from_pretrained(
-                        gpt2_tokenizer_path
+                    gpt2_tokenizer_path = Path(__file__).resolve().parent / "gpt2"
+                    _tokenizer = transformers.GPT2Tokenizer.from_pretrained(
+                        str(gpt2_tokenizer_path),
                     )
                     logger.info(
-                        "Fallback to Transformers' GPT-2 tokenizer from tiktoken"
+                        "Fallback to Transformers' GPT-2 tokenizer from tiktoken",
                     )
 
             return _tokenizer

--- a/src/graphon/model_runtime/model_providers/base/tts_model.py
+++ b/src/graphon/model_runtime/model_providers/base/tts_model.py
@@ -2,15 +2,13 @@ import logging
 from collections.abc import Iterable
 
 from graphon.model_runtime.entities.model_entities import ModelType
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
 
 
 class TTSModel(AIModel):
-    """
-    Model class for TTS model.
-    """
+    """Model class for TTS model."""
 
     model_type: ModelType = ModelType.TTS
 
@@ -21,15 +19,7 @@ class TTSModel(AIModel):
         content_text: str,
         voice: str,
     ) -> Iterable[bytes]:
-        """
-        Invoke large language model
-
-        :param model: model name
-        :param credentials: model credentials
-        :param voice: model timbre
-        :param content_text: text content to be translated
-        :return: translated audio file
-        """
+        """Invoke the TTS model and return an audio byte stream."""
         try:
             return self.model_runtime.invoke_tts(
                 provider=self.provider,
@@ -39,19 +29,15 @@ class TTSModel(AIModel):
                 voice=voice,
             )
         except Exception as e:
-            raise self._transform_invoke_error(e)
+            raise self._transform_invoke_error(e) from e
 
     def get_tts_model_voices(
-        self, model: str, credentials: dict, language: str | None = None
+        self,
+        model: str,
+        credentials: dict,
+        language: str | None = None,
     ):
-        """
-        Retrieves the list of voices supported by a given text-to-speech (TTS) model.
-
-        :param language: The language for which the voices are requested.
-        :param model: The name of the TTS model.
-        :param credentials: The credentials required to access the TTS model.
-        :return: A list of voices supported by the TTS model.
-        """
+        """Retrieve the voices supported by a text-to-speech model."""
         return self.model_runtime.get_tts_model_voices(
             provider=self.provider,
             model=model,

--- a/src/graphon/model_runtime/model_providers/model_provider_factory.py
+++ b/src/graphon/model_runtime/model_providers/model_provider_factory.py
@@ -4,25 +4,24 @@ from collections.abc import Sequence
 
 from graphon.model_runtime.entities.model_entities import AIModelEntity, ModelType
 from graphon.model_runtime.entities.provider_entities import (
-    ProviderConfig,
     ProviderEntity,
     SimpleProviderEntity,
 )
-from graphon.model_runtime.model_providers.__base.ai_model import AIModel
-from graphon.model_runtime.model_providers.__base.large_language_model import (
+from graphon.model_runtime.model_providers.base.ai_model import AIModel
+from graphon.model_runtime.model_providers.base.large_language_model import (
     LargeLanguageModel,
 )
-from graphon.model_runtime.model_providers.__base.moderation_model import (
+from graphon.model_runtime.model_providers.base.moderation_model import (
     ModerationModel,
 )
-from graphon.model_runtime.model_providers.__base.rerank_model import RerankModel
-from graphon.model_runtime.model_providers.__base.speech2text_model import (
+from graphon.model_runtime.model_providers.base.rerank_model import RerankModel
+from graphon.model_runtime.model_providers.base.speech2text_model import (
     Speech2TextModel,
 )
-from graphon.model_runtime.model_providers.__base.text_embedding_model import (
+from graphon.model_runtime.model_providers.base.text_embedding_model import (
     TextEmbeddingModel,
 )
-from graphon.model_runtime.model_providers.__base.tts_model import TTSModel
+from graphon.model_runtime.model_providers.base.tts_model import TTSModel
 from graphon.model_runtime.runtime import ModelRuntime
 from graphon.model_runtime.schema_validators.model_credential_schema_validator import (
     ModelCredentialSchemaValidator,
@@ -32,55 +31,56 @@ from ..schema_validators.provider_credential_schema_validator import (
     ProviderCredentialSchemaValidator,
 )
 
+_MODEL_CLASS_BY_TYPE: dict[ModelType, type[AIModel]] = {
+    ModelType.LLM: LargeLanguageModel,
+    ModelType.TEXT_EMBEDDING: TextEmbeddingModel,
+    ModelType.RERANK: RerankModel,
+    ModelType.SPEECH2TEXT: Speech2TextModel,
+    ModelType.MODERATION: ModerationModel,
+    ModelType.TTS: TTSModel,
+}
+
 
 class ModelProviderFactory:
     """Factory for provider schemas and model-type instances
-    backed by a runtime adapter."""
+    backed by a runtime adapter.
+    """
 
-    def __init__(self, model_runtime: ModelRuntime):
+    def __init__(self, model_runtime: ModelRuntime) -> None:
         if model_runtime is None:
-            raise ValueError("model_runtime is required.")
+            msg = "model_runtime is required."
+            raise ValueError(msg)
         self.model_runtime = model_runtime
 
     def get_providers(self) -> Sequence[ProviderEntity]:
-        """
-        Get all providers.
-        """
+        """Get all providers."""
         return list(self.get_model_providers())
 
     def get_model_providers(self) -> Sequence[ProviderEntity]:
-        """
-        Get all model providers exposed by the runtime adapter.
-        """
+        """Get all model providers exposed by the runtime adapter."""
         return self.model_runtime.fetch_model_providers()
 
     def get_provider_schema(self, provider: str) -> ProviderEntity:
-        """
-        Get provider schema.
-        """
+        """Get provider schema."""
         return self.get_model_provider(provider=provider)
 
     def get_model_provider(self, provider: str) -> ProviderEntity:
-        """
-        Get provider schema.
-        """
+        """Get provider schema."""
         provider_entity = self._resolve_provider(provider)
         if provider_entity is None:
-            raise ValueError(f"Invalid provider: {provider}")
+            msg = f"Invalid provider: {provider}"
+            raise ValueError(msg)
 
         return provider_entity
 
     def provider_credentials_validate(self, *, provider: str, credentials: dict):
-        """
-        Validate provider credentials.
-        """
+        """Validate provider credentials."""
         provider_entity = self.get_model_provider(provider=provider)
 
         provider_credential_schema = provider_entity.provider_credential_schema
         if not provider_credential_schema:
-            raise ValueError(
-                f"Provider {provider} does not have provider_credential_schema"
-            )
+            msg = f"Provider {provider} does not have provider_credential_schema"
+            raise ValueError(msg)
 
         validator = ProviderCredentialSchemaValidator(provider_credential_schema)
         filtered_credentials = validator.validate_and_filter(credentials)
@@ -93,18 +93,20 @@ class ModelProviderFactory:
         return filtered_credentials
 
     def model_credentials_validate(
-        self, *, provider: str, model_type: ModelType, model: str, credentials: dict
+        self,
+        *,
+        provider: str,
+        model_type: ModelType,
+        model: str,
+        credentials: dict,
     ):
-        """
-        Validate model credentials.
-        """
+        """Validate model credentials."""
         provider_entity = self.get_model_provider(provider=provider)
 
         model_credential_schema = provider_entity.model_credential_schema
         if not model_credential_schema:
-            raise ValueError(
-                f"Provider {provider} does not have model_credential_schema"
-            )
+            msg = f"Provider {provider} does not have model_credential_schema"
+            raise ValueError(msg)
 
         validator = ModelCredentialSchemaValidator(model_type, model_credential_schema)
         filtered_credentials = validator.validate_and_filter(credentials)
@@ -126,9 +128,7 @@ class ModelProviderFactory:
         model: str,
         credentials: dict | None,
     ) -> AIModelEntity | None:
-        """
-        Get model schema.
-        """
+        """Get model schema."""
         provider_entity = self.get_model_provider(provider)
         return self.model_runtime.get_model_schema(
             provider=provider_entity.provider,
@@ -142,11 +142,8 @@ class ModelProviderFactory:
         *,
         provider: str | None = None,
         model_type: ModelType | None = None,
-        provider_configs: list[ProviderConfig] | None = None,
     ) -> list[SimpleProviderEntity]:
-        """
-        Get all models for given model type.
-        """
+        """Get all models for given model type."""
         providers = []
         for provider_entity in self.get_model_providers():
             if provider and not self._matches_provider(provider_entity, provider):
@@ -167,47 +164,29 @@ class ModelProviderFactory:
         return providers
 
     def get_model_type_instance(self, provider: str, model_type: ModelType) -> AIModel:
-        """
-        Get model type instance by provider name and model type.
-        """
+        """Get model type instance by provider name and model type."""
         provider_schema = self.get_model_provider(provider)
-
-        if model_type == ModelType.LLM:
-            return LargeLanguageModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-        if model_type == ModelType.TEXT_EMBEDDING:
-            return TextEmbeddingModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-        if model_type == ModelType.RERANK:
-            return RerankModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-        if model_type == ModelType.SPEECH2TEXT:
-            return Speech2TextModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-        if model_type == ModelType.MODERATION:
-            return ModerationModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-        if model_type == ModelType.TTS:
-            return TTSModel(
-                provider_schema=provider_schema, model_runtime=self.model_runtime
-            )
-
-        raise ValueError(f"Unsupported model type: {model_type}")
+        model_class = _MODEL_CLASS_BY_TYPE.get(model_type)
+        if model_class is None:
+            msg = f"Unsupported model type: {model_type}"
+            raise ValueError(msg)
+        return model_class(
+            provider_schema=provider_schema,
+            model_runtime=self.model_runtime,
+        )
 
     def get_provider_icon(
-        self, provider: str, icon_type: str, lang: str
+        self,
+        provider: str,
+        icon_type: str,
+        lang: str,
     ) -> tuple[bytes, str]:
-        """
-        Get provider icon.
-        """
+        """Get provider icon."""
         provider_entity = self.get_model_provider(provider)
         return self.model_runtime.get_provider_icon(
-            provider=provider_entity.provider, icon_type=icon_type, lang=lang
+            provider=provider_entity.provider,
+            icon_type=icon_type,
+            lang=lang,
         )
 
     def _resolve_provider(self, provider: str) -> ProviderEntity | None:
@@ -222,4 +201,4 @@ class ModelProviderFactory:
 
     @staticmethod
     def _matches_provider(provider_entity: ProviderEntity, provider: str) -> bool:
-        return provider in (provider_entity.provider, provider_entity.provider_name)
+        return provider in {provider_entity.provider, provider_entity.provider_name}

--- a/src/graphon/model_runtime/runtime.py
+++ b/src/graphon/model_runtime/runtime.py
@@ -32,11 +32,18 @@ class ModelRuntime(Protocol):
     def fetch_model_providers(self) -> Sequence[ProviderEntity]: ...
 
     def get_provider_icon(
-        self, *, provider: str, icon_type: str, lang: str
+        self,
+        *,
+        provider: str,
+        icon_type: str,
+        lang: str,
     ) -> tuple[bytes, str]: ...
 
     def validate_provider_credentials(
-        self, *, provider: str, credentials: dict[str, Any]
+        self,
+        *,
+        provider: str,
+        credentials: dict[str, Any],
     ) -> None: ...
 
     def validate_model_credentials(

--- a/src/graphon/model_runtime/schema_validators/common_validator.py
+++ b/src/graphon/model_runtime/schema_validators/common_validator.py
@@ -6,8 +6,10 @@ from graphon.model_runtime.entities.provider_entities import (
 
 class CommonValidator:
     def _validate_and_filter_credential_form_schemas(
-        self, credential_form_schemas: list[CredentialFormSchema], credentials: dict
-    ):
+        self,
+        credential_form_schemas: list[CredentialFormSchema],
+        credentials: dict,
+    ) -> dict[str, str | bool]:
         need_validate_credential_form_schema_map = {}
         for credential_form_schema in credential_form_schemas:
             if not credential_form_schema.show_on:
@@ -38,7 +40,8 @@ class CommonValidator:
             # Add the value of the credential_form_schema corresponding to it to
             # validated_credentials
             result = self._validate_credential_form_schema(
-                credential_form_schema, credentials
+                credential_form_schema,
+                credentials,
             )
             if result:
                 validated_credentials[credential_form_schema.variable] = result
@@ -46,15 +49,11 @@ class CommonValidator:
         return validated_credentials
 
     def _validate_credential_form_schema(
-        self, credential_form_schema: CredentialFormSchema, credentials: dict
+        self,
+        credential_form_schema: CredentialFormSchema,
+        credentials: dict,
     ) -> str | bool | None:
-        """
-        Validate credential form schema
-
-        :param credential_form_schema: credential form schema
-        :param credentials: credentials
-        :return: validated credential form schema value
-        """
+        """Validate one credential schema entry and return its normalized value."""
         #  If the variable does not exist in credentials
         value: str | bool | None = None
         if (
@@ -63,9 +62,8 @@ class CommonValidator:
         ):
             # If required is True, an exception is thrown
             if credential_form_schema.required:
-                raise ValueError(
-                    f"Variable {credential_form_schema.variable} is required"
-                )
+                msg = f"Variable {credential_form_schema.variable} is required"
+                raise ValueError(msg)
             # Get the value of default
             if credential_form_schema.default:
                 # If it exists, add it to validated_credentials
@@ -77,37 +75,36 @@ class CommonValidator:
         value = credentials[credential_form_schema.variable]
 
         if not isinstance(value, str):
-            raise ValueError(
-                f"Variable {credential_form_schema.variable} should be string"
-            )
+            msg = f"Variable {credential_form_schema.variable} should be string"
+            raise TypeError(msg)
 
         # If max_length=0, no validation is performed
         if (
             credential_form_schema.max_length
             and len(value) > credential_form_schema.max_length
         ):
-            raise ValueError(
+            msg = (
                 f"Variable {credential_form_schema.variable} length should not be"
                 f" greater than {credential_form_schema.max_length}"
             )
+            raise ValueError(msg)
 
         if (
-            credential_form_schema.type in {FormType.SELECT, FormType.RADIO}
+            credential_form_schema.type in frozenset((FormType.SELECT, FormType.RADIO))
             and credential_form_schema.options
             and value not in [option.value for option in credential_form_schema.options]
         ):
-            raise ValueError(
-                f"Variable {credential_form_schema.variable} is not in options"
-            )
+            msg = f"Variable {credential_form_schema.variable} is not in options"
+            raise ValueError(msg)
 
         if credential_form_schema.type == FormType.SWITCH:
             # If the value is not in ['true', 'false'], an exception is thrown
-            if value.lower() not in {"true", "false"}:
-                raise ValueError(
+            if value.lower() not in frozenset(("true", "false")):
+                msg = (
                     f"Variable {credential_form_schema.variable} should be "
                     "true or false"
                 )
-
+                raise ValueError(msg)
             value = value.lower() == "true"
 
         return value

--- a/src/graphon/model_runtime/schema_validators/model_credential_schema_validator.py
+++ b/src/graphon/model_runtime/schema_validators/model_credential_schema_validator.py
@@ -5,21 +5,18 @@ from graphon.model_runtime.schema_validators.common_validator import CommonValid
 
 class ModelCredentialSchemaValidator(CommonValidator):
     def __init__(
-        self, model_type: ModelType, model_credential_schema: ModelCredentialSchema
-    ):
+        self,
+        model_type: ModelType,
+        model_credential_schema: ModelCredentialSchema,
+    ) -> None:
         self.model_type = model_type
         self.model_credential_schema = model_credential_schema
 
     def validate_and_filter(self, credentials: dict):
-        """
-        Validate model credentials
-
-        :param credentials: model credentials
-        :return: filtered credentials
-        """
-
+        """Validate model credentials and return the filtered credential map."""
         if self.model_credential_schema is None:
-            raise ValueError("Model credential schema is None")
+            msg = "Model credential schema is None"
+            raise ValueError(msg)
 
         # get the credential_form_schemas in provider_credential_schema
         credential_form_schemas = self.model_credential_schema.credential_form_schemas
@@ -27,5 +24,6 @@ class ModelCredentialSchemaValidator(CommonValidator):
         credentials["__model_type"] = self.model_type.value
 
         return self._validate_and_filter_credential_form_schemas(
-            credential_form_schemas, credentials
+            credential_form_schemas,
+            credentials,
         )

--- a/src/graphon/model_runtime/schema_validators/provider_credential_schema_validator.py
+++ b/src/graphon/model_runtime/schema_validators/provider_credential_schema_validator.py
@@ -3,21 +3,17 @@ from graphon.model_runtime.schema_validators.common_validator import CommonValid
 
 
 class ProviderCredentialSchemaValidator(CommonValidator):
-    def __init__(self, provider_credential_schema: ProviderCredentialSchema):
+    def __init__(self, provider_credential_schema: ProviderCredentialSchema) -> None:
         self.provider_credential_schema = provider_credential_schema
 
     def validate_and_filter(self, credentials: dict):
-        """
-        Validate provider credentials
-
-        :param credentials: provider credentials
-        :return: validated provider credentials
-        """
+        """Validate provider credentials and return the filtered credential map."""
         # get the credential_form_schemas in provider_credential_schema
         credential_form_schemas = (
             self.provider_credential_schema.credential_form_schemas
         )
 
         return self._validate_and_filter_credential_form_schemas(
-            credential_form_schemas, credentials
+            credential_form_schemas,
+            credentials,
         )

--- a/src/graphon/model_runtime/slim/config.py
+++ b/src/graphon/model_runtime/slim/config.py
@@ -36,7 +36,8 @@ class SlimConfig:
 
     def __post_init__(self) -> None:
         if not self.bindings:
-            raise ValueError("SlimConfig.bindings must not be empty.")
+            msg = "SlimConfig.bindings must not be empty."
+            raise ValueError(msg)
 
         python_path = self.local.python_path
         if python_path == "python3":

--- a/src/graphon/model_runtime/slim/package_loader.py
+++ b/src/graphon/model_runtime/slim/package_loader.py
@@ -72,13 +72,13 @@ class SlimPackageLoader:
         )
         provider_entity = self._build_provider_entity(
             provider_declaration=provider_declaration,
-            binding=binding,
         )
         if binding.provider and provider_entity.provider != binding.provider:
-            raise ValueError(
+            msg = (
                 "Slim binding provider mismatch: "
                 f"expected {binding.provider}, got {provider_entity.provider}"
             )
+            raise ValueError(msg)
         return LoadedSlimProvider(
             binding=binding,
             plugin_root=plugin_root,
@@ -96,7 +96,10 @@ class SlimPackageLoader:
         return plugin_root
 
     def _download_and_extract_plugin(
-        self, *, plugin_id: str, plugin_root: Path
+        self,
+        *,
+        plugin_id: str,
+        plugin_root: Path,
     ) -> None:
         marketplace_url = self._config.local.marketplace_url
         query = urlencode({"unique_identifier": plugin_id})
@@ -105,10 +108,11 @@ class SlimPackageLoader:
         response = httpx.get(url, timeout=timeout, follow_redirects=True)
         response.raise_for_status()
         if len(response.content) > self._config.marketplace_download_limit_bytes:
-            raise ValueError(
+            msg = (
                 f"Plugin package {plugin_id} exceeds "
                 f"{self._config.marketplace_download_limit_bytes} bytes."
             )
+            raise ValueError(msg)
 
         if plugin_root.exists():
             shutil.rmtree(plugin_root)
@@ -131,9 +135,8 @@ class SlimPackageLoader:
                 target_dir not in resolved_destination.parents
                 and resolved_destination != target_dir
             ):
-                raise ValueError(
-                    f"Unsafe zip entry {member.filename!r} would escape {target_dir}"
-                )
+                msg = f"Unsafe zip entry {member.filename!r} would escape {target_dir}"
+                raise ValueError(msg)
         archive.extractall(target_dir)
 
     def _load_provider_declaration(
@@ -145,13 +148,15 @@ class SlimPackageLoader:
         manifest = self._load_yaml(plugin_root / "manifest.yaml")
         model_provider_paths = manifest.get("plugins", {}).get("models", [])
         if not model_provider_paths:
-            raise ValueError(f"No model provider declarations found in {plugin_root}")
+            msg = f"No model provider declarations found in {plugin_root}"
+            raise ValueError(msg)
 
         if not provider and len(model_provider_paths) > 1:
-            raise ValueError(
+            msg = (
                 "Slim binding provider is required when a plugin declares "
                 "multiple model providers."
             )
+            raise ValueError(msg)
 
         provider_declaration: dict[str, Any] | None = None
         for provider_path in model_provider_paths:
@@ -161,7 +166,8 @@ class SlimPackageLoader:
                 break
 
         if provider_declaration is None:
-            raise ValueError(f"Provider {provider!r} not found in {plugin_root}")
+            msg = f"Provider {provider!r} not found in {plugin_root}"
+            raise ValueError(msg)
 
         models_section = provider_declaration.get("models", {}) or {}
         provider_declaration["models"] = self._load_model_declarations(
@@ -222,7 +228,6 @@ class SlimPackageLoader:
         self,
         *,
         provider_declaration: dict[str, Any],
-        binding: SlimProviderBinding,
     ) -> ProviderEntity:
         supported_model_types = [
             model_type
@@ -240,13 +245,13 @@ class SlimPackageLoader:
             provider_name=str(provider_declaration.get("provider") or ""),
             label=self._convert_i18n(provider_declaration.get("label")),
             description=self._convert_optional_i18n(
-                provider_declaration.get("description")
+                provider_declaration.get("description"),
             ),
             icon_small=self._convert_optional_i18n(
-                provider_declaration.get("icon_small")
+                provider_declaration.get("icon_small"),
             ),
             icon_small_dark=self._convert_optional_i18n(
-                provider_declaration.get("icon_small_dark")
+                provider_declaration.get("icon_small_dark"),
             ),
             background=provider_declaration.get("background"),
             help=self._convert_provider_help(provider_declaration.get("help")),
@@ -258,10 +263,10 @@ class SlimPackageLoader:
                 if (model_entity := self._convert_model_entity(raw_model)) is not None
             ],
             provider_credential_schema=self._convert_provider_credential_schema(
-                provider_declaration.get("provider_credential_schema")
+                provider_declaration.get("provider_credential_schema"),
             ),
             model_credential_schema=self._convert_model_credential_schema(
-                provider_declaration.get("model_credential_schema")
+                provider_declaration.get("model_credential_schema"),
             ),
             position=provider_declaration.get("position") or {},
         )
@@ -303,12 +308,14 @@ class SlimPackageLoader:
     @staticmethod
     def _convert_i18n(value: dict[str, Any] | None) -> I18nObject:
         if value is None:
-            raise ValueError("Missing required i18n object.")
+            msg = "Missing required i18n object."
+            raise ValueError(msg)
         en_us = value.get("en_US") or value.get("en-us") or value.get("en")
         zh_hans = value.get("zh_Hans") or value.get("zh-hans") or value.get("zh_CN")
         if not en_us:
-            raise ValueError(f"Missing en_US translation in {value}")
-        return I18nObject(en_US=str(en_us), zh_Hans=str(zh_hans or en_us))
+            msg = f"Missing en_US translation in {value}"
+            raise ValueError(msg)
+        return I18nObject(en_us=str(en_us), zh_hans=str(zh_hans or en_us))
 
     def _convert_optional_i18n(self, value: dict[str, Any] | None) -> I18nObject | None:
         if value is None:
@@ -316,7 +323,8 @@ class SlimPackageLoader:
         return self._convert_i18n(value)
 
     def _convert_provider_help(
-        self, value: dict[str, Any] | None
+        self,
+        value: dict[str, Any] | None,
     ) -> ProviderHelpEntity | None:
         if value is None:
             return None
@@ -326,7 +334,8 @@ class SlimPackageLoader:
         )
 
     def _convert_provider_credential_schema(
-        self, value: dict[str, Any] | None
+        self,
+        value: dict[str, Any] | None,
     ) -> ProviderCredentialSchema | None:
         if value is None:
             return None
@@ -335,11 +344,12 @@ class SlimPackageLoader:
                 schema
                 for item in value.get("credential_form_schemas", []) or []
                 if (schema := self._convert_credential_form_schema(item)) is not None
-            ]
+            ],
         )
 
     def _convert_model_credential_schema(
-        self, value: dict[str, Any] | None
+        self,
+        value: dict[str, Any] | None,
     ) -> ModelCredentialSchema | None:
         if value is None:
             return None
@@ -347,7 +357,7 @@ class SlimPackageLoader:
             model=FieldModelSchema(
                 label=self._convert_i18n(value.get("model", {}).get("label")),
                 placeholder=self._convert_optional_i18n(
-                    value.get("model", {}).get("placeholder")
+                    value.get("model", {}).get("placeholder"),
                 ),
             ),
             credential_form_schemas=[
@@ -358,7 +368,8 @@ class SlimPackageLoader:
         )
 
     def _convert_credential_form_schema(
-        self, value: dict[str, Any] | None
+        self,
+        value: dict[str, Any] | None,
     ) -> CredentialFormSchema | None:
         if value is None:
             return None
@@ -399,7 +410,8 @@ class SlimPackageLoader:
         )
 
     def _convert_parameter_rule(
-        self, value: dict[str, Any] | None
+        self,
+        value: dict[str, Any] | None,
     ) -> ParameterRule | None:
         if value is None:
             return None

--- a/src/graphon/model_runtime/slim/prepared_llm.py
+++ b/src/graphon/model_runtime/slim/prepared_llm.py
@@ -73,9 +73,8 @@ class SlimPreparedLLM(PreparedLLMProtocol):
             credentials=self._credentials,
         )
         if schema is None:
-            raise ValueError(
-                f"Model schema not found for {self._provider}/{self._model_name}"
-            )
+            msg = f"Model schema not found for {self._provider}/{self._model_name}"
+            raise ValueError(msg)
         return schema
 
     @override

--- a/src/graphon/model_runtime/slim/runtime.py
+++ b/src/graphon/model_runtime/slim/runtime.py
@@ -52,8 +52,8 @@ from graphon.model_runtime.errors.invoke import (
     InvokeConnectionError,
     InvokeServerUnavailableError,
 )
-from graphon.model_runtime.model_providers.__base.large_language_model import (
-    _increase_tool_call,
+from graphon.model_runtime.model_providers.base.large_language_model import (
+    merge_tool_call_deltas,
 )
 from graphon.model_runtime.runtime import ModelRuntime
 from graphon.model_runtime.utils.encoders import jsonable_encoder
@@ -78,6 +78,17 @@ _PROMPT_CONTENT_TYPE_TO_CLASS = {
     PromptMessageContentType.AUDIO.value: AudioPromptMessageContent,
     PromptMessageContentType.VIDEO.value: VideoPromptMessageContent,
     PromptMessageContentType.DOCUMENT.value: DocumentPromptMessageContent,
+}
+
+_I18N_OBJECT_ATTR_BY_LANG = {
+    "en": "en_us",
+    "en-us": "en_us",
+    "en_US": "en_us",
+    "en_us": "en_us",
+    "zh-hans": "zh_hans",
+    "zh_Hans": "zh_hans",
+    "zh_CN": "zh_hans",
+    "zh_cn": "zh_hans",
 }
 
 
@@ -148,27 +159,36 @@ class SlimRuntime(ModelRuntime):
         ]
 
     def get_provider_icon(
-        self, *, provider: str, icon_type: str, lang: str
+        self,
+        *,
+        provider: str,
+        icon_type: str,
+        lang: str,
     ) -> tuple[bytes, str]:
         loaded = self._get_loaded_provider(provider)
         icon_meta = getattr(loaded.provider_entity, icon_type, None)
         if icon_meta is None:
-            raise ValueError(f"Provider {provider} does not expose {icon_type}")
+            msg = f"Provider {provider} does not expose {icon_type}"
+            raise ValueError(msg)
 
-        candidate = getattr(icon_meta, lang, None) or icon_meta.en_US
+        lang_attr = _I18N_OBJECT_ATTR_BY_LANG.get(lang, lang)
+        candidate = getattr(icon_meta, lang_attr, None) or icon_meta.en_us
         if not candidate:
-            raise ValueError(f"Provider {provider} has no icon for language {lang}")
+            msg = f"Provider {provider} has no icon for language {lang}"
+            raise ValueError(msg)
 
         icon_path = loaded.asset_root / candidate
         if not icon_path.exists():
-            raise ValueError(
-                f"Provider icon {candidate} not found under {loaded.asset_root}"
-            )
+            msg = f"Provider icon {candidate} not found under {loaded.asset_root}"
+            raise ValueError(msg)
 
         return icon_path.read_bytes(), icon_path.suffix or ""
 
     def validate_provider_credentials(
-        self, *, provider: str, credentials: dict[str, Any]
+        self,
+        *,
+        provider: str,
+        credentials: dict[str, Any],
     ) -> None:
         loaded = self._get_loaded_provider(provider)
         result = self._invoke_unary_action(
@@ -180,9 +200,8 @@ class SlimRuntime(ModelRuntime):
             },
         )
         if not result.get("result", False):
-            raise InvokeAuthorizationError(
-                "Slim provider credential validation failed."
-            )
+            msg = "Slim provider credential validation failed."
+            raise InvokeAuthorizationError(msg)
 
     def validate_model_credentials(
         self,
@@ -204,7 +223,8 @@ class SlimRuntime(ModelRuntime):
             },
         )
         if not result.get("result", False):
-            raise InvokeAuthorizationError("Slim model credential validation failed.")
+            msg = "Slim model credential validation failed."
+            raise InvokeAuthorizationError(msg)
 
     def get_model_schema(
         self,
@@ -558,7 +578,8 @@ class SlimRuntime(ModelRuntime):
         try:
             return self._providers_by_name[provider]
         except KeyError as exc:
-            raise ValueError(f"Unknown Slim provider: {provider}") from exc
+            msg = f"Unknown Slim provider: {provider}"
+            raise ValueError(msg) from exc
 
     def _invoke_unary_action(
         self,
@@ -582,13 +603,14 @@ class SlimRuntime(ModelRuntime):
             return {}
         if len(chunks) > 1:
             logger.debug(
-                "slim[%s] returned %s chunks for unary action", action, len(chunks)
+                "slim[%s] returned %s chunks for unary action",
+                action,
+                len(chunks),
             )
         payload = chunks[-1]
         if not isinstance(payload, dict):
-            raise ValueError(
-                f"Expected dict payload for action {action}, got {type(payload)}"
-            )
+            msg = f"Expected dict payload for action {action}, got {type(payload)}"
+            raise TypeError(msg)
         return payload
 
     def _invoke_streaming_action(
@@ -664,12 +686,13 @@ class SlimRuntime(ModelRuntime):
                         yield _SlimErrorEvent(
                             code=str(error.get("code", "PLUGIN_EXEC_ERROR")),
                             message=str(
-                                error.get("message", "Slim returned an error event.")
+                                error.get("message", "Slim returned an error event."),
                             ),
                         )
                         break
                     else:
-                        raise ValueError(f"Unknown Slim event type: {event_type}")
+                        msg = f"Unknown Slim event type: {event_type}"
+                        raise ValueError(msg)
             finally:
                 return_code = process.wait()
                 stderr_file.seek(0)
@@ -679,23 +702,26 @@ class SlimRuntime(ModelRuntime):
                         try:
                             stderr_payload = json.loads(stderr_text.splitlines()[-1])
                         except json.JSONDecodeError:
-                            raise ValueError(
-                                f"Slim process exited with code {return_code}: {stderr_text}"
-                            ) from None
+                            msg = (
+                                f"Slim process exited with code {return_code}: "
+                                f"{stderr_text}"
+                            )
+                            raise ValueError(msg) from None
                         raise self._map_slim_error(
                             _SlimErrorEvent(
                                 code=str(
-                                    stderr_payload.get("code", "PLUGIN_EXEC_ERROR")
+                                    stderr_payload.get("code", "PLUGIN_EXEC_ERROR"),
                                 ),
                                 message=str(
                                     stderr_payload.get(
                                         "message",
                                         f"Slim process exited with code {return_code}",
-                                    )
+                                    ),
                                 ),
-                            )
+                            ),
                         )
-                    raise ValueError(f"Slim process exited with code {return_code}")
+                    msg = f"Slim process exited with code {return_code}"
+                    raise ValueError(msg)
 
     def _llm_chunk_generator(
         self,
@@ -709,7 +735,8 @@ class SlimRuntime(ModelRuntime):
                 break
             chunk = event.data
             if not isinstance(chunk, dict):
-                raise ValueError(f"Unexpected LLM chunk payload: {chunk!r}")
+                msg = f"Unexpected LLM chunk payload: {chunk!r}"
+                raise TypeError(msg)
             yield self._parse_llm_chunk(
                 model=model,
                 prompt_messages=prompt_messages,
@@ -739,7 +766,7 @@ class SlimRuntime(ModelRuntime):
                 content_parts.extend(delta_message.content)
 
             if delta_message.tool_calls:
-                _increase_tool_call(delta_message.tool_calls, tool_calls)
+                merge_tool_call_deltas(delta_message.tool_calls, tool_calls)
             if chunk.delta.usage is not None:
                 usage = chunk.delta.usage
             if chunk.delta.finish_reason is not None:

--- a/src/graphon/model_runtime/utils/encoders.py
+++ b/src/graphon/model_runtime/utils/encoders.py
@@ -25,8 +25,10 @@ from pydantic_core import Url
 from pydantic_extra_types.color import Color
 
 
-def _model_dump(
-    model: BaseModel, mode: Literal["json", "python"] = "json", **kwargs: Any
+def model_dump(
+    model: BaseModel,
+    mode: Literal["json", "python"] = "json",
+    **kwargs: Any,
 ) -> Any:
     return model.model_dump(mode=mode, **kwargs)
 
@@ -39,8 +41,7 @@ def isoformat(o: datetime.date | datetime.time) -> str:
 # Taken from Pydantic v1 as is
 # TODO: pv2 should this return strings instead?
 def decimal_encoder(dec_value: Decimal) -> int | float:
-    """
-    Encodes a Decimal as int of there's no exponent, otherwise float
+    """Encodes a Decimal as int of there's no exponent, otherwise float
 
     This is useful when we use ConstrainedDecimal to represent Numeric(x,0)
     where a integer (but not int typed) is used. Encoding this as a float
@@ -52,6 +53,10 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
 
     >>> decimal_encoder(Decimal("1"))
     1
+
+    Returns:
+        An `int` for integral decimals, otherwise a `float`.
+
     """
     if dec_value.as_tuple().exponent >= 0:  # type: ignore[operator]
         return int(dec_value)
@@ -92,7 +97,7 @@ def generate_encoders_by_class_tuples(
     type_encoder_map: dict[Any, Callable[[Any], Any]],
 ) -> dict[Callable[[Any], Any], tuple[Any, ...]]:
     encoders_by_class_tuples: dict[Callable[[Any], Any], tuple[Any, ...]] = defaultdict(
-        tuple
+        tuple,
     )
     for type_, encoder in type_encoder_map.items():
         encoders_by_class_tuples[encoder] += (type_,)
@@ -100,6 +105,158 @@ def generate_encoders_by_class_tuples(
 
 
 encoders_by_class_tuples = generate_encoders_by_class_tuples(ENCODERS_BY_TYPE)
+_ENCODER_UNSET = object()
+
+
+def _encode_with_custom_encoder(
+    obj: Any,
+    custom_encoder: dict[Any, Callable[[Any], Any]],
+) -> Any:
+    if type(obj) in custom_encoder:
+        return custom_encoder[type(obj)](obj)
+    for encoder_type, encoder_instance in custom_encoder.items():
+        if isinstance(obj, encoder_type):
+            return encoder_instance(obj)
+    return _ENCODER_UNSET
+
+
+def _encode_pydantic_model(
+    obj: BaseModel,
+    *,
+    by_alias: bool,
+    exclude_unset: bool,
+    exclude_defaults: bool,
+    exclude_none: bool,
+    excluded_key_prefixes: Sequence[str],
+) -> Any:
+    obj_dict = model_dump(
+        obj,
+        mode="json",
+        include=None,
+        exclude=None,
+        by_alias=by_alias,
+        exclude_unset=exclude_unset,
+        exclude_none=exclude_none,
+        exclude_defaults=exclude_defaults,
+    )
+    if "__root__" in obj_dict:
+        obj_dict = obj_dict["__root__"]
+    return jsonable_encoder(
+        obj_dict,
+        exclude_none=exclude_none,
+        exclude_defaults=exclude_defaults,
+        excluded_key_prefixes=excluded_key_prefixes,
+    )
+
+
+def _encode_dataclass(
+    obj: Any,
+    *,
+    by_alias: bool,
+    exclude_unset: bool,
+    exclude_defaults: bool,
+    exclude_none: bool,
+    custom_encoder: dict[Any, Callable[[Any], Any]],
+    excluded_key_prefixes: Sequence[str],
+) -> Any:
+    obj_dict = dataclasses.asdict(obj)
+    return jsonable_encoder(
+        obj_dict,
+        by_alias=by_alias,
+        exclude_unset=exclude_unset,
+        exclude_defaults=exclude_defaults,
+        exclude_none=exclude_none,
+        custom_encoder=custom_encoder,
+        excluded_key_prefixes=excluded_key_prefixes,
+    )
+
+
+def _encode_mapping(
+    obj: dict[Any, Any],
+    *,
+    by_alias: bool,
+    exclude_unset: bool,
+    exclude_none: bool,
+    custom_encoder: dict[Any, Callable[[Any], Any]],
+    excluded_key_prefixes: Sequence[str],
+) -> dict[Any, Any]:
+    encoded_dict = {}
+    for key, value in obj.items():
+        if isinstance(key, str) and any(
+            key.startswith(prefix) for prefix in excluded_key_prefixes
+        ):
+            continue
+        if value is None and exclude_none:
+            continue
+
+        encoded_key = jsonable_encoder(
+            key,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_none=exclude_none,
+            custom_encoder=custom_encoder,
+            excluded_key_prefixes=excluded_key_prefixes,
+        )
+        encoded_value = jsonable_encoder(
+            value,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_none=exclude_none,
+            custom_encoder=custom_encoder,
+            excluded_key_prefixes=excluded_key_prefixes,
+        )
+        encoded_dict[encoded_key] = encoded_value
+    return encoded_dict
+
+
+def _encode_collection(
+    obj: list[Any]
+    | set[Any]
+    | frozenset[Any]
+    | GeneratorType
+    | tuple[Any, ...]
+    | deque,
+    *,
+    by_alias: bool,
+    exclude_unset: bool,
+    exclude_defaults: bool,
+    exclude_none: bool,
+    custom_encoder: dict[Any, Callable[[Any], Any]],
+    excluded_key_prefixes: Sequence[str],
+) -> list[Any]:
+    return [
+        jsonable_encoder(
+            item,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            custom_encoder=custom_encoder,
+            excluded_key_prefixes=excluded_key_prefixes,
+        )
+        for item in obj
+    ]
+
+
+def _find_type_encoder(obj: Any) -> Callable[[Any], Any] | None:
+    if type(obj) in ENCODERS_BY_TYPE:
+        return ENCODERS_BY_TYPE[type(obj)]
+    for encoder, classes_tuple in encoders_by_class_tuples.items():
+        if isinstance(obj, classes_tuple):
+            return encoder
+    return None
+
+
+def _coerce_mapping_like(obj: Any) -> Any:
+    try:
+        return dict(obj)
+    except (TypeError, ValueError) as dict_error:
+        errors = [dict_error]
+        try:
+            return vars(obj)
+        except TypeError as vars_error:
+            errors.append(vars_error)
+            raise ValueError(str(errors)) from vars_error
 
 
 def jsonable_encoder(
@@ -112,115 +269,68 @@ def jsonable_encoder(
     excluded_key_prefixes: Sequence[str] = (),
 ) -> Any:
     custom_encoder = custom_encoder or {}
-    if custom_encoder:
-        if type(obj) in custom_encoder:
-            return custom_encoder[type(obj)](obj)
-        for encoder_type, encoder_instance in custom_encoder.items():
-            if isinstance(obj, encoder_type):
-                return encoder_instance(obj)
-    if isinstance(obj, BaseModel):
-        obj_dict = _model_dump(
-            obj,
-            mode="json",
-            include=None,
-            exclude=None,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_none=exclude_none,
-            exclude_defaults=exclude_defaults,
-        )
-        if "__root__" in obj_dict:
-            obj_dict = obj_dict["__root__"]
-        return jsonable_encoder(
-            obj_dict,
-            exclude_none=exclude_none,
-            exclude_defaults=exclude_defaults,
-            excluded_key_prefixes=excluded_key_prefixes,
-        )
-    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        # Ensure obj is a dataclass instance, not a dataclass type
-        obj_dict = dataclasses.asdict(obj)
-        return jsonable_encoder(
-            obj_dict,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-            custom_encoder=custom_encoder,
-            excluded_key_prefixes=excluded_key_prefixes,
-        )
-    if isinstance(obj, Enum):
-        return obj.value
-    if isinstance(obj, PurePath):
-        return str(obj)
-    if isinstance(obj, str | int | float | type(None)):
-        return obj
-    if isinstance(obj, Decimal):
-        return format(obj, "f")
-    if isinstance(obj, dict):
-        encoded_dict = {}
-        for key, value in obj.items():
-            if isinstance(key, str) and any(
-                key.startswith(prefix) for prefix in excluded_key_prefixes
-            ):
-                continue
-            if value is None and exclude_none:
-                continue
-
-            encoded_key = jsonable_encoder(
-                key,
-                by_alias=by_alias,
-                exclude_unset=exclude_unset,
-                exclude_none=exclude_none,
-                custom_encoder=custom_encoder,
-                excluded_key_prefixes=excluded_key_prefixes,
-            )
-            encoded_value = jsonable_encoder(
-                value,
-                by_alias=by_alias,
-                exclude_unset=exclude_unset,
-                exclude_none=exclude_none,
-                custom_encoder=custom_encoder,
-                excluded_key_prefixes=excluded_key_prefixes,
-            )
-            encoded_dict[encoded_key] = encoded_value
-        return encoded_dict
-    if isinstance(obj, list | set | frozenset | GeneratorType | tuple | deque):
-        return [
-            jsonable_encoder(
-                item,
-                by_alias=by_alias,
-                exclude_unset=exclude_unset,
-                exclude_defaults=exclude_defaults,
-                exclude_none=exclude_none,
-                custom_encoder=custom_encoder,
-                excluded_key_prefixes=excluded_key_prefixes,
-            )
-            for item in obj
-        ]
-
-    if type(obj) in ENCODERS_BY_TYPE:
-        return ENCODERS_BY_TYPE[type(obj)](obj)
-    for encoder, classes_tuple in encoders_by_class_tuples.items():
-        if isinstance(obj, classes_tuple):
-            return encoder(obj)
-
-    try:
-        data = dict(obj)  # type: ignore
-    except Exception as e:
-        errors: list[Exception] = []
-        errors.append(e)
-        try:
-            data = vars(obj)  # type: ignore
-        except Exception as e:
-            errors.append(e)
-            raise ValueError(str(errors)) from e
-    return jsonable_encoder(
-        data,
-        by_alias=by_alias,
-        exclude_unset=exclude_unset,
-        exclude_defaults=exclude_defaults,
-        exclude_none=exclude_none,
-        custom_encoder=custom_encoder,
-        excluded_key_prefixes=excluded_key_prefixes,
-    )
+    result = _encode_with_custom_encoder(obj, custom_encoder)
+    if result is _ENCODER_UNSET:
+        match obj:
+            case BaseModel():
+                result = _encode_pydantic_model(
+                    obj,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    excluded_key_prefixes=excluded_key_prefixes,
+                )
+            case _ if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+                result = _encode_dataclass(
+                    obj,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    excluded_key_prefixes=excluded_key_prefixes,
+                )
+            case Enum():
+                result = obj.value
+            case PurePath():
+                result = str(obj)
+            case None | bool() | str() | int() | float():
+                result = obj
+            case Decimal():
+                result = format(obj, "f")
+            case dict():
+                result = _encode_mapping(
+                    obj,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    excluded_key_prefixes=excluded_key_prefixes,
+                )
+            case list() | set() | frozenset() | GeneratorType() | tuple() | deque():
+                result = _encode_collection(
+                    obj,
+                    by_alias=by_alias,
+                    exclude_unset=exclude_unset,
+                    exclude_defaults=exclude_defaults,
+                    exclude_none=exclude_none,
+                    custom_encoder=custom_encoder,
+                    excluded_key_prefixes=excluded_key_prefixes,
+                )
+            case _:
+                type_encoder = _find_type_encoder(obj)
+                if type_encoder is not None:
+                    result = type_encoder(obj)
+                else:
+                    data = _coerce_mapping_like(obj)
+                    result = jsonable_encoder(
+                        data,
+                        by_alias=by_alias,
+                        exclude_unset=exclude_unset,
+                        exclude_defaults=exclude_defaults,
+                        exclude_none=exclude_none,
+                        custom_encoder=custom_encoder,
+                        excluded_key_prefixes=excluded_key_prefixes,
+                    )
+    return result

--- a/src/graphon/node_events/base.py
+++ b/src/graphon/node_events/base.py
@@ -11,15 +11,13 @@ class NodeEventBase(BaseModel):
     """Base class for all node events"""
 
 
-def _default_metadata():
+def _default_metadata() -> Mapping[WorkflowNodeExecutionMetadataKey, Any]:
     v: Mapping[WorkflowNodeExecutionMetadataKey, Any] = {}
     return v
 
 
 class NodeRunResult(BaseModel):
-    """
-    Node Run Result.
-    """
+    """Node Run Result."""
 
     status: WorkflowNodeExecutionStatus = WorkflowNodeExecutionStatus.PENDING
 
@@ -27,7 +25,7 @@ class NodeRunResult(BaseModel):
     process_data: Mapping[str, Any] = Field(default_factory=dict)
     outputs: Mapping[str, Any] = Field(default_factory=dict)
     metadata: Mapping[WorkflowNodeExecutionMetadataKey, Any] = Field(
-        default_factory=_default_metadata
+        default_factory=_default_metadata,
     )
     llm_usage: LLMUsage = Field(default_factory=LLMUsage.empty_usage)
 

--- a/src/graphon/node_events/node.py
+++ b/src/graphon/node_events/node.py
@@ -15,7 +15,8 @@ from .base import NodeEventBase
 
 class RunRetrieverResourceEvent(NodeEventBase):
     retriever_resources: Sequence[Mapping[str, Any]] = Field(
-        ..., description="retriever resources"
+        ...,
+        description="retriever resources",
     )
     context: str = Field(..., description="context")
     context_files: list[File] | None = Field(default=None, description="context files")
@@ -45,7 +46,8 @@ class StreamChunkEvent(NodeEventBase):
     )
     chunk: str = Field(..., description="the actual chunk content")
     is_final: bool = Field(
-        default=False, description="indicates if this is the last chunk"
+        default=False,
+        description="indicates if this is the last chunk",
     )
 
 

--- a/src/graphon/nodes/answer/answer_node.py
+++ b/src/graphon/nodes/answer/answer_node.py
@@ -6,6 +6,7 @@ from graphon.enums import (
     NodeExecutionType,
     WorkflowNodeExecutionStatus,
 )
+from graphon.file.models import File
 from graphon.node_events.base import NodeRunResult
 from graphon.nodes.answer.entities import AnswerNodeData
 from graphon.nodes.base.node import Node
@@ -30,7 +31,7 @@ class AnswerNode(Node[AnswerNodeData]):
     @override
     def _run(self) -> NodeRunResult:
         segments = self.graph_runtime_state.variable_pool.convert_template(
-            self.node_data.answer
+            self.node_data.answer,
         )
         files = self._extract_files_from_segments(segments.value)
         return NodeRunResult(
@@ -41,12 +42,16 @@ class AnswerNode(Node[AnswerNodeData]):
             },
         )
 
-    def _extract_files_from_segments(self, segments: Sequence[Segment]):
+    def _extract_files_from_segments(self, segments: Sequence[Segment]) -> list[File]:
         """Extract all files from segments containing FileSegment or
         ArrayFileSegment instances.
 
         FileSegment contains a single file, while ArrayFileSegment contains
         multiple files. This method flattens all files into a single list.
+
+        Returns:
+            A flat list of `File` objects extracted from the segments.
+
         """
         files = []
         for segment in segments:
@@ -80,10 +85,10 @@ class AnswerNode(Node[AnswerNodeData]):
         return variable_mapping
 
     def get_streaming_template(self) -> Template:
-        """
-        Get the template for streaming.
+        """Get the template for streaming.
 
         Returns:
             Template instance for this Answer node
+
         """
         return Template.from_answer_template(self.node_data.answer)

--- a/src/graphon/nodes/answer/entities.py
+++ b/src/graphon/nodes/answer/entities.py
@@ -8,20 +8,18 @@ from graphon.enums import BuiltinNodeTypes, NodeType
 
 
 class AnswerNodeData(BaseNodeData):
-    """
-    Answer Node Data.
-    """
+    """Answer Node Data."""
 
     type: NodeType = BuiltinNodeTypes.ANSWER
     answer: str = Field(..., description="answer template string")
 
 
 class GenerateRouteChunk(BaseModel):
-    """
-    Generate Route Chunk.
-    """
+    """Generate Route Chunk."""
 
     class ChunkType(StrEnum):
+        """Kinds of generate-route chunks."""
+
         VAR = auto()
         TEXT = auto()
 
@@ -29,9 +27,7 @@ class GenerateRouteChunk(BaseModel):
 
 
 class VarGenerateRouteChunk(GenerateRouteChunk):
-    """
-    Var Generate Route Chunk.
-    """
+    """Var Generate Route Chunk."""
 
     type: GenerateRouteChunk.ChunkType = GenerateRouteChunk.ChunkType.VAR
     """generate route chunk type"""
@@ -39,9 +35,7 @@ class VarGenerateRouteChunk(GenerateRouteChunk):
 
 
 class TextGenerateRouteChunk(GenerateRouteChunk):
-    """
-    Text Generate Route Chunk.
-    """
+    """Text Generate Route Chunk."""
 
     type: GenerateRouteChunk.ChunkType = GenerateRouteChunk.ChunkType.TEXT
     """generate route chunk type"""
@@ -55,9 +49,7 @@ class AnswerNodeDoubleLink(BaseModel):
 
 
 class AnswerStreamGenerateRoute(BaseModel):
-    """
-    AnswerStreamGenerateRoute entity
-    """
+    """AnswerStreamGenerateRoute entity"""
 
     answer_dependencies: dict[str, list[str]] = Field(
         ...,

--- a/src/graphon/nodes/base/entities.py
+++ b/src/graphon/nodes/base/entities.py
@@ -10,9 +10,7 @@ from graphon.entities.base_node_data import BaseNodeData
 
 
 class VariableSelector(BaseModel):
-    """
-    Variable Selector.
-    """
+    """Variable Selector."""
 
     variable: str
     value_selector: Sequence[str]
@@ -37,9 +35,7 @@ class OutputVariableType(StrEnum):
 
 
 class OutputVariableEntity(BaseModel):
-    """
-    Output Variable Entity.
-    """
+    """Output Variable Entity."""
 
     variable: str
     value_type: OutputVariableType = OutputVariableType.ANY
@@ -48,10 +44,7 @@ class OutputVariableEntity(BaseModel):
     @field_validator("value_type", mode="before")
     @classmethod
     def normalize_value_type(cls, v: Any) -> Any:
-        """
-        Normalize value_type to handle case-insensitive array types.
-        Converts 'Array[...]' to 'array[...]' for backward compatibility.
-        """
+        """Normalize `Array[...]` literals to lowercase for backward compatibility."""
         if isinstance(v, str) and v.startswith("Array["):
             return v.lower()
         return v
@@ -67,7 +60,7 @@ class BaseIterationState(BaseModel):
     inputs: dict
 
     class MetaData(BaseModel):
-        pass
+        """Metadata associated with an iteration state."""
 
     metadata: MetaData
 
@@ -82,6 +75,6 @@ class BaseLoopState(BaseModel):
     inputs: dict
 
     class MetaData(BaseModel):
-        pass
+        """Metadata associated with a loop state."""
 
     metadata: MetaData

--- a/src/graphon/nodes/base/node.py
+++ b/src/graphon/nodes/base/node.py
@@ -78,7 +78,253 @@ _MISSING_RUN_CONTEXT_VALUE = object()
 logger = logging.getLogger(__name__)
 
 
-class Node[NodeDataT: BaseNodeData]:
+class _NodeRegistryMixin[NodeDataT: BaseNodeData]:
+    """Node registry and config helpers kept separate from execution flow."""
+
+    @classmethod
+    def get_registry_version(cls) -> int:
+        return cls._registry_version
+
+    @classmethod
+    def extract_variable_selector_to_variable_mapping(
+        cls,
+        *,
+        graph_config: Mapping[str, Any],
+        config: NodeConfigDict,
+    ) -> Mapping[str, Sequence[str]]:
+        """Extracts references variable selectors from node configuration.
+
+        The `config` parameter represents the configuration for a specific node
+        type and corresponds to the `data` field in the node definition object.
+
+        The returned mapping has the following structure:
+
+            {'1747829548239.#1747829667553.result#': ['1747829667553', 'result']}
+
+        For loop and iteration nodes, the mapping may look like this:
+
+            {
+                "1748332301644.input_selector": ["1748332363630", "result"],
+                "1748332325079.1748332325079.#sys.workflow_id#": ["sys", "workflow_id"],
+            }
+
+        where `1748332301644` is the ID of the loop / iteration node,
+        and `1748332325079` is the ID of the node inside the loop or iteration node.
+
+        Here, the key consists of two parts: the current node ID (provided as the
+        `node_id` parameter to `_extract_variable_selector_to_variable_mapping`)
+        and the variable selector,
+        enclosed in `#` symbols. These two parts are separated by a dot (`.`).
+
+        The value is a list of string representing the variable selector, where the
+        first element is the node ID of the referenced variable, and the second
+        element is the variable name within that node.
+
+        The meaning of the above response is:
+
+        The node with ID `1747829548239` references the variable `result` from the
+        node with ID `1747829667553`. For example, if `1747829548239` is a LLM
+        node, its prompt may contain a reference to the `result` output variable
+        of node `1747829667553`.
+
+        :param graph_config: graph config
+        :param config: node config
+
+        Returns:
+            A mapping from node-local reference keys to concrete variable selectors.
+
+        """
+        node_id = config["id"]
+        node_data = cls.validate_node_data(config["data"])
+        return cls._extract_variable_selector_to_variable_mapping(
+            graph_config=graph_config,
+            node_id=node_id,
+            node_data=node_data,
+        )
+
+    @classmethod
+    def get_default_config(
+        cls,
+        filters: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        _ = filters
+        return {}
+
+    @classmethod
+    def get_node_type_classes_mapping(
+        cls,
+    ) -> Mapping[NodeType, Mapping[str, type[Node]]]:
+        """Return a read-only view of the currently registered node classes.
+
+        This accessor intentionally performs no imports. The embedding layer that
+        owns bootstrap (for example `core.workflow.node_factory`) must import any
+        extension node packages before calling it so their subclasses register via
+        `__init_subclass__`.
+
+        Returns:
+            A read-only mapping of node types to versioned node classes.
+
+        """
+        return {
+            node_type: MappingProxyType(version_map)
+            for node_type, version_map in cls._registry.items()
+        }
+
+
+class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
+    """Typed node-data hydration helpers."""
+
+    @classmethod
+    def validate_node_data(
+        cls,
+        node_data: BaseNodeData | Mapping[str, Any],
+    ) -> NodeDataT:
+        """Validate shared graph node payloads against the subclass-declared
+        NodeData model.
+
+        Re-validate from a dumped payload instead of `from_attributes=True` so
+        compatibility extras stored on `BaseNodeData` survive the handoff to the
+        concrete node data model. Human Input delivery methods are one such extra
+        field until graphon owns that schema.
+
+        Returns:
+            The validated node data instance for the concrete node subclass.
+
+        """
+        if isinstance(node_data, BaseNodeData):
+            payload = node_data.model_dump(mode="python")
+        else:
+            payload = dict(node_data)
+        return cast("NodeDataT", cls._node_data_type.model_validate(payload))
+
+    def init_node_data(self, data: BaseNodeData | Mapping[str, Any]) -> None:
+        """Hydrate `_node_data` for legacy callers that bypass `__init__`."""
+        self._node_data = self.validate_node_data(cast("BaseNodeData", data))
+
+    @property
+    def retry(self) -> bool:
+        return False
+
+    def _get_error_strategy(self) -> ErrorStrategy | None:
+        """Get the error strategy for this node."""
+        return self._node_data.error_strategy
+
+    def _get_retry_config(self) -> RetryConfig:
+        """Get the retry configuration for this node."""
+        return self._node_data.retry_config
+
+    def _get_title(self) -> str:
+        """Get the node title."""
+        return self._node_data.title
+
+    def _get_description(self) -> str | None:
+        """Get the node description."""
+        return self._node_data.desc
+
+    def _get_default_value_dict(self) -> dict[str, Any]:
+        """Get the default values dictionary for this node."""
+        return self._node_data.default_value_dict
+
+    @property
+    def error_strategy(self) -> ErrorStrategy | None:
+        """Get the error strategy for this node."""
+        return self._get_error_strategy()
+
+    @property
+    def retry_config(self) -> RetryConfig:
+        """Get the retry configuration for this node."""
+        return self._get_retry_config()
+
+    @property
+    def title(self) -> str:
+        """Get the node title."""
+        return self._get_title()
+
+    @property
+    def description(self) -> str | None:
+        """Get the node description."""
+        return self._get_description()
+
+    @property
+    def default_value_dict(self) -> dict[str, Any]:
+        """Get the default values dictionary for this node."""
+        return self._get_default_value_dict()
+
+    @property
+    def node_data(self) -> NodeDataT:
+        """Typed access to this node's configuration data."""
+        return self._node_data
+
+
+class _NodeRuntimeMixin[NodeDataT: BaseNodeData]:
+    """Run-context and execution-lifecycle accessors."""
+
+    def post_init(self) -> None:
+        """Optional hook for subclasses requiring extra initialization."""
+        return
+
+    @property
+    def graph_init_params(self) -> GraphInitParams:
+        return self._graph_init_params
+
+    @property
+    def run_context(self) -> Mapping[str, Any]:
+        return self._run_context
+
+    def get_run_context_value(self, key: str, default: Any = None) -> Any:
+        return self._run_context.get(key, default)
+
+    def require_run_context_value(self, key: str) -> Any:
+        value = self.get_run_context_value(key, _MISSING_RUN_CONTEXT_VALUE)
+        if value is _MISSING_RUN_CONTEXT_VALUE:
+            msg = f"run_context missing required key: {key}"
+            raise ValueError(msg)
+        return value
+
+    @property
+    def execution_id(self) -> str:
+        return self._node_execution_id
+
+    def ensure_execution_id(self) -> str:
+        if self._node_execution_id:
+            return self._node_execution_id
+
+        resumed_execution_id = self._restore_execution_id_from_runtime_state()
+        if resumed_execution_id:
+            self._node_execution_id = resumed_execution_id
+            return self._node_execution_id
+
+        self._node_execution_id = str(uuid4())
+        return self._node_execution_id
+
+    def populate_start_event(self, event: NodeRunStartedEvent) -> None:
+        """Allow subclasses to enrich the started event without cross-node imports
+        in the base class.
+        """
+        _ = event
+
+    def blocks_variable_output(self, variable_selectors: set[tuple[str, ...]]) -> bool:
+        """Check if this node blocks the output of specific variables.
+
+        This method is used to determine if a node must complete execution before
+        the specified variables can be used in streaming output.
+
+        :param variable_selectors: Set of variable selectors, each as a tuple
+        (e.g., ('conversation', 'str'))
+
+        Returns:
+            `True` if this node blocks any requested selector, otherwise `False`.
+
+        """
+        _ = variable_selectors
+        return False
+
+
+class Node[NodeDataT: BaseNodeData](
+    _NodeRegistryMixin[NodeDataT],
+    _NodeDataModelMixin[NodeDataT],
+    _NodeRuntimeMixin[NodeDataT],
+):
     """BaseNode serves as the foundational class for all node implementations.
 
     Nodes are allowed to maintain transient states
@@ -94,8 +340,7 @@ class Node[NodeDataT: BaseNodeData]:
     _node_data_type: ClassVar[type[BaseNodeData]] = BaseNodeData
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """
-        Automatically extract and validate the node data type from the generic
+        """Automatically extract and validate the node data type from the generic
         parameter.
 
         When a subclass is defined as `class MyNode(Node[MyNodeData])`, this method:
@@ -156,6 +401,11 @@ class Node[NodeDataT: BaseNodeData]:
             class CodeNode(Node[CodeNodeData]):  # CodeNodeData is auto-extracted
                 node_type = BuiltinNodeTypes.CODE
                 # No need to implement _get_title, _get_error_strategy, etc.
+
+        Raises:
+            TypeError: If the subclass does not parameterize `Node` with a valid
+                `BaseNodeData` subtype.
+
         """
         super().__init_subclass__(**kwargs)
 
@@ -165,9 +415,10 @@ class Node[NodeDataT: BaseNodeData]:
         node_data_type = cls._extract_node_data_type_from_generic()
 
         if node_data_type is None:
-            raise TypeError(
+            msg = (
                 f"{cls.__name__} must inherit from Node[T] with a BaseNodeData subtype"
             )
+            raise TypeError(msg)
 
         cls._node_data_type = node_data_type
 
@@ -203,8 +454,7 @@ class Node[NodeDataT: BaseNodeData]:
 
     @classmethod
     def _extract_node_data_type_from_generic(cls) -> type[BaseNodeData] | None:
-        """
-        Extract the node data type from the generic parameter `Node[T]`.
+        """Extract the node data type from the generic parameter `Node[T]`.
 
         Inspects `__orig_bases__` to find the `Node[T]` parameterization and
         extracts `T`.
@@ -215,6 +465,7 @@ class Node[NodeDataT: BaseNodeData]:
         Raises:
             TypeError: If the generic argument is invalid (not exactly one argument,
                       or not a BaseNodeData subtype).
+
         """
         # __orig_bases__ contains the original generic bases before type erasure.
         # For `class CodeNode(Node[CodeNodeData])`, this would be
@@ -223,22 +474,25 @@ class Node[NodeDataT: BaseNodeData]:
             origin = get_origin(base)  # Returns `Node` for `Node[CodeNodeData]`
             if origin is Node:
                 args = get_args(
-                    base
+                    base,
                 )  # Returns `(CodeNodeData,)` for `Node[CodeNodeData]`
                 if len(args) != 1:
-                    raise TypeError(
+                    msg = (
                         f"{cls.__name__} must specify exactly one node data "
                         f"generic argument"
                     )
+                    raise TypeError(msg)
 
                 candidate = args[0]
                 if not isinstance(candidate, type) or not issubclass(
-                    candidate, BaseNodeData
+                    candidate,
+                    BaseNodeData,
                 ):
-                    raise TypeError(
+                    msg = (
                         f"{cls.__name__} must parameterize Node with a "
                         f"BaseNodeData subtype"
                     )
+                    raise TypeError(msg)
 
                 return candidate
 
@@ -248,94 +502,37 @@ class Node[NodeDataT: BaseNodeData]:
     _registry: ClassVar[dict[NodeType, dict[str, type[Node]]]] = {}
     _registry_version: ClassVar[int] = 0
 
-    @classmethod
-    def get_registry_version(cls) -> int:
-        return cls._registry_version
-
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
         self._graph_init_params = graph_init_params
         self._run_context = MappingProxyType(dict(graph_init_params.run_context))
-        self.id = id
+        self.id = node_id
         self.workflow_id = graph_init_params.workflow_id
         self.graph_config = graph_init_params.graph_config
         self.workflow_call_depth = graph_init_params.call_depth
         self.graph_runtime_state = graph_runtime_state
         self.state: NodeState = NodeState.UNKNOWN  # node execution state
 
-        node_id = config["id"]
+        config_node_id = config["id"]
+        if node_id != config_node_id:
+            msg = (
+                "node_id must match config['id'], "
+                f"got node_id={node_id!r}, config['id']={config_node_id!r}"
+            )
+            raise ValueError(msg)
 
-        self._node_id = node_id
+        self._node_id = config_node_id
         self._node_execution_id: str = ""
         self._start_at = datetime.now(UTC).replace(tzinfo=None)
 
         self._node_data = self.validate_node_data(config["data"])
 
         self.post_init()
-
-    @classmethod
-    def validate_node_data(
-        cls, node_data: BaseNodeData | Mapping[str, Any]
-    ) -> NodeDataT:
-        """Validate shared graph node payloads against the subclass-declared
-        NodeData model.
-
-        Re-validate from a dumped payload instead of `from_attributes=True` so
-        compatibility extras stored on `BaseNodeData` survive the handoff to the
-        concrete node data model. Human Input delivery methods are one such extra
-        field until graphon owns that schema.
-        """
-        if isinstance(node_data, BaseNodeData):
-            payload = node_data.model_dump(mode="python")
-        else:
-            payload = dict(node_data)
-        return cast("NodeDataT", cls._node_data_type.model_validate(payload))
-
-    def init_node_data(self, data: BaseNodeData | Mapping[str, Any]) -> None:
-        """Hydrate `_node_data` for legacy callers that bypass `__init__`."""
-        self._node_data = self.validate_node_data(data)
-
-    def post_init(self) -> None:
-        """Optional hook for subclasses requiring extra initialization."""
-        return
-
-    @property
-    def graph_init_params(self) -> GraphInitParams:
-        return self._graph_init_params
-
-    @property
-    def run_context(self) -> Mapping[str, Any]:
-        return self._run_context
-
-    def get_run_context_value(self, key: str, default: Any = None) -> Any:
-        return self._run_context.get(key, default)
-
-    def require_run_context_value(self, key: str) -> Any:
-        value = self.get_run_context_value(key, _MISSING_RUN_CONTEXT_VALUE)
-        if value is _MISSING_RUN_CONTEXT_VALUE:
-            raise ValueError(f"run_context missing required key: {key}")
-        return value
-
-    @property
-    def execution_id(self) -> str:
-        return self._node_execution_id
-
-    def ensure_execution_id(self) -> str:
-        if self._node_execution_id:
-            return self._node_execution_id
-
-        resumed_execution_id = self._restore_execution_id_from_runtime_state()
-        if resumed_execution_id:
-            self._node_execution_id = resumed_execution_id
-            return self._node_execution_id
-
-        self._node_execution_id = str(uuid4())
-        return self._node_execution_id
 
     def _restore_execution_id_from_runtime_state(self) -> str | None:
         graph_execution = self.graph_runtime_state.graph_execution
@@ -355,16 +552,8 @@ class Node[NodeDataT: BaseNodeData]:
 
     @abstractmethod
     def _run(self) -> NodeRunResult | Generator[NodeEventBase, None, None]:
-        """
-        Run node
-        :return:
-        """
+        """Run the node and return either a result object or an event stream."""
         raise NotImplementedError
-
-    def populate_start_event(self, event: NodeRunStartedEvent) -> None:
-        """Allow subclasses to enrich the started event without cross-node imports
-        in the base class."""
-        _ = event
 
     def run(self) -> Generator[GraphNodeEventBase, None, None]:
         execution_id = self.ensure_execution_id()
@@ -474,16 +663,18 @@ class Node[NodeDataT: BaseNodeData]:
 
         :param graph_config: graph config
         :param config: node config
-        :return:
+
+        Returns:
+            A mapping from node-local reference keys to concrete variable selectors.
+
         """
         node_id = config["id"]
         node_data = cls.validate_node_data(config["data"])
-        data = cls._extract_variable_selector_to_variable_mapping(
+        return cls._extract_variable_selector_to_variable_mapping(
             graph_config=graph_config,
             node_id=node_id,
             node_data=node_data,
         )
-        return data
 
     @classmethod
     def _extract_variable_selector_to_variable_mapping(
@@ -493,26 +684,9 @@ class Node[NodeDataT: BaseNodeData]:
         node_id: str,
         node_data: NodeDataT,
     ) -> Mapping[str, Sequence[str]]:
-        return {}
-
-    def blocks_variable_output(self, variable_selectors: set[tuple[str, ...]]) -> bool:
-        """
-        Check if this node blocks the output of specific variables.
-
-        This method is used to determine if a node must complete execution before
-        the specified variables can be used in streaming output.
-
-        :param variable_selectors: Set of variable selectors, each as a tuple
-        (e.g., ('conversation', 'str'))
-        :return: True if this node blocks output of any of the specified
-        variables, False otherwise
-        """
-        return False
-
-    @classmethod
-    def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
-    ) -> Mapping[str, object]:
+        _ = graph_config
+        _ = node_id
+        _ = node_data
         return {}
 
     @classmethod
@@ -521,83 +695,12 @@ class Node[NodeDataT: BaseNodeData]:
         """`node_version` returns the version of current node type."""
         # NOTE(QuantumGhost): Node versions must remain unique per `NodeType` so
         # registry lookups can resolve numeric versions and `latest`.
-        raise NotImplementedError(
-            "subclasses of BaseNode must implement `version` method."
-        )
-
-    @classmethod
-    def get_node_type_classes_mapping(
-        cls,
-    ) -> Mapping[NodeType, Mapping[str, type[Node]]]:
-        """Return a read-only view of the currently registered node classes.
-
-        This accessor intentionally performs no imports. The embedding layer that
-        owns bootstrap (for example `core.workflow.node_factory`) must import any
-        extension node packages before calling it so their subclasses register via
-        `__init_subclass__`.
-        """
-        return {
-            node_type: MappingProxyType(version_map)
-            for node_type, version_map in cls._registry.items()
-        }
-
-    @property
-    def retry(self) -> bool:
-        return False
-
-    def _get_error_strategy(self) -> ErrorStrategy | None:
-        """Get the error strategy for this node."""
-        return self._node_data.error_strategy
-
-    def _get_retry_config(self) -> RetryConfig:
-        """Get the retry configuration for this node."""
-        return self._node_data.retry_config
-
-    def _get_title(self) -> str:
-        """Get the node title."""
-        return self._node_data.title
-
-    def _get_description(self) -> str | None:
-        """Get the node description."""
-        return self._node_data.desc
-
-    def _get_default_value_dict(self) -> dict[str, Any]:
-        """Get the default values dictionary for this node."""
-        return self._node_data.default_value_dict
-
-    # Public interface properties that delegate to abstract methods
-    @property
-    def error_strategy(self) -> ErrorStrategy | None:
-        """Get the error strategy for this node."""
-        return self._get_error_strategy()
-
-    @property
-    def retry_config(self) -> RetryConfig:
-        """Get the retry configuration for this node."""
-        return self._get_retry_config()
-
-    @property
-    def title(self) -> str:
-        """Get the node title."""
-        return self._get_title()
-
-    @property
-    def description(self) -> str | None:
-        """Get the node description."""
-        return self._get_description()
-
-    @property
-    def default_value_dict(self) -> dict[str, Any]:
-        """Get the default values dictionary for this node."""
-        return self._get_default_value_dict()
-
-    @property
-    def node_data(self) -> NodeDataT:
-        """Typed access to this node's configuration data."""
-        return self._node_data
+        msg = "subclasses of BaseNode must implement `version` method."
+        raise NotImplementedError(msg)
 
     def _convert_node_run_result_to_graph_node_event(
-        self, result: NodeRunResult
+        self,
+        result: NodeRunResult,
     ) -> GraphNodeEventBase:
         finished_at = datetime.now(UTC).replace(tzinfo=None)
         match result.status:
@@ -621,13 +724,13 @@ class Node[NodeDataT: BaseNodeData]:
                     node_run_result=result,
                 )
             case _:
-                raise Exception(f"result status {result.status} not supported")
+                msg = f"result status {result.status} not supported"
+                raise ValueError(msg)
 
     @singledispatchmethod
     def _dispatch(self, event: NodeEventBase) -> GraphNodeEventBase:
-        raise NotImplementedError(
-            f"Node {self._node_id} does not support event type {type(event)}"
-        )
+        msg = f"Node {self._node_id} does not support event type {type(event)}"
+        raise NotImplementedError(msg)
 
     @_dispatch.register
     def _(self, event: StreamChunkEvent) -> NodeRunStreamChunkEvent:
@@ -642,7 +745,8 @@ class Node[NodeDataT: BaseNodeData]:
 
     @_dispatch.register
     def _(
-        self, event: StreamCompletedEvent
+        self,
+        event: StreamCompletedEvent,
     ) -> NodeRunSucceededEvent | NodeRunFailedEvent:
         finished_at = datetime.now(UTC).replace(tzinfo=None)
         match event.node_run_result.status:
@@ -666,10 +770,11 @@ class Node[NodeDataT: BaseNodeData]:
                     error=event.node_run_result.error,
                 )
             case _:
-                raise NotImplementedError(
+                msg = (
                     f"Node {self._node_id} does not support status "
                     f"{event.node_run_result.status}"
                 )
+                raise NotImplementedError(msg)
 
     @_dispatch.register
     def _(self, event: VariableUpdatedEvent) -> NodeRunVariableUpdatedEvent:
@@ -707,7 +812,7 @@ class Node[NodeDataT: BaseNodeData]:
         )
 
     @_dispatch.register
-    def _(self, event: HumanInputFormFilledEvent):
+    def _(self, event: HumanInputFormFilledEvent) -> NodeRunHumanInputFormFilledEvent:
         return NodeRunHumanInputFormFilledEvent(
             id=self.execution_id,
             node_id=self._node_id,
@@ -719,7 +824,7 @@ class Node[NodeDataT: BaseNodeData]:
         )
 
     @_dispatch.register
-    def _(self, event: HumanInputFormTimeoutEvent):
+    def _(self, event: HumanInputFormTimeoutEvent) -> NodeRunHumanInputFormTimeoutEvent:
         return NodeRunHumanInputFormTimeoutEvent(
             id=self.execution_id,
             node_id=self._node_id,

--- a/src/graphon/nodes/base/template.py
+++ b/src/graphon/nodes/base/template.py
@@ -6,6 +6,7 @@ similar to SegmentGroup but focused on template representation without values.
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -71,6 +72,7 @@ class Template:
 
         Returns:
             Template instance
+
         """
         parser = VariableTemplateParser(template_str)
         segments: list[TemplateSegmentUnion] = []
@@ -81,8 +83,6 @@ class Template:
 
         # Parse template to get ordered segments
         # We need to split the template by variable placeholders while preserving order
-        import re
-
         # Create a regex pattern that matches variable placeholders
         pattern = (
             r"\{\{(#[a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}"
@@ -112,7 +112,7 @@ class Template:
 
     @classmethod
     def from_end_outputs(cls, outputs_config: list[dict[str, Any]]) -> Template:
-        """Create a Template from an End node outputs configuration.
+        r"""Create a Template from an End node outputs configuration.
 
         End nodes are treated as templates of concatenated variables with newlines.
 
@@ -130,6 +130,7 @@ class Template:
 
         Returns:
             Template instance
+
         """
         segments: list[TemplateSegmentUnion] = []
 
@@ -143,8 +144,9 @@ class Template:
             if value_selector:
                 segments.append(
                     VariableSegment(
-                        selector=list(value_selector), variable_name=variable_name
-                    )
+                        selector=list(value_selector),
+                        variable_name=variable_name,
+                    ),
                 )
 
         if len(segments) > 0 and isinstance(segments[-1], TextSegment):

--- a/src/graphon/nodes/base/usage_tracking_mixin.py
+++ b/src/graphon/nodes/base/usage_tracking_mixin.py
@@ -4,7 +4,8 @@ from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
 class LLMUsageTrackingMixin:
     """Provides shared helpers for merging and recording
-    LLM usage within workflow nodes."""
+    LLM usage within workflow nodes.
+    """
 
     graph_runtime_state: GraphRuntimeState
 

--- a/src/graphon/nodes/base/variable_template_parser.py
+++ b/src/graphon/nodes/base/variable_template_parser.py
@@ -5,11 +5,11 @@ from typing import Any
 from .entities import VariableSelector
 
 REGEX = re.compile(
-    r"\{\{(#[a-zA-Z0-9_]{1,50}(\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}"
+    r"\{\{(#[a-zA-Z0-9_]{1,50}(\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}",
 )
 
 SELECTOR_PATTERN = re.compile(
-    r"\{\{(#[a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}"
+    r"\{\{(#[a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10}#)\}\}",
 )
 
 
@@ -23,8 +23,7 @@ def extract_selectors_from_template(template: str, /) -> Sequence[VariableSelect
 
 
 class VariableTemplateParser:
-    """
-    !NOTE: Consider to use the new `segments` module instead of this class.
+    """!NOTE: Consider to use the new `segments` module instead of this class.
 
     A class for parsing and manipulating template variables in a string.
 
@@ -61,16 +60,16 @@ class VariableTemplateParser:
     # Output: "Hello, John! Your age is 25."
     """
 
-    def __init__(self, template: str):
+    def __init__(self, template: str) -> None:
         self.template = template
         self.variable_keys = self.extract()
 
     def extract(self):
-        """
-        Extracts all the template variable keys from the template string.
+        """Extracts all the template variable keys from the template string.
 
         Returns:
             A list of template variable keys.
+
         """
         # Regular expression to match the template rules
         matches = re.findall(REGEX, self.template)
@@ -80,11 +79,11 @@ class VariableTemplateParser:
         return list(set(first_group_matches))
 
     def extract_variable_selectors(self) -> list[VariableSelector]:
-        """
-        Extracts the variable selectors from the template variable keys.
+        """Extracts the variable selectors from the template variable keys.
 
         Returns:
             A list of VariableSelector objects representing the variable selectors.
+
         """
         variable_selectors = []
         for variable_key in self.variable_keys:
@@ -94,14 +93,13 @@ class VariableTemplateParser:
                 continue
 
             variable_selectors.append(
-                VariableSelector(variable=variable_key, value_selector=split_result)
+                VariableSelector(variable=variable_key, value_selector=split_result),
             )
 
         return variable_selectors
 
     def format(self, inputs: Mapping[str, Any]) -> str:
-        """
-        Formats the template string by replacing the template variables
+        """Formats the template string by replacing the template variables
         with their corresponding values.
 
         Args:
@@ -109,12 +107,14 @@ class VariableTemplateParser:
 
         Returns:
             The formatted string with template variables replaced by their values.
+
         """
 
-        def replacer(match):
+        def replacer(match: re.Match[str]) -> str:
             key = match.group(1)
             value = inputs.get(
-                key, match.group(0)
+                key,
+                match.group(0),
             )  # return original matched string if key not found
 
             if value is None:
@@ -130,14 +130,14 @@ class VariableTemplateParser:
         return re.sub(r"<\|.*?\|>", "", prompt)
 
     @classmethod
-    def remove_template_variables(cls, text: str):
-        """
-        Removes the template variables from the given text.
+    def remove_template_variables(cls, text: str) -> str:
+        """Removes the template variables from the given text.
 
         Args:
             text: The text from which to remove the template variables.
 
         Returns:
             The text with template variables removed.
+
         """
         return re.sub(REGEX, r"{\1}", text)

--- a/src/graphon/nodes/code/code_node.py
+++ b/src/graphon/nodes/code/code_node.py
@@ -57,7 +57,7 @@ _DEFAULT_CODE_BY_LANGUAGE: Mapping[CodeLanguage, str] = {
             return {
                 "result": arg1 + arg2,
             }
-        """
+        """,
     ),
     CodeLanguage.JAVASCRIPT: dedent(
         """
@@ -66,7 +66,7 @@ _DEFAULT_CODE_BY_LANGUAGE: Mapping[CodeLanguage, str] = {
                 result: arg1 + arg2
             }
         }
-        """
+        """,
     ),
 }
 
@@ -78,7 +78,7 @@ class CodeNode(Node[CodeNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -87,7 +87,7 @@ class CodeNode(Node[CodeNodeData]):
         code_limits: CodeNodeLimits,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -98,13 +98,10 @@ class CodeNode(Node[CodeNodeData]):
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
-        """
-        Get default config of node.
-        :param filters: filter by node config parameters.
-        :return:
-        """
+        """Build the default node config, optionally honoring language filters."""
         code_language = CodeLanguage.PYTHON3
         if filters:
             raw_code_language = filters.get("code_language", CodeLanguage.PYTHON3)
@@ -113,13 +110,13 @@ class CodeNode(Node[CodeNodeData]):
             elif isinstance(raw_code_language, str):
                 code_language = CodeLanguage(raw_code_language)
             else:
-                raise CodeNodeError(
-                    f"Unsupported code language filter: {raw_code_language!r}"
-                )
+                msg = f"Unsupported code language filter: {raw_code_language!r}"
+                raise CodeNodeError(msg)
 
         default_code = _DEFAULT_CODE_BY_LANGUAGE.get(code_language)
         if default_code is None:
-            raise CodeNodeError(f"Unsupported code language: {code_language}")
+            msg = f"Unsupported code language: {code_language}"
+            raise CodeNodeError(msg)
         return _build_default_config(language=code_language, code=default_code)
 
     @classmethod
@@ -138,7 +135,7 @@ class CodeNode(Node[CodeNodeData]):
         for variable_selector in self.node_data.variables:
             variable_name = variable_selector.variable
             variable = self.graph_runtime_state.variable_pool.get(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
             if isinstance(variable, ArrayFileSegment):
                 variables[variable_name] = (
@@ -156,7 +153,8 @@ class CodeNode(Node[CodeNodeData]):
 
             # Transform result
             result = self._transform_result(
-                result=result, output_schema=self.node_data.outputs
+                result=result,
+                output_schema=self.node_data.outputs,
             )
         except CodeNodeError as e:
             return NodeRunResult(
@@ -182,45 +180,37 @@ class CodeNode(Node[CodeNodeData]):
         )
 
     def _check_string(self, value: str | None, variable: str) -> str | None:
-        """
-        Check string
-        :param value: value
-        :param variable: variable
-        :return:
-        """
+        """Validate a string output against node limits and sanitize NUL bytes."""
         if value is None:
             return None
 
         if len(value) > self._limits.max_string_length:
-            raise OutputValidationError(
+            msg = (
                 f"The length of output variable `{variable}` must be"
                 f" less than {self._limits.max_string_length} characters"
             )
+            raise OutputValidationError(msg)
 
         return value.replace("\x00", "")
 
-    def _check_boolean(self, value: bool | None, variable: str) -> bool | None:
+    def _check_boolean(self, value: bool | None) -> bool | None:
         if value is None:
             return None
 
         return value
 
     def _check_number(self, value: float | None, variable: str) -> int | float | None:
-        """
-        Check number
-        :param value: value
-        :param variable: variable
-        :return:
-        """
+        """Validate a numeric output against configured range and precision limits."""
         if value is None:
             return None
 
         if value > self._limits.max_number or value < self._limits.min_number:
-            raise OutputValidationError(
+            msg = (
                 f"Output variable `{variable}` is out of range, "
                 f"it must be between {self._limits.min_number} "
                 f"and {self._limits.max_number}."
             )
+            raise OutputValidationError(msg)
 
         if isinstance(value, float):
             decimal_value = Decimal(str(value)).normalize()
@@ -231,12 +221,371 @@ class CodeNode(Node[CodeNodeData]):
             )  # type: ignore[operator]
             # raise error if precision is too high
             if precision > self._limits.max_precision:
-                raise OutputValidationError(
+                msg = (
                     f"Output variable `{variable}` has too high precision,"
                     f" it must be less than {self._limits.max_precision} digits."
                 )
+                raise OutputValidationError(msg)
 
         return value
+
+    @staticmethod
+    def _output_path(prefix: str, output_name: str) -> str:
+        if prefix:
+            return f"{prefix}.{output_name}"
+        return output_name
+
+    @staticmethod
+    def _output_path_with_index(prefix: str, output_name: str, index: int) -> str:
+        return f"{CodeNode._output_path(prefix, output_name)}[{index}]"
+
+    def _validate_untyped_list(
+        self,
+        *,
+        output_name: str,
+        output_value: list[Any],
+        prefix: str,
+        depth: int,
+    ) -> None:
+        output_path = self._output_path(prefix, output_name)
+        first_element = output_value[0] if output_value else None
+        if first_element is None:
+            return
+
+        if isinstance(first_element, int | float) and all(
+            value is None or isinstance(value, int | float) for value in output_value
+        ):
+            for i, value in enumerate(output_value):
+                self._check_number(
+                    value=value,
+                    variable=self._output_path_with_index(prefix, output_name, i),
+                )
+            return
+
+        if isinstance(first_element, str) and all(
+            value is None or isinstance(value, str) for value in output_value
+        ):
+            for i, value in enumerate(output_value):
+                self._check_string(
+                    value=value,
+                    variable=self._output_path_with_index(prefix, output_name, i),
+                )
+            return
+
+        if (
+            isinstance(first_element, dict)
+            and all(value is None or isinstance(value, dict) for value in output_value)
+        ) or (
+            isinstance(first_element, list)
+            and all(value is None or isinstance(value, list) for value in output_value)
+        ):
+            for i, value in enumerate(output_value):
+                if value is not None:
+                    self._transform_result(
+                        result=value,
+                        output_schema=None,
+                        prefix=self._output_path_with_index(prefix, output_name, i),
+                        depth=depth + 1,
+                    )
+            return
+
+        msg = (
+            f"Output {output_path} is not a valid array."
+            f" make sure all elements are of the same type."
+        )
+        raise OutputValidationError(msg)
+
+    def _validate_untyped_output(
+        self,
+        *,
+        output_name: str,
+        output_value: Any,
+        prefix: str,
+        depth: int,
+    ) -> None:
+        output_path = self._output_path(prefix, output_name)
+        if isinstance(output_value, dict):
+            self._transform_result(
+                result=output_value,
+                output_schema=None,
+                prefix=output_path,
+                depth=depth + 1,
+            )
+            return
+        if isinstance(output_value, bool):
+            self._check_boolean(output_value)
+            return
+        if isinstance(output_value, int | float):
+            self._check_number(value=output_value, variable=output_path)
+            return
+        if isinstance(output_value, str):
+            self._check_string(value=output_value, variable=output_path)
+            return
+        if isinstance(output_value, list):
+            self._validate_untyped_list(
+                output_name=output_name,
+                output_value=output_value,
+                prefix=prefix,
+                depth=depth,
+            )
+            return
+        if output_value is None:
+            return
+
+        msg = f"Output {output_path} is not a valid type."
+        raise OutputValidationError(msg)
+
+    def _transform_object_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+        depth: int,
+        output_schema: dict[str, CodeNodeData.Output] | None,
+    ) -> dict[str, Any] | None:
+        output_path = self._output_path(prefix, output_name)
+        if not isinstance(value, dict):
+            if value is None:
+                return None
+            msg = f"Output {output_path} is not an object, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        return self._transform_result(
+            result=value,
+            output_schema=output_schema,
+            prefix=output_path,
+            depth=depth + 1,
+        )
+
+    def _transform_number_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+    ) -> int | float | None:
+        output_path = self._output_path(prefix, output_name)
+        if value is not None and not isinstance(value, (int, float)):
+            msg = f"Output {output_path} is not a number, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        checked = self._check_number(value=value, variable=output_path)
+        return self._convert_boolean_to_int(checked)
+
+    def _transform_string_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+    ) -> str | None:
+        output_path = self._output_path(prefix, output_name)
+        if value is not None and not isinstance(value, str):
+            msg = (
+                f"Output {output_path} must be a string,"
+                f" got {type(value).__name__} instead."
+            )
+            raise OutputValidationError(msg)
+
+        return self._check_string(value=value, variable=output_path)
+
+    def _transform_boolean_output(self, *, value: Any) -> bool | None:
+        return self._check_boolean(value=value)
+
+    def _transform_array_number_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+    ) -> list[int | float | None] | None:
+        output_path = self._output_path(prefix, output_name)
+        if not isinstance(value, list):
+            if value is None:
+                return None
+            msg = f"Output {output_path} is not an array, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        if len(value) > self._limits.max_number_array_length:
+            msg = (
+                f"The length of output variable `{output_path}` must be "
+                f"less than {self._limits.max_number_array_length} elements."
+            )
+            raise OutputValidationError(msg)
+
+        for i, inner_value in enumerate(value):
+            if not isinstance(inner_value, (int, float)):
+                msg = (
+                    f"The element at index {i} of output variable "
+                    f"`{output_path}` must be a number."
+                )
+                raise OutputValidationError(msg)
+
+        return [self._convert_boolean_to_int(v) for v in value]
+
+    def _transform_array_string_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+    ) -> list[str | None] | None:
+        output_path = self._output_path(prefix, output_name)
+        if not isinstance(value, list):
+            if value is None:
+                return None
+            msg = f"Output {output_path} is not an array, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        if len(value) > self._limits.max_string_array_length:
+            msg = (
+                f"The length of output variable `{output_path}` must be "
+                f"less than {self._limits.max_string_array_length} elements."
+            )
+            raise OutputValidationError(msg)
+
+        return [
+            self._check_string(
+                value=inner_value,
+                variable=self._output_path_with_index(prefix, output_name, i),
+            )
+            for i, inner_value in enumerate(value)
+        ]
+
+    def _transform_array_object_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+        depth: int,
+        output_schema: dict[str, CodeNodeData.Output] | None,
+    ) -> list[dict[str, Any] | None] | None:
+        output_path = self._output_path(prefix, output_name)
+        if not isinstance(value, list):
+            if value is None:
+                return None
+            msg = f"Output {output_path} is not an array, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        if len(value) > self._limits.max_object_array_length:
+            msg = (
+                f"The length of output variable `{output_path}` must be "
+                f"less than {self._limits.max_object_array_length} elements."
+            )
+            raise OutputValidationError(msg)
+
+        for i, inner_value in enumerate(value):
+            if not isinstance(inner_value, dict):
+                if inner_value is None:
+                    continue
+                msg = (
+                    f"Output {output_path}[{i}] is not an object, got "
+                    f"{type(inner_value)} instead at index {i}."
+                )
+                raise OutputValidationError(msg)
+
+        return [
+            None
+            if inner_value is None
+            else self._transform_result(
+                result=inner_value,
+                output_schema=output_schema,
+                prefix=self._output_path_with_index(prefix, output_name, i),
+                depth=depth + 1,
+            )
+            for i, inner_value in enumerate(value)
+        ]
+
+    def _transform_array_boolean_output(
+        self,
+        *,
+        value: Any,
+        output_name: str,
+        prefix: str,
+    ) -> list[bool | None] | None:
+        output_path = self._output_path(prefix, output_name)
+        if not isinstance(value, list):
+            if value is None:
+                return None
+            msg = f"Output {output_path} is not an array, got {type(value)} instead."
+            raise OutputValidationError(msg)
+
+        for i, inner_value in enumerate(value):
+            if inner_value is not None and not isinstance(inner_value, bool):
+                msg = (
+                    f"Output {output_path}[{i}] is not a boolean, got "
+                    f"{type(inner_value)} instead."
+                )
+                raise OutputValidationError(msg)
+            self._check_boolean(value=inner_value)
+
+        return value
+
+    def _transform_schema_output(
+        self,
+        *,
+        output_name: str,
+        output_config: CodeNodeData.Output,
+        result: Mapping[str, Any],
+        prefix: str,
+        depth: int,
+    ) -> Any:
+        value = result[output_name]
+        match output_config.type:
+            case SegmentType.OBJECT:
+                transformed_value = self._transform_object_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                    depth=depth,
+                    output_schema=output_config.children,
+                )
+            case SegmentType.NUMBER:
+                transformed_value = self._transform_number_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                )
+            case SegmentType.STRING:
+                transformed_value = self._transform_string_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                )
+            case SegmentType.BOOLEAN:
+                transformed_value = self._transform_boolean_output(value=value)
+            case SegmentType.ARRAY_NUMBER:
+                transformed_value = self._transform_array_number_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                )
+            case SegmentType.ARRAY_STRING:
+                transformed_value = self._transform_array_string_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                )
+            case SegmentType.ARRAY_OBJECT:
+                transformed_value = self._transform_array_object_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                    depth=depth,
+                    output_schema=output_config.children,
+                )
+            case SegmentType.ARRAY_BOOLEAN:
+                transformed_value = self._transform_array_boolean_output(
+                    value=value,
+                    output_name=output_name,
+                    prefix=prefix,
+                )
+            case _:
+                msg = f"Output type {output_config.type} is not supported."
+                raise OutputValidationError(msg)
+        return transformed_value
 
     def _transform_result(
         self,
@@ -244,306 +593,46 @@ class CodeNode(Node[CodeNodeData]):
         output_schema: dict[str, CodeNodeData.Output] | None,
         prefix: str = "",
         depth: int = 1,
-    ):
+    ) -> Mapping[str, Any]:
         # TODO(QuantumGhost): Replace native Python lists with `Array*Segment` classes.
         # Note that `_transform_result` may produce lists containing `None` values,
         # which don't conform to the type requirements of `Array*Segment` classes.
         if depth > self._limits.max_depth:
-            raise DepthLimitError(
-                f"Depth limit {self._limits.max_depth} reached, object too deep."
-            )
+            msg = f"Depth limit {self._limits.max_depth} reached, object too deep."
+            raise DepthLimitError(msg)
 
         transformed_result: dict[str, Any] = {}
         if output_schema is None:
-            # validate output thought instance type
             for output_name, output_value in result.items():
-                if isinstance(output_value, dict):
-                    self._transform_result(
-                        result=output_value,
-                        output_schema=None,
-                        prefix=f"{prefix}.{output_name}" if prefix else output_name,
-                        depth=depth + 1,
-                    )
-                elif isinstance(output_value, bool):
-                    self._check_boolean(
-                        output_value,
-                        variable=f"{prefix}.{output_name}" if prefix else output_name,
-                    )
-                elif isinstance(output_value, int | float):
-                    self._check_number(
-                        value=output_value,
-                        variable=f"{prefix}.{output_name}" if prefix else output_name,
-                    )
-                elif isinstance(output_value, str):
-                    self._check_string(
-                        value=output_value,
-                        variable=f"{prefix}.{output_name}" if prefix else output_name,
-                    )
-                elif isinstance(output_value, list):
-                    first_element = output_value[0] if len(output_value) > 0 else None
-                    if first_element is not None:
-                        if isinstance(first_element, int | float) and all(
-                            value is None or isinstance(value, int | float)
-                            for value in output_value
-                        ):
-                            for i, value in enumerate(output_value):
-                                self._check_number(
-                                    value=value,
-                                    variable=f"{prefix}.{output_name}[{i}]"
-                                    if prefix
-                                    else f"{output_name}[{i}]",
-                                )
-                        elif isinstance(first_element, str) and all(
-                            value is None or isinstance(value, str)
-                            for value in output_value
-                        ):
-                            for i, value in enumerate(output_value):
-                                self._check_string(
-                                    value=value,
-                                    variable=f"{prefix}.{output_name}[{i}]"
-                                    if prefix
-                                    else f"{output_name}[{i}]",
-                                )
-                        elif (
-                            isinstance(first_element, dict)
-                            and all(
-                                value is None or isinstance(value, dict)
-                                for value in output_value
-                            )
-                        ) or (
-                            isinstance(first_element, list)
-                            and all(
-                                value is None or isinstance(value, list)
-                                for value in output_value
-                            )
-                        ):
-                            for i, value in enumerate(output_value):
-                                if value is not None:
-                                    self._transform_result(
-                                        result=value,
-                                        output_schema=None,
-                                        prefix=f"{prefix}.{output_name}[{i}]"
-                                        if prefix
-                                        else f"{output_name}[{i}]",
-                                        depth=depth + 1,
-                                    )
-                        else:
-                            raise OutputValidationError(
-                                f"Output {prefix}.{output_name} is not a valid array."
-                                f" make sure all elements are of the same type."
-                            )
-                elif output_value is None:
-                    pass
-                else:
-                    raise OutputValidationError(
-                        f"Output {prefix}.{output_name} is not a valid type."
-                    )
+                self._validate_untyped_output(
+                    output_name=output_name,
+                    output_value=output_value,
+                    prefix=prefix,
+                    depth=depth,
+                )
 
             return result
 
         parameters_validated = {}
         for output_name, output_config in output_schema.items():
-            dot = "." if prefix else ""
             if output_name not in result:
-                raise OutputValidationError(
-                    f"Output {prefix}{dot}{output_name} is missing."
-                )
-
-            if output_config.type == SegmentType.OBJECT:
-                # check if output is object
-                if not isinstance(result.get(output_name), dict):
-                    if result[output_name] is None:
-                        transformed_result[output_name] = None
-                    else:
-                        raise OutputValidationError(
-                            f"Output {prefix}{dot}{output_name} is not an object,"
-                            f" got {type(result.get(output_name))} instead."
-                        )
-                else:
-                    transformed_result[output_name] = self._transform_result(
-                        result=result[output_name],
-                        output_schema=output_config.children,
-                        prefix=f"{prefix}.{output_name}",
-                        depth=depth + 1,
-                    )
-            elif output_config.type == SegmentType.NUMBER:
-                # check if number available
-                value = result.get(output_name)
-                if value is not None and not isinstance(value, (int, float)):
-                    raise OutputValidationError(
-                        f"Output {prefix}{dot}{output_name} is not a number,"
-                        f" got {type(result.get(output_name))} instead."
-                    )
-                checked = self._check_number(
-                    value=value, variable=f"{prefix}{dot}{output_name}"
-                )
-                # If the output is a boolean and the output schema specifies
-                # NUMBER type, convert the boolean value to an integer.
-                # This ensures compatibility with existing workflows that
-                # may use `True` and `False` as values for NUMBER type outputs.
-                transformed_result[output_name] = self._convert_boolean_to_int(checked)
-
-            elif output_config.type == SegmentType.STRING:
-                # check if string available
-                value = result.get(output_name)
-                if value is not None and not isinstance(value, str):
-                    raise OutputValidationError(
-                        f"Output {prefix}{dot}{output_name} must be a string, "
-                        f"got {type(value).__name__} instead."
-                    )
-                transformed_result[output_name] = self._check_string(
-                    value=value,
-                    variable=f"{prefix}{dot}{output_name}",
-                )
-            elif output_config.type == SegmentType.BOOLEAN:
-                transformed_result[output_name] = self._check_boolean(
-                    value=result[output_name],
-                    variable=f"{prefix}{dot}{output_name}",
-                )
-            elif output_config.type == SegmentType.ARRAY_NUMBER:
-                # check if array of number available
-                value = result[output_name]
-                if not isinstance(value, list):
-                    if value is None:
-                        transformed_result[output_name] = None
-                    else:
-                        raise OutputValidationError(
-                            f"Output {prefix}{dot}{output_name} is not an array, "
-                            f"got {type(value)} instead."
-                        )
-                else:
-                    if len(value) > self._limits.max_number_array_length:
-                        raise OutputValidationError(
-                            f"The length of output variable "
-                            f"`{prefix}{dot}{output_name}` must be "
-                            f"less than {self._limits.max_number_array_length} "
-                            f"elements."
-                        )
-
-                    for i, inner_value in enumerate(value):
-                        if not isinstance(inner_value, (int, float)):
-                            raise OutputValidationError(
-                                f"The element at index {i} of output variable "
-                                f"`{prefix}{dot}{output_name}` must be a number."
-                            )
-                            _ = self._check_number(
-                                value=inner_value,
-                                variable=f"{prefix}{dot}{output_name}[{i}]",
-                            )
-                    transformed_result[output_name] = [
-                        # If the element is a boolean and the output schema
-                        # specifies a `array[number]` type, convert the boolean
-                        # value to an integer.
-                        #
-                        # This ensures compatibility with existing workflows
-                        # that may use `True` and `False` as values for
-                        # NUMBER type outputs.
-                        self._convert_boolean_to_int(v)
-                        for v in value
-                    ]
-            elif output_config.type == SegmentType.ARRAY_STRING:
-                # check if array of string available
-                if not isinstance(result[output_name], list):
-                    if result[output_name] is None:
-                        transformed_result[output_name] = None
-                    else:
-                        raise OutputValidationError(
-                            f"Output {prefix}{dot}{output_name} is not an array, "
-                            f"got {type(result.get(output_name))} instead."
-                        )
-                else:
-                    if len(result[output_name]) > self._limits.max_string_array_length:
-                        raise OutputValidationError(
-                            f"The length of output variable "
-                            f"`{prefix}{dot}{output_name}` must be "
-                            f"less than {self._limits.max_string_array_length} "
-                            f"elements."
-                        )
-
-                    transformed_result[output_name] = [
-                        self._check_string(
-                            value=value, variable=f"{prefix}{dot}{output_name}[{i}]"
-                        )
-                        for i, value in enumerate(result[output_name])
-                    ]
-            elif output_config.type == SegmentType.ARRAY_OBJECT:
-                # check if array of object available
-                if not isinstance(result[output_name], list):
-                    if result[output_name] is None:
-                        transformed_result[output_name] = None
-                    else:
-                        raise OutputValidationError(
-                            f"Output {prefix}{dot}{output_name} is not an array, "
-                            f"got {type(result.get(output_name))} instead."
-                        )
-                else:
-                    if len(result[output_name]) > self._limits.max_object_array_length:
-                        raise OutputValidationError(
-                            f"The length of output variable "
-                            f"`{prefix}{dot}{output_name}` must be "
-                            f"less than {self._limits.max_object_array_length} "
-                            f"elements."
-                        )
-
-                    for i, value in enumerate(result[output_name]):
-                        if not isinstance(value, dict):
-                            if value is None:
-                                pass
-                            else:
-                                raise OutputValidationError(
-                                    f"Output {prefix}{dot}{output_name}[{i}] "
-                                    f"is not an object, got {type(value)} "
-                                    f"instead at index {i}."
-                                )
-
-                    transformed_result[output_name] = [
-                        None
-                        if value is None
-                        else self._transform_result(
-                            result=value,
-                            output_schema=output_config.children,
-                            prefix=f"{prefix}{dot}{output_name}[{i}]",
-                            depth=depth + 1,
-                        )
-                        for i, value in enumerate(result[output_name])
-                    ]
-            elif output_config.type == SegmentType.ARRAY_BOOLEAN:
-                # check if array of object available
-                value = result[output_name]
-                if not isinstance(value, list):
-                    if value is None:
-                        transformed_result[output_name] = None
-                    else:
-                        raise OutputValidationError(
-                            f"Output {prefix}{dot}{output_name} is not an array,"
-                            f" got {type(result.get(output_name))} instead."
-                        )
-                else:
-                    for i, inner_value in enumerate(value):
-                        if inner_value is not None and not isinstance(
-                            inner_value, bool
-                        ):
-                            raise OutputValidationError(
-                                f"Output {prefix}{dot}{output_name}[{i}] "
-                                f"is not a boolean, got {type(inner_value)} "
-                                f"instead."
-                            )
-                        _ = self._check_boolean(
-                            value=inner_value,
-                            variable=f"{prefix}{dot}{output_name}[{i}]",
-                        )
-                    transformed_result[output_name] = value
-
-            else:
-                raise OutputValidationError(
-                    f"Output type {output_config.type} is not supported."
-                )
+                output_path = self._output_path(prefix, output_name)
+                msg = f"Output {output_path} is missing."
+                raise OutputValidationError(msg)
+            transformed_result[output_name] = self._transform_schema_output(
+                output_name=output_name,
+                output_config=output_config,
+                result=result,
+                prefix=prefix,
+                depth=depth,
+            )
 
             parameters_validated[output_name] = True
 
         # check if all output parameters are validated
         if len(parameters_validated) != len(result):
-            raise CodeNodeError("Not all output parameters are validated.")
+            msg = "Not all output parameters are validated."
+            raise CodeNodeError(msg)
 
         return transformed_result
 
@@ -568,11 +657,15 @@ class CodeNode(Node[CodeNodeData]):
 
     @staticmethod
     def _convert_boolean_to_int(value: bool | float | None) -> int | float | None:
-        """This function convert boolean to integers when the output schema
-        specifies a NUMBER type.
+        """Convert booleans to integers when the output schema specifies a
+        NUMBER type.
 
         This ensures compatibility with existing workflows that may use
         `True` and `False` as values for NUMBER type outputs.
+
+        Returns:
+            `None`, the original numeric value, or an integer converted from `bool`.
+
         """
         if value is None:
             return None

--- a/src/graphon/nodes/code/entities.py
+++ b/src/graphon/nodes/code/entities.py
@@ -29,25 +29,28 @@ _ALLOWED_OUTPUT_FROM_CODE = frozenset([
 
 def _validate_type(segment_type: SegmentType) -> SegmentType:
     if segment_type not in _ALLOWED_OUTPUT_FROM_CODE:
-        raise ValueError(
+        msg = (
             f"invalid type for code output, expected {_ALLOWED_OUTPUT_FROM_CODE}, "
             f"actual {segment_type}"
         )
+        raise ValueError(msg)
     return segment_type
 
 
 class CodeNodeData(BaseNodeData):
-    """
-    Code Node Data.
-    """
+    """Code Node Data."""
 
     type: NodeType = BuiltinNodeTypes.CODE
 
     class Output(BaseModel):
+        """Schema for a single code-node output."""
+
         type: Annotated[SegmentType, AfterValidator(_validate_type)]
         children: dict[str, "CodeNodeData.Output"] | None = None
 
     class Dependency(BaseModel):
+        """Dependency required by a code node."""
+
         name: str
         version: str
 

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -46,9 +46,34 @@ if TYPE_CHECKING:
     from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
 
+def _partition_file_via_unstructured_api(
+    partition_via_api: Any,
+    file_content: bytes,
+    *,
+    suffix: str,
+    unstructured_api_config: UnstructuredApiConfig,
+) -> Sequence[Any]:
+    api_key = unstructured_api_config.api_key or ""
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_file.write(file_content)
+        temp_file.flush()
+        temp_path = pathlib.Path(temp_file.name)
+
+    try:
+        with temp_path.open("rb") as file:
+            return partition_via_api(
+                file=file,
+                metadata_filename=temp_path.name,
+                api_url=unstructured_api_config.api_url,
+                api_key=api_key,
+            )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
-    """
-    Extracts text content from various file types.
+    """Extracts text content from various file types.
     Supports plain text, PDF, and DOC/DOCX files.
     """
 
@@ -62,7 +87,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -71,7 +96,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
         http_client: HttpClientProtocol | None = None,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -86,15 +111,19 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
         variable_selector = self.node_data.variable_selector
         variable = self.graph_runtime_state.variable_pool.get(variable_selector)
 
+        error_message = None
         if variable is None:
             error_message = f"File variable not found for selector: {variable_selector}"
-            return NodeRunResult(
-                status=WorkflowNodeExecutionStatus.FAILED, error=error_message
-            )
-        if variable.value and not isinstance(variable, ArrayFileSegment | FileSegment):
+        elif variable.value and not isinstance(
+            variable,
+            ArrayFileSegment | FileSegment,
+        ):
             error_message = f"Variable {variable_selector} is not an ArrayFileSegment"
+
+        if error_message is not None:
             return NodeRunResult(
-                status=WorkflowNodeExecutionStatus.FAILED, error=error_message
+                status=WorkflowNodeExecutionStatus.FAILED,
+                error=error_message,
             )
 
         value = variable.value
@@ -111,8 +140,8 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
                 outputs={"text": ArrayStringSegment(value=[])},
             )
 
-        try:
-            if isinstance(value, list):
+        if isinstance(value, list):
+            try:
                 extracted_text_list = [
                     _extract_text_from_file(
                         self._http_client,
@@ -121,33 +150,38 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
                     )
                     for file in value
                 ]
+            except DocumentExtractorError as e:
+                logger.warning(e, exc_info=True)
                 return NodeRunResult(
-                    status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                    status=WorkflowNodeExecutionStatus.FAILED,
+                    error=str(e),
                     inputs=inputs,
                     process_data=process_data,
-                    outputs={"text": ArrayStringSegment(value=extracted_text_list)},
                 )
-            if isinstance(value, File):
+            outputs = {"text": ArrayStringSegment(value=extracted_text_list)}
+        else:
+            try:
                 extracted_text = _extract_text_from_file(
                     self._http_client,
                     value,
                     unstructured_api_config=self._unstructured_api_config,
                 )
+            except DocumentExtractorError as e:
+                logger.warning(e, exc_info=True)
                 return NodeRunResult(
-                    status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                    status=WorkflowNodeExecutionStatus.FAILED,
+                    error=str(e),
                     inputs=inputs,
                     process_data=process_data,
-                    outputs={"text": extracted_text},
                 )
-            raise DocumentExtractorError(f"Unsupported variable type: {type(value)}")
-        except DocumentExtractorError as e:
-            logger.warning(e, exc_info=True)
-            return NodeRunResult(
-                status=WorkflowNodeExecutionStatus.FAILED,
-                error=str(e),
-                inputs=inputs,
-                process_data=process_data,
-            )
+            outputs = {"text": extracted_text}
+
+        return NodeRunResult(
+            status=WorkflowNodeExecutionStatus.SUCCEEDED,
+            inputs=inputs,
+            process_data=process_data,
+            outputs=outputs,
+        )
 
     @classmethod
     @override
@@ -171,50 +205,56 @@ def _extract_text_by_mime_type(
     """Extract text from a file based on its MIME type."""
     match mime_type:
         case "text/plain" | "text/html" | "text/htm" | "text/markdown" | "text/xml":
-            return _extract_text_from_plain_text(file_content)
+            extracted_text = _extract_text_from_plain_text(file_content)
         case "application/pdf":
-            return _extract_text_from_pdf(file_content)
+            extracted_text = _extract_text_from_pdf(file_content)
         case "application/msword":
-            return _extract_text_from_doc(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_doc(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-            return _extract_text_from_docx(file_content)
+            extracted_text = _extract_text_from_docx(file_content)
         case "text/csv":
-            return _extract_text_from_csv(file_content)
+            extracted_text = _extract_text_from_csv(file_content)
         case (
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             | "application/vnd.ms-excel"
         ):
-            return _extract_text_from_excel(file_content)
+            extracted_text = _extract_text_from_excel(file_content)
         case "application/vnd.ms-powerpoint":
-            return _extract_text_from_ppt(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_ppt(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case (
             "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         ):
-            return _extract_text_from_pptx(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_pptx(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case "application/epub+zip":
-            return _extract_text_from_epub(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_epub(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case "message/rfc822":
-            return _extract_text_from_eml(file_content)
+            extracted_text = _extract_text_from_eml(file_content)
         case "application/vnd.ms-outlook":
-            return _extract_text_from_msg(file_content)
+            extracted_text = _extract_text_from_msg(file_content)
         case "application/json":
-            return _extract_text_from_json(file_content)
+            extracted_text = _extract_text_from_json(file_content)
         case "application/x-yaml" | "text/yaml":
-            return _extract_text_from_yaml(file_content)
+            extracted_text = _extract_text_from_yaml(file_content)
         case "text/vtt":
-            return _extract_text_from_vtt(file_content)
+            extracted_text = _extract_text_from_vtt(file_content)
         case "text/properties":
-            return _extract_text_from_properties(file_content)
+            extracted_text = _extract_text_from_properties(file_content)
         case _:
-            raise UnsupportedFileTypeError(f"Unsupported MIME type: {mime_type}")
+            msg = f"Unsupported MIME type: {mime_type}"
+            raise UnsupportedFileTypeError(msg)
+    return extracted_text
 
 
 def _extract_text_by_file_extension(
@@ -277,52 +317,57 @@ def _extract_text_by_file_extension(
             | ".log"
             | ".vtt"
         ):
-            return _extract_text_from_plain_text(file_content)
+            extracted_text = _extract_text_from_plain_text(file_content)
         case ".json":
-            return _extract_text_from_json(file_content)
+            extracted_text = _extract_text_from_json(file_content)
         case ".yaml" | ".yml":
-            return _extract_text_from_yaml(file_content)
+            extracted_text = _extract_text_from_yaml(file_content)
         case ".pdf":
-            return _extract_text_from_pdf(file_content)
+            extracted_text = _extract_text_from_pdf(file_content)
         case ".doc":
-            return _extract_text_from_doc(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_doc(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case ".docx":
-            return _extract_text_from_docx(file_content)
+            extracted_text = _extract_text_from_docx(file_content)
         case ".csv":
-            return _extract_text_from_csv(file_content)
+            extracted_text = _extract_text_from_csv(file_content)
         case ".xls" | ".xlsx":
-            return _extract_text_from_excel(file_content)
+            extracted_text = _extract_text_from_excel(file_content)
         case ".ppt":
-            return _extract_text_from_ppt(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_ppt(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case ".pptx":
-            return _extract_text_from_pptx(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_pptx(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case ".epub":
-            return _extract_text_from_epub(
-                file_content, unstructured_api_config=unstructured_api_config
+            extracted_text = _extract_text_from_epub(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
             )
         case ".eml":
-            return _extract_text_from_eml(file_content)
+            extracted_text = _extract_text_from_eml(file_content)
         case ".msg":
-            return _extract_text_from_msg(file_content)
+            extracted_text = _extract_text_from_msg(file_content)
         case ".properties":
-            return _extract_text_from_properties(file_content)
+            extracted_text = _extract_text_from_properties(file_content)
         case _:
-            raise UnsupportedFileTypeError(
-                f"Unsupported Extension Type: {file_extension}"
-            )
+            msg = f"Unsupported Extension Type: {file_extension}"
+            raise UnsupportedFileTypeError(msg)
+    return extracted_text
 
 
 def _extract_text_from_plain_text(file_content: bytes) -> str:
     try:
         # Detect encoding using charset_normalizer
         result = charset_normalizer.from_bytes(
-            file_content, cp_isolation=["utf_8", "latin_1", "cp1252"]
+            file_content,
+            cp_isolation=["utf_8", "latin_1", "cp1252"],
         ).best()
         encoding = result.encoding if result else "utf-8"
 
@@ -336,7 +381,8 @@ def _extract_text_from_plain_text(file_content: bytes) -> str:
         try:
             return file_content.decode("utf-8", errors="ignore")
         except UnicodeDecodeError:
-            raise TextExtractionError(f"Failed to decode plain text file: {e}") from e
+            msg = f"Failed to decode plain text file: {e}"
+            raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_json(file_content: bytes) -> str:
@@ -357,9 +403,8 @@ def _extract_text_from_json(file_content: bytes) -> str:
             json_data = json.loads(file_content.decode("utf-8", errors="ignore"))
             return json.dumps(json_data, indent=2, ensure_ascii=False)
         except (UnicodeDecodeError, json.JSONDecodeError):
-            raise TextExtractionError(
-                f"Failed to decode or parse JSON file: {e}"
-            ) from e
+            msg = f"Failed to decode or parse JSON file: {e}"
+            raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_yaml(file_content: bytes) -> str:
@@ -379,13 +424,12 @@ def _extract_text_from_yaml(file_content: bytes) -> str:
         # If decoding fails, try with utf-8 as last resort
         try:
             yaml_data = yaml.safe_load_all(
-                file_content.decode("utf-8", errors="ignore")
+                file_content.decode("utf-8", errors="ignore"),
             )
             return yaml.dump_all(yaml_data, allow_unicode=True, sort_keys=False)
         except (UnicodeDecodeError, yaml.YAMLError):
-            raise TextExtractionError(
-                f"Failed to decode or parse YAML file: {e}"
-            ) from e
+            msg = f"Failed to decode or parse YAML file: {e}"
+            raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_pdf(file_content: bytes) -> str:
@@ -398,52 +442,59 @@ def _extract_text_from_pdf(file_content: bytes) -> str:
             text += text_page.get_text_range()
             text_page.close()
             page.close()
-        return text
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from PDF: {e!s}") from e
+        msg = f"Failed to extract text from PDF: {e!s}"
+        raise TextExtractionError(msg) from e
+    else:
+        return text
 
 
 def _extract_text_from_doc(
-    file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+    file_content: bytes,
+    *,
+    unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
-    """
-    Extract text from a DOC file.
-    """
-    from unstructured.partition.api import partition_via_api
+    """Extract text from a DOC file."""
+    from unstructured.partition.api import partition_via_api  # noqa: PLC0415
 
     if not unstructured_api_config.api_url:
-        raise TextExtractionError(
-            "Unstructured API URL is not configured for DOC file processing."
-        )
-    api_key = unstructured_api_config.api_key or ""
+        msg = "Unstructured API URL is not configured for DOC file processing."
+        raise TextExtractionError(msg)
 
     try:
-        with tempfile.NamedTemporaryFile(suffix=".doc", delete=False) as temp_file:
-            temp_file.write(file_content)
-            temp_file.flush()
-            with pathlib.Path(temp_file.name).open("rb") as file:
-                elements = partition_via_api(
-                    file=file,
-                    metadata_filename=temp_file.name,
-                    api_url=unstructured_api_config.api_url,
-                    api_key=api_key,
-                )
-            pathlib.Path(temp_file.name).unlink()
+        elements = _partition_file_via_unstructured_api(
+            partition_via_api,
+            file_content,
+            suffix=".doc",
+            unstructured_api_config=unstructured_api_config,
+        )
         return "\n".join([getattr(element, "text", "") for element in elements])
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from DOC: {e!s}") from e
+        msg = f"Failed to extract text from DOC: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
-def parser_docx_part(block, doc: Document, content_items, i):
-    if isinstance(block, CT_P):
-        content_items.append((i, "paragraph", Paragraph(block, doc)))
-    elif isinstance(block, CT_Tbl):
-        content_items.append((i, "table", Table(block, doc)))
+def parser_docx_part(
+    block: object,
+    doc: Document,
+    content_items: list[tuple[int, str, Table | Paragraph]],
+    i: int,
+) -> None:
+    content_item: tuple[int, str, Table | Paragraph] | None = None
+    match block:
+        case CT_P():
+            content_item = (i, "paragraph", Paragraph(block, doc))
+        case CT_Tbl():
+            content_item = (i, "table", Table(block, doc))
+        case _:
+            pass
+
+    if content_item is not None:
+        content_items.append(content_item)
 
 
 def _normalize_docx_zip(file_content: bytes) -> bytes:
-    """
-    Some DOCX files (e.g. exported by Evernote on Windows) are malformed:
+    r"""Some DOCX files (e.g. exported by Evernote on Windows) are malformed:
     ZIP entry names use backslash (\\) as path separator instead of the forward
     slash (/) required by both the ZIP spec and OOXML.  On Linux/Mac the entry
     "word\\document.xml" is never found when python-docx looks for
@@ -451,12 +502,18 @@ def _normalize_docx_zip(file_content: bytes) -> bytes:
 
     This function rewrites the ZIP in-memory, normalizing all entry names to
     use forward slashes without touching any actual document content.
+
+    Returns:
+        Normalized DOCX bytes, or the original bytes if the payload is not a ZIP.
+
     """
     try:
         with zipfile.ZipFile(io.BytesIO(file_content), "r") as zin:
             out_buf = io.BytesIO()
             with zipfile.ZipFile(
-                out_buf, "w", compression=zipfile.ZIP_DEFLATED
+                out_buf,
+                "w",
+                compression=zipfile.ZIP_DEFLATED,
             ) as zout:
                 for item in zin.infolist():
                     data = zin.read(item.filename)
@@ -470,94 +527,105 @@ def _normalize_docx_zip(file_content: bytes) -> bytes:
 
 
 def _extract_text_from_docx(file_content: bytes) -> str:
-    """
-    Extract text from a DOCX file.
+    """Extract text from a DOCX file.
     For now support only paragraph and table add more if needed
+
+    Returns:
+        Extracted plain text content from the DOCX file.
+
+    Raises:
+        TextExtractionError: If the DOCX cannot be parsed after normalization and retry.
+
     """
     try:
-        doc_file = io.BytesIO(file_content)
-        try:
-            doc = docx.Document(doc_file)
-        except Exception as e:
-            logger.warning(
-                "Failed to parse DOCX, attempting to normalize ZIP entry paths: %s", e
-            )
-            # Some DOCX files exported by tools like Evernote on Windows use
-            # backslash path separators in ZIP entries and/or single-quoted XML
-            # attributes, both of which break python-docx on Linux. Normalize and retry.
-            file_content = _normalize_docx_zip(file_content)
-            doc = docx.Document(io.BytesIO(file_content))
-        text = []
-
-        # Keep track of paragraph and table positions
-        content_items: list[tuple[int, str, Table | Paragraph]] = []
-
-        it = iter(doc.element.body)
-        part = next(it, None)
-        i = 0
-        while part is not None:
-            parser_docx_part(part, doc, content_items, i)
-            i = i + 1
-            part = next(it, None)
-
-        # Process sorted content
-        for _, item_type, item in content_items:
-            if item_type == "paragraph":
-                if isinstance(item, Table):
-                    continue
-                text.append(item.text)
-            elif item_type == "table":
-                # Process tables
-                if not isinstance(item, Table):
-                    continue
-                try:
-                    # Check if any cell in the table has text
-                    has_content = False
-                    for row in item.rows:
-                        if any(cell.text.strip() for cell in row.cells):
-                            has_content = True
-                            break
-
-                    if has_content:
-                        cell_texts = [
-                            cell.text.replace("\n", "<br>")
-                            for cell in item.rows[0].cells
-                        ]
-                        markdown_table = f"| {' | '.join(cell_texts)} |\n"
-                        markdown_table += (
-                            f"| {' | '.join(['---'] * len(item.rows[0].cells))} |\n"
-                        )
-
-                        for row in item.rows[1:]:
-                            # Replace newlines with <br> in each cell
-                            row_cells = [
-                                cell.text.replace("\n", "<br>") for cell in row.cells
-                            ]
-                            markdown_table += "| " + " | ".join(row_cells) + " |\n"
-
-                        text.append(markdown_table)
-                except Exception as e:
-                    logger.warning("Failed to extract table from DOC: %s", e)
-                    continue
-
+        doc = _load_docx_document(file_content)
+        text: list[str] = []
+        for item_type, item in _iter_docx_content_items(doc):
+            extracted_text = _extract_docx_item_text(item_type, item)
+            if extracted_text is not None:
+                text.append(extracted_text)
         return "\n".join(text)
 
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from DOCX: {e!s}") from e
+        logger.exception("Failed to extract text from DOCX")
+        msg = f"Failed to extract text from DOCX: {e!s}"
+        raise TextExtractionError(msg) from e
+
+
+def _load_docx_document(file_content: bytes) -> Document:
+    try:
+        return docx.Document(io.BytesIO(file_content))
+    except Exception as e:
+        logger.warning(
+            "Failed to parse DOCX, attempting to normalize ZIP entry paths: %s",
+            e,
+            exc_info=e,
+        )
+        normalized_file_content = _normalize_docx_zip(file_content)
+        return docx.Document(io.BytesIO(normalized_file_content))
+
+
+def _iter_docx_content_items(doc: Document) -> list[tuple[str, Table | Paragraph]]:
+    content_items: list[tuple[int, str, Table | Paragraph]] = []
+    for index, part in enumerate(doc.element.body):
+        parser_docx_part(part, doc, content_items, index)
+    return [(item_type, item) for _, item_type, item in content_items]
+
+
+def _extract_docx_item_text(item_type: str, item: Table | Paragraph) -> str | None:
+    result: str | None
+    match item_type, item:
+        case "paragraph", Paragraph():
+            result = item.text
+        case "table", Table():
+            result = _extract_docx_table_text(item)
+        case _:
+            result = None
+    return result
+
+
+def _extract_docx_table_text(item: Table) -> str | None:
+    try:
+        if not _docx_table_has_content(item):
+            return None
+        return _build_docx_markdown_table(item)
+    except Exception as e:
+        logger.warning("Failed to extract table from DOC: %s", e, exc_info=e)
+        return None
+
+
+def _docx_table_has_content(item: Table) -> bool:
+    return any(any(cell.text.strip() for cell in row.cells) for row in item.rows)
+
+
+def _build_docx_markdown_table(item: Table) -> str:
+    cell_texts = [cell.text.replace("\n", "<br>") for cell in item.rows[0].cells]
+    markdown_table = f"| {' | '.join(cell_texts)} |\n"
+    markdown_table += f"| {' | '.join(['---'] * len(item.rows[0].cells))} |\n"
+    for row in item.rows[1:]:
+        row_cells = [cell.text.replace("\n", "<br>") for cell in row.cells]
+        markdown_table += "| " + " | ".join(row_cells) + " |\n"
+    return markdown_table
 
 
 def _download_file_content(http_client: HttpClientProtocol, file: File) -> bytes:
     """Download the content of a file based on its transfer method."""
+    if (
+        file.transfer_method == FileTransferMethod.REMOTE_URL
+        and file.remote_url is None
+    ):
+        msg = "Missing URL for remote file"
+        raise FileDownloadError(msg)
+
     try:
         if file.transfer_method == FileTransferMethod.REMOTE_URL:
-            if file.remote_url is None:
-                raise FileDownloadError("Missing URL for remote file")
             response = http_client.get(file.remote_url)
             response.raise_for_status()
             return response.content
         return file_manager.download(file)
     except Exception as e:
-        raise FileDownloadError(f"Error downloading file: {e!s}") from e
+        msg = f"Error downloading file: {e!s}"
+        raise FileDownloadError(msg) from e
 
 
 def _extract_text_from_file(
@@ -580,9 +648,8 @@ def _extract_text_from_file(
             unstructured_api_config=unstructured_api_config,
         )
     else:
-        raise UnsupportedFileTypeError(
-            "Unable to determine file type: MIME type or file extension is missing"
-        )
+        msg = "Unable to determine file type: MIME type or file extension is missing"
+        raise UnsupportedFileTypeError(msg)
     return extracted_text
 
 
@@ -622,9 +689,11 @@ def _extract_text_from_csv(file_content: bytes) -> str:
             processed_row = [cell.replace("\n", " ").replace("\r", "") for cell in row]
             markdown_table += "| " + " | ".join(processed_row) + " |\n"
 
-        return markdown_table
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from CSV: {e!s}") from e
+        msg = f"Failed to extract text from CSV: {e!s}"
+        raise TextExtractionError(msg) from e
+    else:
+        return markdown_table
 
 
 def _extract_text_from_excel(file_content: bytes) -> str:
@@ -645,8 +714,7 @@ def _extract_text_from_excel(file_content: bytes) -> str:
             data_rows.append(data_row)
 
         # Combine all rows into a single string
-        markdown_table = "\n".join([header_row, separator_row] + data_rows)
-        return markdown_table
+        return "\n".join([header_row, separator_row, *data_rows])
 
     try:
         excel_file = pd.ExcelFile(io.BytesIO(file_content))
@@ -654,11 +722,13 @@ def _extract_text_from_excel(file_content: bytes) -> str:
         for sheet_name in excel_file.sheet_names:
             try:
                 df = excel_file.parse(sheet_name=sheet_name)
-                df.dropna(how="all", inplace=True)
+                df = df.dropna(how="all")
 
                 # Combine multi-line text in each cell into a single line
                 df = df.map(
-                    lambda x: " ".join(str(x).splitlines()) if isinstance(x, str) else x
+                    lambda x: (
+                        " ".join(str(x).splitlines()) if isinstance(x, str) else x
+                    ),
                 )
 
                 # Combine multi-line text in column names into a single line
@@ -668,124 +738,117 @@ def _extract_text_from_excel(file_content: bytes) -> str:
 
                 # Manually construct the Markdown table
                 markdown_table += _construct_markdown_table(df) + "\n\n"
-            except Exception:
+            except (TypeError, ValueError):
                 continue
-        return markdown_table
     except Exception as e:
-        raise TextExtractionError(
-            f"Failed to extract text from Excel file: {e!s}"
-        ) from e
+        msg = f"Failed to extract text from Excel file: {e!s}"
+        raise TextExtractionError(msg) from e
+    else:
+        return markdown_table
 
 
 def _extract_text_from_ppt(
-    file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+    file_content: bytes,
+    *,
+    unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
-    from unstructured.partition.api import partition_via_api
-    from unstructured.partition.ppt import partition_ppt
-
-    api_key = unstructured_api_config.api_key or ""
-
     try:
         if unstructured_api_config.api_url:
-            with tempfile.NamedTemporaryFile(suffix=".ppt", delete=False) as temp_file:
-                temp_file.write(file_content)
-                temp_file.flush()
-                with pathlib.Path(temp_file.name).open("rb") as file:
-                    elements = partition_via_api(
-                        file=file,
-                        metadata_filename=temp_file.name,
-                        api_url=unstructured_api_config.api_url,
-                        api_key=api_key,
-                    )
-                pathlib.Path(temp_file.name).unlink()
+            from unstructured.partition.api import partition_via_api  # noqa: PLC0415
+
+            elements = _partition_file_via_unstructured_api(
+                partition_via_api,
+                file_content,
+                suffix=".ppt",
+                unstructured_api_config=unstructured_api_config,
+            )
         else:
+            from unstructured.partition.ppt import partition_ppt  # noqa: PLC0415
+
             with io.BytesIO(file_content) as file:
                 elements = partition_ppt(file=file)
         return "\n".join([getattr(element, "text", "") for element in elements])
 
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from PPTX: {e!s}") from e
+        msg = f"Failed to extract text from PPTX: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_pptx(
-    file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+    file_content: bytes,
+    *,
+    unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
-    from unstructured.partition.api import partition_via_api
-    from unstructured.partition.pptx import partition_pptx
-
-    api_key = unstructured_api_config.api_key or ""
-
     try:
         if unstructured_api_config.api_url:
-            with tempfile.NamedTemporaryFile(suffix=".pptx", delete=False) as temp_file:
-                temp_file.write(file_content)
-                temp_file.flush()
-                with pathlib.Path(temp_file.name).open("rb") as file:
-                    elements = partition_via_api(
-                        file=file,
-                        metadata_filename=temp_file.name,
-                        api_url=unstructured_api_config.api_url,
-                        api_key=api_key,
-                    )
-                pathlib.Path(temp_file.name).unlink()
+            from unstructured.partition.api import partition_via_api  # noqa: PLC0415
+
+            elements = _partition_file_via_unstructured_api(
+                partition_via_api,
+                file_content,
+                suffix=".pptx",
+                unstructured_api_config=unstructured_api_config,
+            )
         else:
+            from unstructured.partition.pptx import partition_pptx  # noqa: PLC0415
+
             with io.BytesIO(file_content) as file:
                 elements = partition_pptx(file=file)
         return "\n".join([getattr(element, "text", "") for element in elements])
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from PPTX: {e!s}") from e
+        msg = f"Failed to extract text from PPTX: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_epub(
-    file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+    file_content: bytes,
+    *,
+    unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
-    from unstructured.partition.api import partition_via_api
-    from unstructured.partition.epub import partition_epub
-
-    api_key = unstructured_api_config.api_key or ""
-
     try:
         if unstructured_api_config.api_url:
-            with tempfile.NamedTemporaryFile(suffix=".epub", delete=False) as temp_file:
-                temp_file.write(file_content)
-                temp_file.flush()
-                with pathlib.Path(temp_file.name).open("rb") as file:
-                    elements = partition_via_api(
-                        file=file,
-                        metadata_filename=temp_file.name,
-                        api_url=unstructured_api_config.api_url,
-                        api_key=api_key,
-                    )
-                pathlib.Path(temp_file.name).unlink()
+            from unstructured.partition.api import partition_via_api  # noqa: PLC0415
+
+            elements = _partition_file_via_unstructured_api(
+                partition_via_api,
+                file_content,
+                suffix=".epub",
+                unstructured_api_config=unstructured_api_config,
+            )
         else:
             pypandoc.download_pandoc()
+            from unstructured.partition.epub import partition_epub  # noqa: PLC0415
+
             with io.BytesIO(file_content) as file:
                 elements = partition_epub(file=file)
         return "\n".join([str(element) for element in elements])
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from EPUB: {e!s}") from e
+        msg = f"Failed to extract text from EPUB: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_eml(file_content: bytes) -> str:
-    from unstructured.partition.email import partition_email
-
     try:
+        from unstructured.partition.email import partition_email  # noqa: PLC0415
+
         with io.BytesIO(file_content) as file:
             elements = partition_email(file=file)
         return "\n".join([str(element) for element in elements])
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from EML: {e!s}") from e
+        msg = f"Failed to extract text from EML: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_msg(file_content: bytes) -> str:
-    from unstructured.partition.msg import partition_msg
-
     try:
+        from unstructured.partition.msg import partition_msg  # noqa: PLC0415
+
         with io.BytesIO(file_content) as file:
             elements = partition_msg(file=file)
         return "\n".join([str(element) for element in elements])
     except Exception as e:
-        raise TextExtractionError(f"Failed to extract text from MSG: {e!s}") from e
+        msg = f"Failed to extract text from MSG: {e!s}"
+        raise TextExtractionError(msg) from e
 
 
 def _extract_text_from_vtt(vtt_bytes: bytes) -> str:
@@ -833,23 +896,22 @@ def _extract_text_from_properties(file_content: bytes) -> str:
         lines = text.splitlines()
         result = []
         for line in lines:
-            line = line.strip()
+            stripped_line = line.strip()
             # Preserve comments and empty lines
-            if not line or line.startswith("#") or line.startswith("!"):
-                result.append(line)
+            if not stripped_line or stripped_line.startswith(("#", "!")):
+                result.append(stripped_line)
                 continue
 
-            if "=" in line:
-                key, value = line.split("=", 1)
-            elif ":" in line:
-                key, value = line.split(":", 1)
+            if "=" in stripped_line:
+                key, value = stripped_line.split("=", 1)
+            elif ":" in stripped_line:
+                key, value = stripped_line.split(":", 1)
             else:
-                key, value = line, ""
+                key, value = stripped_line, ""
 
             result.append(f"{key.strip()}: {value.strip()}")
 
         return "\n".join(result)
     except Exception as e:
-        raise TextExtractionError(
-            f"Failed to extract text from properties file: {e!s}"
-        ) from e
+        msg = f"Failed to extract text from properties file: {e!s}"
+        raise TextExtractionError(msg) from e

--- a/src/graphon/nodes/end/end_node.py
+++ b/src/graphon/nodes/end/end_node.py
@@ -22,18 +22,21 @@ class EndNode(Node[EndNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run node - collect all outputs at once.
+        """Run node - collect all outputs at once.
 
         This method runs after streaming is complete (if streaming was enabled).
         It collects all output variables and returns them.
+
+        Returns:
+            A succeeded `NodeRunResult` containing the collected outputs.
+
         """
         output_variables = self.node_data.outputs
 
         outputs = {}
         for variable_selector in output_variables:
             variable = self.graph_runtime_state.variable_pool.get(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
             value = variable.to_object() if variable is not None else None
             outputs[variable_selector.variable] = value
@@ -45,11 +48,11 @@ class EndNode(Node[EndNodeData]):
         )
 
     def get_streaming_template(self) -> Template:
-        """
-        Get the template for streaming.
+        """Get the template for streaming.
 
         Returns:
             Template instance for this End node
+
         """
         outputs_config = [
             {"variable": output.variable, "value_selector": output.value_selector}

--- a/src/graphon/nodes/end/entities.py
+++ b/src/graphon/nodes/end/entities.py
@@ -6,21 +6,18 @@ from graphon.nodes.base.entities import OutputVariableEntity
 
 
 class EndNodeData(BaseNodeData):
-    """
-    END Node Data.
-    """
+    """END Node Data."""
 
     type: NodeType = BuiltinNodeTypes.END
     outputs: list[OutputVariableEntity]
 
 
 class EndStreamParam(BaseModel):
-    """
-    EndStreamParam entity
-    """
+    """EndStreamParam entity"""
 
     end_dependencies: dict[str, list[str]] = Field(
-        ..., description="end dependencies (end node id -> dependent node ids)"
+        ...,
+        description="end dependencies (end node id -> dependent node ids)",
     )
     end_stream_variable_selector_mapping: dict[str, list[list[str]]] = Field(
         ...,

--- a/src/graphon/nodes/http_request/config.py
+++ b/src/graphon/nodes/http_request/config.py
@@ -28,12 +28,10 @@ def resolve_http_request_config(
     filters: Mapping[str, object] | None,
 ) -> HttpRequestNodeConfig:
     if not filters:
-        raise ValueError(
-            "http_request_config is required to build HTTP request default config"
-        )
+        msg = "http_request_config is required to build HTTP request default config"
+        raise ValueError(msg)
     config = filters.get(HTTP_REQUEST_CONFIG_FILTER_KEY)
     if not isinstance(config, HttpRequestNodeConfig):
-        raise ValueError(
-            "http_request_config must be an HttpRequestNodeConfig instance"
-        )
+        msg = "http_request_config must be an HttpRequestNodeConfig instance"
+        raise TypeError(msg)
     return config

--- a/src/graphon/nodes/http_request/entities.py
+++ b/src/graphon/nodes/http_request/entities.py
@@ -11,6 +11,12 @@ from graphon.enums import BuiltinNodeTypes, NodeType
 from graphon.http import HttpResponse
 
 HTTP_REQUEST_CONFIG_FILTER_KEY = "http_request_config"
+_BINARY_CONTENT_MAIN_TYPES = frozenset((
+    "application",
+    "image",
+    "audio",
+    "video",
+))
 
 
 class HttpRequestNodeAuthorizationConfig(BaseModel):
@@ -26,16 +32,16 @@ class HttpRequestNodeAuthorization(BaseModel):
     @field_validator("config", mode="before")
     @classmethod
     def check_config(
-        cls, v: HttpRequestNodeAuthorizationConfig, values: ValidationInfo
-    ):
-        """
-        Check config:
-        if type is no-auth, config should be None, otherwise it should be a dict.
-        """
+        cls,
+        v: Any,
+        values: ValidationInfo,
+    ) -> Any:
+        """Validate auth config for `no-auth` and API-key modes."""
         if values.data["type"] == "no-auth":
             return None
         if not v or not isinstance(v, dict):
-            raise ValueError("config should be a dict")
+            msg = "config should be a dict"
+            raise ValueError(msg)
 
         return v
 
@@ -49,13 +55,18 @@ class BodyData(BaseModel):
 
 class HttpRequestNodeBody(BaseModel):
     type: Literal[
-        "none", "form-data", "x-www-form-urlencoded", "raw-text", "json", "binary"
+        "none",
+        "form-data",
+        "x-www-form-urlencoded",
+        "raw-text",
+        "json",
+        "binary",
     ]
     data: Sequence[BodyData] = Field(default_factory=list)
 
     @field_validator("data", mode="before")
     @classmethod
-    def check_data(cls, v: Any):
+    def check_data(cls, v: Any) -> Any:
         """For compatibility, if body is not set, return empty list."""
         if not v:
             return []
@@ -89,9 +100,7 @@ class HttpRequestNodeConfig:
 
 
 class HttpRequestNodeData(BaseNodeData):
-    """
-    Code Node Data.
-    """
+    """Code Node Data."""
 
     type: NodeType = BuiltinNodeTypes.HTTP_REQUEST
     method: Literal[
@@ -123,20 +132,20 @@ class Response:
     headers: dict[str, str]
     response: HttpResponse
 
-    def __init__(self, response: HttpResponse):
+    def __init__(self, response: HttpResponse) -> None:
         self.response = response
         self.headers = dict(response.headers)
 
     @property
     def is_file(self):
-        """
-        Determine if the response contains a file by checking:
+        """Determine if the response contains a file by checking:
         1. Content-Disposition header (RFC 6266)
         2. Content characteristics
         3. MIME type analysis
         """
         content_type = self.content_type.split(";")[0].strip().lower()
         parsed_content_disposition = self.parsed_content_disposition
+        is_file = False
 
         # Check if it's explicitly marked as an attachment
         if parsed_content_disposition:
@@ -147,11 +156,13 @@ class Response:
                 parsed_content_disposition.get_filename()
             )  # Returns filename if present, None otherwise
             if disp_type == "attachment" or filename is not None:
-                return True
+                is_file = True
 
         # For 'text/' types, only 'csv' should be downloaded as file
+        if is_file:
+            return is_file
         if content_type.startswith("text/") and "csv" not in content_type:
-            return False
+            return is_file
 
         # For application types, try to detect if it's a text-based format
         if content_type.startswith("application/"):
@@ -167,7 +178,7 @@ class Response:
                     "graphql",
                 )
             ):
-                return False
+                return is_file
 
             # Try to detect if content is text-based by sampling first few bytes
             try:
@@ -186,22 +197,25 @@ class Response:
                     b"let ",
                 )
                 if any(marker in content_sample for marker in text_markers):
-                    return False
+                    return is_file
             except UnicodeDecodeError:
                 # If we can't decode as UTF-8, likely a binary file
-                return True
+                is_file = True
 
         # For other types, use MIME type analysis
         main_type, _ = mimetypes.guess_type(
-            "dummy" + (mimetypes.guess_extension(content_type) or "")
+            "dummy" + (mimetypes.guess_extension(content_type) or ""),
         )
         if main_type:
-            return main_type.split("/")[0] in ("application", "image", "audio", "video")
+            is_file = main_type.split("/")[0] in _BINARY_CONTENT_MAIN_TYPES
 
         # For unknown types, check if it's a media type
-        return any(
-            media_type in content_type for media_type in ("image/", "audio/", "video/")
-        )
+        if not is_file:
+            is_file = any(
+                media_type in content_type
+                for media_type in ("image/", "audio/", "video/")
+            )
+        return is_file
 
     @property
     def content_type(self) -> str:

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -2,10 +2,10 @@ import base64
 import json
 import secrets
 import string
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Literal
-from urllib.parse import urlencode, urlparse
+from urllib.parse import ParseResult, urlencode, urlparse
 
 from json_repair import repair_json
 
@@ -16,6 +16,7 @@ from graphon.variables.segments import ArrayFileSegment, FileSegment
 
 from ..protocols import FileManagerProtocol
 from .entities import (
+    BodyData,
     HttpRequestNodeAuthorization,
     HttpRequestNodeConfig,
     HttpRequestNodeData,
@@ -81,25 +82,27 @@ class Executor:
         ssl_verify: bool | None = None,
         http_client: HttpClientProtocol,
         file_manager: FileManagerProtocol,
-    ):
+    ) -> None:
         self._http_request_config = http_request_config
         # If authorization API key is present, convert it using
         # the variable pool.
         if node_data.authorization.type == "api-key":
             if node_data.authorization.config is None:
-                raise AuthorizationConfigError("authorization config is required")
+                msg = "authorization config is required"
+                raise AuthorizationConfigError(msg)
             node_data.authorization.config.api_key = variable_pool.convert_template(
-                node_data.authorization.config.api_key
+                node_data.authorization.config.api_key,
             ).text
             # Validate that API key is not empty after template conversion
             if (
                 not node_data.authorization.config.api_key
                 or not node_data.authorization.config.api_key.strip()
             ):
-                raise AuthorizationConfigError(
+                msg = (
                     "API key is required for authorization but was empty. "
                     "Please provide a valid API key."
                 )
+                raise AuthorizationConfigError(msg)
 
         self.url = node_data.url
         self.method = node_data.method
@@ -109,7 +112,8 @@ class Executor:
         if self.ssl_verify is None:
             self.ssl_verify = self._http_request_config.ssl_verify
         if not isinstance(self.ssl_verify, bool):
-            raise ValueError("ssl_verify must be a boolean")
+            msg = "ssl_verify must be a boolean"
+            raise TypeError(msg)
         self.params = None
         self.headers = {}
         self.content = None
@@ -129,24 +133,25 @@ class Executor:
         self.node_data = node_data
         self._initialize()
 
-    def _initialize(self):
+    def _initialize(self) -> None:
         self._init_url()
         self._init_params()
         self._init_headers()
         self._init_body()
 
-    def _init_url(self):
+    def _init_url(self) -> None:
         self.url = self.variable_pool.convert_template(self.node_data.url).text
 
         # check if url is a valid URL
         if not self.url:
-            raise InvalidURLError("url is required")
+            msg = "url is required"
+            raise InvalidURLError(msg)
         if not self.url.startswith(("http://", "https://")):
-            raise InvalidURLError("url should start with http:// or https://")
+            msg = "url should start with http:// or https://"
+            raise InvalidURLError(msg)
 
-    def _init_params(self):
-        """
-        Almost same as _init_headers(), difference:
+    def _init_params(self) -> None:
+        r"""Almost same as _init_headers(), difference:
         1. response a list tuple to support same key, like 'aa=1&aa=2'
         2. param value may have '\n', splitlines then extract
         the variable value.
@@ -169,9 +174,8 @@ class Executor:
         if result:
             self.params = result
 
-    def _init_headers(self):
-        """
-        Convert the header string of frontend to a dictionary.
+    def _init_headers(self) -> None:
+        r"""Convert the header string of frontend to a dictionary.
 
         Each line in the header string represents a key-value pair.
         Keys and values are separated by ':'.
@@ -191,179 +195,201 @@ class Executor:
             for key, *value in [line.split(":", 1)]
         }
 
-    def _init_body(self):
+    def _init_body(self) -> None:
         body = self.node_data.body
-        if body is not None:
-            data = body.data
-            match body.type:
-                case "none":
-                    self.content = ""
-                case "raw-text":
-                    if len(data) != 1:
-                        raise RequestBodyError(
-                            "raw-text body type should have exactly one item"
-                        )
-                    self.content = self.variable_pool.convert_template(
-                        data[0].value
-                    ).text
-                case "json":
-                    if len(data) != 1:
-                        raise RequestBodyError(
-                            "json body type should have exactly one item"
-                        )
-                    json_string = self.variable_pool.convert_template(
-                        data[0].value
-                    ).text
-                    try:
-                        repaired = repair_json(json_string)
-                        json_object = json.loads(repaired, strict=False)
-                    except json.JSONDecodeError as e:
-                        raise RequestBodyError(
-                            f"Failed to parse JSON: {json_string}"
-                        ) from e
-                    self.json = json_object
-                    # self.json = self._parse_object_contains_variables(json_object)
-                case "binary":
-                    if len(data) != 1:
-                        raise RequestBodyError(
-                            "binary body type should have exactly one item"
-                        )
-                    file_selector = data[0].file
-                    file_variable = self.variable_pool.get_file(file_selector)
-                    if file_variable is None:
-                        raise FileFetchError(
-                            f"cannot fetch file with selector {file_selector}"
-                        )
-                    file = file_variable.value
-                    self.content = self._file_manager.download(file)
-                case "x-www-form-urlencoded":
-                    form_data = {
-                        self.variable_pool.convert_template(
-                            item.key
-                        ).text: self.variable_pool.convert_template(item.value).text
-                        for item in data
-                    }
-                    self.data = form_data
-                case "form-data":
-                    form_data = {
-                        self.variable_pool.convert_template(
-                            item.key
-                        ).text: self.variable_pool.convert_template(item.value).text
-                        for item in filter(lambda item: item.type == "text", data)
-                    }
-                    file_selectors = {
-                        self.variable_pool.convert_template(item.key).text: item.file
-                        for item in filter(lambda item: item.type == "file", data)
-                    }
+        if body is None:
+            return
 
-                    # get files from file_selectors, with support for
-                    # array file variables
-                    files_list = []
-                    for key, selector in file_selectors.items():
-                        segment = self.variable_pool.get(selector)
-                        if isinstance(segment, FileSegment):
-                            files_list.append((key, [segment.value]))
-                        elif isinstance(segment, ArrayFileSegment):
-                            files_list.append((key, list(segment.value)))
+        match body.type:
+            case "none":
+                self._init_empty_body(body.data)
+            case "raw-text":
+                self._init_raw_text_body(body.data)
+            case "json":
+                self._init_json_body(body.data)
+            case "binary":
+                self._init_binary_body(body.data)
+            case "x-www-form-urlencoded":
+                self._init_urlencoded_body(body.data)
+            case "form-data":
+                self._init_form_data_body(body.data)
 
-                    # get files from file_manager
-                    files: dict[str, list[tuple[str | None, bytes, str]]] = {}
-                    for key, files_in_segment in files_list:
-                        for file in files_in_segment:
-                            if file.reference is not None or (
-                                file.transfer_method == FileTransferMethod.REMOTE_URL
-                                and file.remote_url is not None
-                            ):
-                                file_tuple = (
-                                    file.filename,
-                                    self._file_manager.download(file),
-                                    file.mime_type or "application/octet-stream",
-                                )
-                                if key not in files:
-                                    files[key] = []
-                                files[key].append(file_tuple)
+    @staticmethod
+    def _require_single_body_item(
+        data: Sequence[BodyData],
+        *,
+        body_type: str,
+    ) -> BodyData:
+        if len(data) != 1:
+            msg = f"{body_type} body type should have exactly one item"
+            raise RequestBodyError(msg)
+        return data[0]
 
-                    # convert files to list for httpx request
-                    # If there are no actual files, we still need to force
-                    # httpx to use `multipart/form-data`.
-                    # This is achieved by inserting a harmless placeholder file
-                    # that will be ignored by the server.
-                    if not files:
-                        self.files = [
-                            (
-                                "__multipart_placeholder__",
-                                ("", b"", "application/octet-stream"),
-                            )
-                        ]
-                    if files:
-                        self.files = []
-                        for key, file_tuples in files.items():
-                            for file_tuple in file_tuples:
-                                self.files.append((key, file_tuple))
+    def _init_empty_body(self, data: Sequence[BodyData]) -> None:
+        _ = data
+        self.content = ""
 
-                    self.data = form_data
+    def _init_raw_text_body(self, data: Sequence[BodyData]) -> None:
+        item = self._require_single_body_item(data, body_type="raw-text")
+        self.content = self.variable_pool.convert_template(item.value).text
+
+    def _init_json_body(self, data: Sequence[BodyData]) -> None:
+        item = self._require_single_body_item(data, body_type="json")
+        json_string = self.variable_pool.convert_template(item.value).text
+        try:
+            repaired = repair_json(json_string)
+            self.json = json.loads(repaired, strict=False)
+        except json.JSONDecodeError as e:
+            msg = f"Failed to parse JSON: {json_string}"
+            raise RequestBodyError(msg) from e
+
+    def _init_binary_body(self, data: Sequence[BodyData]) -> None:
+        item = self._require_single_body_item(data, body_type="binary")
+        file_selector = item.file
+        file_variable = self.variable_pool.get_file(file_selector)
+        if file_variable is None:
+            msg = f"cannot fetch file with selector {file_selector}"
+            raise FileFetchError(msg)
+        self.content = self._file_manager.download(file_variable.value)
+
+    def _init_urlencoded_body(self, data: Sequence[BodyData]) -> None:
+        self.data = {
+            self.variable_pool.convert_template(
+                item.key,
+            ).text: self.variable_pool.convert_template(item.value).text
+            for item in data
+        }
+
+    def _init_form_data_body(self, data: Sequence[BodyData]) -> None:
+        self.data = self._build_form_text_data(data)
+        file_selectors = self._build_form_file_selectors(data)
+        files_list = self._resolve_form_files(file_selectors)
+        self.files = self._build_request_files(files_list)
+
+    def _build_form_text_data(self, data: Sequence[BodyData]) -> dict[str, str]:
+        return {
+            self.variable_pool.convert_template(
+                item.key,
+            ).text: self.variable_pool.convert_template(item.value).text
+            for item in data
+            if item.type == "text"
+        }
+
+    def _build_form_file_selectors(
+        self,
+        data: Sequence[BodyData],
+    ) -> dict[str, Sequence[str]]:
+        return {
+            self.variable_pool.convert_template(item.key).text: item.file
+            for item in data
+            if item.type == "file"
+        }
+
+    def _resolve_form_files(
+        self,
+        file_selectors: Mapping[str, Sequence[str]],
+    ) -> list[tuple[str, list[Any]]]:
+        files_list: list[tuple[str, list[Any]]] = []
+        for key, selector in file_selectors.items():
+            segment = self.variable_pool.get(selector)
+            if isinstance(segment, FileSegment):
+                files_list.append((key, [segment.value]))
+            elif isinstance(segment, ArrayFileSegment):
+                files_list.append((key, list(segment.value)))
+        return files_list
+
+    def _build_request_files(
+        self,
+        files_list: Sequence[tuple[str, Sequence[Any]]],
+    ) -> list[tuple[str, tuple[str | None, bytes, str]]]:
+        files: list[tuple[str, tuple[str | None, bytes, str]]] = []
+        for key, files_in_segment in files_list:
+            for file in files_in_segment:
+                if file.reference is None and (
+                    file.transfer_method != FileTransferMethod.REMOTE_URL
+                    or file.remote_url is None
+                ):
+                    continue
+                files.append((
+                    key,
+                    (
+                        file.filename,
+                        self._file_manager.download(file),
+                        file.mime_type or "application/octet-stream",
+                    ),
+                ))
+
+        if files:
+            return files
+
+        return [
+            (
+                "__multipart_placeholder__",
+                ("", b"", "application/octet-stream"),
+            ),
+        ]
 
     def _assembling_headers(self) -> dict[str, Any]:
         authorization = deepcopy(self.auth)
         headers = deepcopy(self.headers) or {}
-        if self.auth.type == "api-key":
-            if self.auth.config is None:
-                raise AuthorizationConfigError("self.authorization config is required")
-            if authorization.config is None:
-                raise AuthorizationConfigError("authorization config is required")
+        headers.update(self._build_authorization_headers(authorization))
+        return self._apply_content_type_header(headers)
 
-            if not authorization.config.header:
-                authorization.config.header = "Authorization"
+    def _build_authorization_headers(
+        self,
+        authorization: HttpRequestNodeAuthorization,
+    ) -> dict[str, str]:
+        if self.auth.type != "api-key":
+            return {}
+        if self.auth.config is None:
+            msg = "self.authorization config is required"
+            raise AuthorizationConfigError(msg)
+        if authorization.config is None:
+            msg = "authorization config is required"
+            raise AuthorizationConfigError(msg)
 
-            if self.auth.config.type == "bearer" and authorization.config.api_key:
-                headers[authorization.config.header] = (
-                    f"Bearer {authorization.config.api_key}"
-                )
-            elif self.auth.config.type == "basic" and authorization.config.api_key:
-                credentials = authorization.config.api_key
-                if ":" in credentials:
-                    encoded_credentials = base64.b64encode(
-                        credentials.encode("utf-8")
-                    ).decode("utf-8")
-                else:
-                    encoded_credentials = credentials
-                headers[authorization.config.header] = f"Basic {encoded_credentials}"
-            elif (
-                self.auth.config.type == "custom"
-                and authorization.config.header
-                and authorization.config.api_key
-            ):
-                headers[authorization.config.header] = authorization.config.api_key
+        authorization.config.header = authorization.config.header or "Authorization"
+        header = authorization.config.header
+        api_key = authorization.config.api_key
 
-        # Handle Content-Type for multipart/form-data requests
-        # Fix for issue #23829: Missing boundary when using multipart/form-data
+        match authorization.config.type:
+            case "bearer" if api_key:
+                return {header: f"Bearer {api_key}"}
+            case "basic" if api_key:
+                return {header: f"Basic {self._encode_basic_credentials(api_key)}"}
+            case "custom" if header and api_key:
+                return {header: api_key}
+            case _:
+                return {}
+
+    @staticmethod
+    def _encode_basic_credentials(credentials: str) -> str:
+        if ":" not in credentials:
+            return credentials
+        return base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
+
+    def _apply_content_type_header(self, headers: dict[str, str]) -> dict[str, str]:
         body = self.node_data.body
-        if body and body.type == "form-data":
-            # For multipart/form-data with files (including placeholder files),
-            # remove any manually set Content-Type header to let httpx handle
-            # For multipart/form-data, if any files are present
-            # (including placeholder files), we must remove any manually
-            # set Content-Type header. This is because httpx needs to
-            # automatically set the Content-Type and boundary for multipart
-            # encoding whenever files are included, even if they are
-            # placeholders. This avoids boundary issues and invalid
-            # requests.
-            if self.files:
-                # Remove Content-Type if it was manually set to avoid boundary issues
-                headers = {
-                    k: v for k, v in headers.items() if k.lower() != "content-type"
-                }
-            # No files at all, set Content-Type manually
-            elif "content-type" not in (k.lower() for k in headers):
-                headers["Content-Type"] = "multipart/form-data"
-        elif (
-            body
-            and body.type in BODY_TYPE_TO_CONTENT_TYPE
-            and "content-type" not in (k.lower() for k in headers)
-        ):
-            # Set Content-Type for other body types
-            headers["Content-Type"] = BODY_TYPE_TO_CONTENT_TYPE[body.type]
+        if body is None:
+            return headers
 
+        lower_headers = {key.lower() for key in headers}
+        if body.type == "form-data":
+            if self.files:
+                return {
+                    key: value
+                    for key, value in headers.items()
+                    if key.lower() != "content-type"
+                }
+            if "content-type" not in lower_headers:
+                headers["Content-Type"] = "multipart/form-data"
+            return headers
+
+        if (
+            body.type in BODY_TYPE_TO_CONTENT_TYPE
+            and "content-type" not in lower_headers
+        ):
+            headers["Content-Type"] = BODY_TYPE_TO_CONTENT_TYPE[body.type]
         return headers
 
     def _validate_and_parse_response(self, response: HttpResponse) -> Response:
@@ -375,19 +401,18 @@ class Executor:
             else self._http_request_config.max_text_size
         )
         if executor_response.size > threshold_size:
-            raise ResponseSizeError(
+            msg = (
                 f"{'File' if executor_response.is_file else 'Text'} size is too large,"
                 f" max size is {threshold_size / 1024 / 1024:.2f} MB,"
                 f" but current size is {executor_response.readable_size}."
             )
+            raise ResponseSizeError(msg)
 
         return executor_response
 
     def _do_http_request(self, headers: dict[str, Any]) -> HttpResponse:
-        """
-        do http request depending on api bundle
-        """
-        _METHOD_MAP: dict[str, Callable[..., HttpResponse]] = {
+        """Do http request depending on api bundle"""
+        method_map: dict[str, Callable[..., HttpResponse]] = {
             "get": self._http_client.get,
             "head": self._http_client.head,
             "post": self._http_client.post,
@@ -396,8 +421,9 @@ class Executor:
             "patch": self._http_client.patch,
         }
         method_lc = self.method.lower()
-        if method_lc not in _METHOD_MAP:
-            raise InvalidHttpMethodError(f"Invalid http method {self.method}")
+        if method_lc not in method_map:
+            msg = f"Invalid http method {self.method}"
+            raise InvalidHttpMethodError(msg)
 
         request_args: dict[str, Any] = {
             "data": self.data,
@@ -412,15 +438,14 @@ class Executor:
         }
         # request_args = {k: v for k, v in request_args.items() if v is not None}
         try:
-            response = _METHOD_MAP[method_lc](
+            response = method_map[method_lc](
                 url=self.url,
                 **request_args,
                 max_retries=self.max_retries,
             )
         except self._http_client.max_retries_exceeded_error as e:
-            raise HttpRequestNodeError(
-                f"Reached maximum retries for URL {self.url}"
-            ) from e
+            msg = f"Reached maximum retries for URL {self.url}"
+            raise HttpRequestNodeError(msg) from e
         except self._http_client.request_error as e:
             raise HttpRequestNodeError(str(e)) from e
         return response
@@ -435,96 +460,15 @@ class Executor:
 
     def to_log(self):
         url_parts = urlparse(self.url)
-        path = url_parts.path or "/"
-
-        # Add query parameters
-        if self.params:
-            query_string = urlencode(self.params)
-            path += f"?{query_string}"
-        elif url_parts.query:
-            path += f"?{url_parts.query}"
-
+        path = self._build_log_path(url_parts)
         raw = f"{self.method.upper()} {path} HTTP/1.1\r\n"
         raw += f"Host: {url_parts.netloc}\r\n"
 
-        headers = self._assembling_headers()
-        body = self.node_data.body
         boundary = f"----WebKitFormBoundary{_generate_random_string(16)}"
-        if body:
-            if (
-                "content-type" not in (k.lower() for k in self.headers)
-                and body.type in BODY_TYPE_TO_CONTENT_TYPE
-            ):
-                headers["Content-Type"] = BODY_TYPE_TO_CONTENT_TYPE[body.type]
-            if body.type == "form-data":
-                headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
-        for k, v in headers.items():
-            if self.auth.type == "api-key":
-                authorization_header = "Authorization"
-                if self.auth.config and self.auth.config.header:
-                    authorization_header = self.auth.config.header
-                if k.lower() == authorization_header.lower():
-                    raw += f"{k}: {'*' * len(v)}\r\n"
-                    continue
-            raw += f"{k}: {v}\r\n"
+        headers = self._build_log_headers(boundary)
+        raw += self._render_log_headers(headers)
 
-        body_string = ""
-        # Only log actual files if present.
-        # '__multipart_placeholder__' is inserted to force multipart
-        # encoding, but it is not a real file.
-        # This prevents logging meaningless placeholder entries.
-        if self.files and not all(
-            f[0] == "__multipart_placeholder__" for f in self.files
-        ):
-            for file_entry in self.files:
-                # file_entry should be (key, filename, content, mime_type),
-                # but this handles edge cases.
-                if len(file_entry) != 2 or len(file_entry[1]) < 2:
-                    continue  # skip malformed entries
-                key = file_entry[0]
-                content = file_entry[1][1]
-                body_string += f"--{boundary}\r\n"
-                body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
-                # decode content safely
-                # Do not decode binary content; use a placeholder with
-                # file metadata instead.
-                # Includes filename, size, and MIME type for better logging context.
-                file_mime_type = (
-                    file_entry[1][2] if len(file_entry[1]) > 2 else "unknown"
-                )
-                body_string += (
-                    f"<file_content_binary: '{file_entry[1][0] or 'unknown'}', "
-                    f"type='{file_mime_type}', "
-                    f"size={len(content)} bytes>\r\n"
-                )
-            body_string += f"--{boundary}--\r\n"
-        elif self.node_data.body:
-            if self.content:
-                # If content is bytes, do not decode it; show a placeholder with size.
-                # Provides content size information for binary data without
-                # exposing the raw bytes.
-                if isinstance(self.content, bytes):
-                    body_string = f"<binary_content: size={len(self.content)} bytes>"
-                else:
-                    body_string = self.content
-            elif self.data and self.node_data.body.type == "x-www-form-urlencoded":
-                body_string = urlencode(self.data)
-            elif self.data and self.node_data.body.type == "form-data":
-                for key, value in self.data.items():
-                    body_string += f"--{boundary}\r\n"
-                    body_string += (
-                        f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
-                    )
-                    body_string += f"{value}\r\n"
-                body_string += f"--{boundary}--\r\n"
-            elif self.json:
-                body_string = json.dumps(self.json)
-            elif self.node_data.body.type == "raw-text":
-                if len(self.node_data.body.data) != 1:
-                    raise RequestBodyError(
-                        "raw-text body type should have exactly one item"
-                    )
-                body_string = self.node_data.body.data[0].value
+        body_string = self._build_log_body(boundary)
         if body_string:
             raw += f"Content-Length: {len(body_string)}\r\n"
         raw += "\r\n"  # Empty line between headers and body
@@ -532,10 +476,107 @@ class Executor:
 
         return raw
 
+    def _build_log_path(self, url_parts: ParseResult) -> str:
+        path = url_parts.path or "/"
+        if self.params:
+            return path + f"?{urlencode(self.params)}"
+        if url_parts.query:
+            return path + f"?{url_parts.query}"
+        return path
+
+    def _build_log_headers(self, boundary: str) -> dict[str, Any]:
+        headers = self._assembling_headers()
+        body = self.node_data.body
+        if body is None:
+            return headers
+        if (
+            "content-type" not in (k.lower() for k in self.headers)
+            and body.type in BODY_TYPE_TO_CONTENT_TYPE
+        ):
+            headers["Content-Type"] = BODY_TYPE_TO_CONTENT_TYPE[body.type]
+        if body.type == "form-data":
+            headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+        return headers
+
+    def _render_log_headers(self, headers: Mapping[str, Any]) -> str:
+        raw_headers = ""
+        for key, value in headers.items():
+            masked_value = self._mask_log_header_value(key, str(value))
+            raw_headers += f"{key}: {masked_value}\r\n"
+        return raw_headers
+
+    def _mask_log_header_value(self, key: str, value: str) -> str:
+        if self.auth.type != "api-key":
+            return value
+        authorization_header = "Authorization"
+        if self.auth.config and self.auth.config.header:
+            authorization_header = self.auth.config.header
+        if key.lower() == authorization_header.lower():
+            return "*" * len(value)
+        return value
+
+    def _build_log_body(self, boundary: str) -> str:
+        body_string = ""
+        if self._has_loggable_files():
+            body_string = self._build_file_log_body(boundary)
+        elif self.node_data.body is None:
+            body_string = ""
+        elif self.content:
+            body_string = self._build_content_log_body()
+        elif self.data and self.node_data.body.type == "x-www-form-urlencoded":
+            body_string = urlencode(self.data)
+        elif self.data and self.node_data.body.type == "form-data":
+            body_string = self._build_form_data_log_body(boundary)
+        elif self.json:
+            body_string = json.dumps(self.json)
+        elif self.node_data.body.type == "raw-text":
+            item = self._require_single_body_item(
+                self.node_data.body.data,
+                body_type="raw-text",
+            )
+            body_string = item.value
+        return body_string
+
+    def _has_loggable_files(self) -> bool:
+        return bool(self.files) and not all(
+            file_entry[0] == "__multipart_placeholder__" for file_entry in self.files
+        )
+
+    def _build_file_log_body(self, boundary: str) -> str:
+        body_string = ""
+        for file_entry in self.files or []:
+            if len(file_entry) != 2 or len(file_entry[1]) < 2:
+                continue
+            key = file_entry[0]
+            filename, content = file_entry[1][0], file_entry[1][1]
+            file_mime_type = file_entry[1][2] if len(file_entry[1]) > 2 else "unknown"
+            body_string += f"--{boundary}\r\n"
+            body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
+            body_string += (
+                f"<file_content_binary: '{filename or 'unknown'}', "
+                f"type='{file_mime_type}', "
+                f"size={len(content)} bytes>\r\n"
+            )
+        body_string += f"--{boundary}--\r\n"
+        return body_string
+
+    def _build_content_log_body(self) -> str:
+        if isinstance(self.content, bytes):
+            return f"<binary_content: size={len(self.content)} bytes>"
+        return str(self.content)
+
+    def _build_form_data_log_body(self, boundary: str) -> str:
+        body_string = ""
+        for key, value in (self.data or {}).items():
+            body_string += f"--{boundary}\r\n"
+            body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
+            body_string += f"{value}\r\n"
+        body_string += f"--{boundary}--\r\n"
+        return body_string
+
 
 def _generate_random_string(n: int) -> str:
-    """
-    Generate a random string of lowercase ASCII letters.
+    """Generate a random string of lowercase ASCII letters.
 
     Args:
         n (int): The length of the random string to generate.
@@ -546,5 +587,6 @@ def _generate_random_string(n: int) -> str:
     Example:
         >>> _generate_random_string(5)
         'abcde'
+
     """
     return "".join(secrets.choice(string.ascii_lowercase) for _ in range(n))

--- a/src/graphon/nodes/http_request/node.py
+++ b/src/graphon/nodes/http_request/node.py
@@ -23,6 +23,7 @@ from graphon.variables.segments import ArrayFileSegment
 from .config import build_http_request_config, resolve_http_request_config
 from .entities import (
     HTTP_REQUEST_CONFIG_FILTER_KEY,
+    BodyData,
     HttpRequestNodeConfig,
     HttpRequestNodeData,
     HttpRequestNodeTimeout,
@@ -43,7 +44,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -55,7 +56,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
         file_reference_factory: FileReferenceFactoryProtocol,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -70,7 +71,8 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
         if not filters or HTTP_REQUEST_CONFIG_FILTER_KEY not in filters:
             http_request_config = build_http_request_config()
@@ -163,7 +165,8 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
             )
 
     def _get_request_timeout(
-        self, node_data: HttpRequestNodeData
+        self,
+        node_data: HttpRequestNodeData,
     ) -> HttpRequestNodeTimeout:
         default_timeout = self._http_request_config.default_timeout()
         timeout = node_data.timeout
@@ -185,92 +188,100 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
         node_id: str,
         node_data: HttpRequestNodeData,
     ) -> Mapping[str, Sequence[str]]:
+        _ = graph_config
+        selectors = cls._extract_template_selectors(
+            node_data.url,
+            node_data.headers,
+            node_data.params,
+        )
+        selectors.extend(cls._extract_body_selectors(node_data))
+        return {
+            node_id + "." + selector.variable: selector.value_selector
+            for selector in selectors
+        }
+
+    @staticmethod
+    def _extract_template_selectors(*templates: str) -> list[VariableSelector]:
         selectors: list[VariableSelector] = []
-        selectors += variable_template_parser.extract_selectors_from_template(
-            node_data.url
-        )
-        selectors += variable_template_parser.extract_selectors_from_template(
-            node_data.headers
-        )
-        selectors += variable_template_parser.extract_selectors_from_template(
-            node_data.params
-        )
-        if node_data.body:
-            body_type = node_data.body.type
-            data = node_data.body.data
-            match body_type:
-                case "none":
-                    pass
-                case "binary":
-                    if len(data) != 1:
-                        raise RequestBodyError(
-                            "invalid body data, should have only one item"
-                        )
-                    selector = data[0].file
-                    selectors.append(
-                        VariableSelector(
-                            variable="#" + ".".join(selector) + "#",
-                            value_selector=selector,
-                        )
-                    )
-                case "json" | "raw-text":
-                    if len(data) != 1:
-                        raise RequestBodyError(
-                            "invalid body data, should have only one item"
-                        )
-                    selectors += (
-                        variable_template_parser.extract_selectors_from_template(
-                            data[0].key
-                        )
-                    )
-                    selectors += (
-                        variable_template_parser.extract_selectors_from_template(
-                            data[0].value
-                        )
-                    )
-                case "x-www-form-urlencoded":
-                    for item in data:
-                        selectors += (
-                            variable_template_parser.extract_selectors_from_template(
-                                item.key
-                            )
-                        )
-                        selectors += (
-                            variable_template_parser.extract_selectors_from_template(
-                                item.value
-                            )
-                        )
-                case "form-data":
-                    for item in data:
-                        selectors += (
-                            variable_template_parser.extract_selectors_from_template(
-                                item.key
-                            )
-                        )
-                        if item.type == "text":
-                            selectors += variable_template_parser.extract_selectors_from_template(
-                                item.value
-                            )
-                        elif item.type == "file":
-                            selectors.append(
-                                VariableSelector(
-                                    variable="#" + ".".join(item.file) + "#",
-                                    value_selector=item.file,
-                                )
-                            )
-
-        mapping = {}
-        for selector_iter in selectors:
-            mapping[node_id + "." + selector_iter.variable] = (
-                selector_iter.value_selector
+        for template in templates:
+            selectors.extend(
+                variable_template_parser.extract_selectors_from_template(template),
             )
+        return selectors
 
-        return mapping
+    @classmethod
+    def _extract_body_selectors(
+        cls,
+        node_data: HttpRequestNodeData,
+    ) -> list[VariableSelector]:
+        if node_data.body is None or node_data.body.type == "none":
+            return []
+        match node_data.body.type:
+            case "binary":
+                selectors = cls._extract_binary_body_selectors(node_data.body.data)
+            case "json" | "raw-text":
+                selectors = cls._extract_template_body_selectors(node_data.body.data)
+            case "x-www-form-urlencoded":
+                selectors = cls._extract_key_value_body_selectors(node_data.body.data)
+            case "form-data":
+                selectors = cls._extract_form_data_body_selectors(node_data.body.data)
+            case _:
+                selectors = []
+        return selectors
+
+    @staticmethod
+    def _build_file_selector(selector: Sequence[str]) -> VariableSelector:
+        return VariableSelector(
+            variable="#" + ".".join(selector) + "#",
+            value_selector=selector,
+        )
+
+    @classmethod
+    def _extract_binary_body_selectors(
+        cls,
+        data: Sequence[BodyData],
+    ) -> list[VariableSelector]:
+        if len(data) != 1:
+            msg = "invalid body data, should have only one item"
+            raise RequestBodyError(msg)
+        return [cls._build_file_selector(data[0].file)]
+
+    @classmethod
+    def _extract_template_body_selectors(
+        cls,
+        data: Sequence[BodyData],
+    ) -> list[VariableSelector]:
+        if len(data) != 1:
+            msg = "invalid body data, should have only one item"
+            raise RequestBodyError(msg)
+        return cls._extract_template_selectors(data[0].key, data[0].value)
+
+    @classmethod
+    def _extract_key_value_body_selectors(
+        cls,
+        data: Sequence[BodyData],
+    ) -> list[VariableSelector]:
+        selectors: list[VariableSelector] = []
+        for item in data:
+            selectors.extend(cls._extract_template_selectors(item.key, item.value))
+        return selectors
+
+    @classmethod
+    def _extract_form_data_body_selectors(
+        cls,
+        data: Sequence[BodyData],
+    ) -> list[VariableSelector]:
+        selectors: list[VariableSelector] = []
+        for item in data:
+            selectors.extend(cls._extract_template_selectors(item.key))
+            if item.type == "text":
+                selectors.extend(cls._extract_template_selectors(item.value))
+                continue
+            selectors.append(cls._build_file_selector(item.file))
+        return selectors
 
     def extract_files(self, url: str, response: Response) -> ArrayFileSegment:
-        """
-        Extract files from response by checking both Content-Type header and URL
-        """
+        """Extract files from response by checking both Content-Type header and URL"""
         files: list[File] = []
         is_file = response.is_file
         content_type = response.content_type
@@ -287,7 +298,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
                 # If filename is available from content-disposition,
                 # use it to guess the content type
                 content_disposition_type = mimetypes.guess_type(
-                    content_disposition_filename
+                    content_disposition_filename,
                 )[0]
 
         # Guess file extension from URL or Content-Type header
@@ -309,7 +320,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
             mapping={
                 "tool_file_id": tool_file.id,
                 "transfer_method": FileTransferMethod.TOOL_FILE,
-            }
+            },
         )
         files.append(file)
 

--- a/src/graphon/nodes/human_input/entities.py
+++ b/src/graphon/nodes/human_input/entities.py
@@ -20,7 +20,7 @@ from graphon.variables.consts import SELECTORS_LENGTH
 from .enums import ButtonStyle, FormInputType, PlaceholderType, TimeoutUnit
 
 _OUTPUT_VARIABLE_PATTERN = re.compile(
-    r"\{\{#\$output\.(?P<field_name>[a-zA-Z_][a-zA-Z0-9_]{0,29})#\}\}"
+    r"\{\{#\$output\.(?P<field_name>[a-zA-Z_][a-zA-Z0-9_]{0,29})#\}\}",
 )
 
 
@@ -46,10 +46,11 @@ class FormInputDefault(BaseModel):
         if self.type == PlaceholderType.CONSTANT:
             return self
         if len(self.selector) < SELECTORS_LENGTH:
-            raise ValueError(
+            msg = (
                 f"the length of selector should be at least {SELECTORS_LENGTH}, "
                 f"selector={self.selector}"
             )
+            raise ValueError(msg)
         return self
 
 
@@ -79,11 +80,12 @@ class UserAction(BaseModel):
     @classmethod
     def _validate_id(cls, value: str) -> str:
         if not _IDENTIFIER_PATTERN.match(value):
-            raise ValueError(
+            msg = (
                 f"'{value}' is not a valid identifier. It must start with "
                 f"a letter or underscore, and contain only letters, "
                 f"numbers, or underscores."
             )
+            raise ValueError(msg)
         return value
 
 
@@ -104,7 +106,8 @@ class HumanInputNodeData(BaseNodeData):
         for form_input in inputs:
             name = form_input.output_variable_name
             if name in seen_names:
-                raise ValueError(f"duplicated output_variable_name '{name}' in inputs")
+                msg = f"duplicated output_variable_name '{name}' in inputs"
+                raise ValueError(msg)
             seen_names.add(name)
         return inputs
 
@@ -115,7 +118,8 @@ class HumanInputNodeData(BaseNodeData):
         for action in user_actions:
             action_id = action.id
             if action_id in seen_ids:
-                raise ValueError(f"duplicated user action id '{action_id}'")
+                msg = f"duplicated user action id '{action_id}'"
+                raise ValueError(msg)
             seen_ids.add(action_id)
         return user_actions
 
@@ -124,7 +128,8 @@ class HumanInputNodeData(BaseNodeData):
             return start_time + timedelta(hours=self.timeout)
         if self.timeout_unit == TimeoutUnit.DAY:
             return start_time + timedelta(days=self.timeout)
-        raise AssertionError("unknown timeout unit.")
+        msg = "unknown timeout unit."
+        raise AssertionError(msg)
 
     def outputs_field_names(self) -> Sequence[str]:
         return [
@@ -133,7 +138,8 @@ class HumanInputNodeData(BaseNodeData):
         ]
 
     def extract_variable_selector_to_variable_mapping(
-        self, node_id: str
+        self,
+        node_id: str,
     ) -> Mapping[str, Sequence[str]]:
         variable_mappings: dict[str, Sequence[str]] = {}
 
@@ -145,7 +151,7 @@ class HumanInputNodeData(BaseNodeData):
                     f"{node_id}.#{'.'.join(selector[:SELECTORS_LENGTH])}#"
                 )
                 variable_mappings[qualified_variable_mapping_key] = list(
-                    selector[:SELECTORS_LENGTH]
+                    selector[:SELECTORS_LENGTH],
                 )
 
         form_template_parser = VariableTemplateParser(template=self.form_content)
@@ -154,8 +160,8 @@ class HumanInputNodeData(BaseNodeData):
             for selector in form_template_parser.extract_variable_selectors()
         ])
 
-        for input in self.inputs:
-            default_value = input.default
+        for form_input in self.inputs:
+            default_value = form_input.default
             if default_value is None:
                 continue
             if default_value.type == PlaceholderType.CONSTANT:
@@ -167,9 +173,7 @@ class HumanInputNodeData(BaseNodeData):
         return variable_mappings
 
     def find_action_text(self, action_id: str) -> str:
-        """
-        Resolve action display text by id.
-        """
+        """Resolve action display text by id."""
         for action in self.user_actions:
             if action.id == action_id:
                 return action.title
@@ -206,9 +210,8 @@ def validate_human_input_submission(
 ) -> None:
     available_actions = {action.id for action in user_actions}
     if selected_action_id not in available_actions:
-        raise HumanInputSubmissionValidationError(
-            f"Invalid action: {selected_action_id}"
-        )
+        msg = f"Invalid action: {selected_action_id}"
+        raise HumanInputSubmissionValidationError(msg)
 
     provided_inputs = set(form_data.keys())
     missing_inputs = [
@@ -219,6 +222,5 @@ def validate_human_input_submission(
 
     if missing_inputs:
         missing_list = ", ".join(missing_inputs)
-        raise HumanInputSubmissionValidationError(
-            f"Missing required inputs: {missing_list}"
-        )
+        msg = f"Missing required inputs: {missing_list}"
+        raise HumanInputSubmissionValidationError(msg)

--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -63,7 +63,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -71,24 +71,26 @@ class HumanInputNode(Node[HumanInputNodeData]):
         form_repository: object | None = None,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
         resolved_runtime = runtime
         if resolved_runtime is None:
-            raise ValueError("runtime is required")
+            msg = "runtime is required"
+            raise ValueError(msg)
         if form_repository is not None:
             with_form_repository = getattr(
-                resolved_runtime, "with_form_repository", None
+                resolved_runtime,
+                "with_form_repository",
+                None,
             )
             if callable(with_form_repository):
                 updated_runtime = with_form_repository(form_repository)
                 if not isinstance(updated_runtime, HumanInputNodeRuntimeProtocol):
-                    raise TypeError(
-                        "with_form_repository() must return a HumanInput runtime"
-                    )
+                    msg = "with_form_repository() must return a HumanInput runtime"
+                    raise TypeError(msg)
                 resolved_runtime = updated_runtime
         self._runtime: HumanInputNodeRuntimeProtocol = resolved_runtime
 
@@ -99,7 +101,6 @@ class HumanInputNode(Node[HumanInputNodeData]):
 
     def _resolve_branch_selection(self) -> str | None:
         """Determine the branch handle selected by human input if available."""
-
         variable_pool = self.graph_runtime_state.variable_pool
 
         for key in self._BRANCH_SELECTION_KEYS:
@@ -153,16 +154,18 @@ class HumanInputNode(Node[HumanInputNodeData]):
 
         return None
 
-    def _form_to_pause_event(self, form_entity: HumanInputFormStateProtocol):
+    def _form_to_pause_event(
+        self,
+        form_entity: HumanInputFormStateProtocol,
+    ) -> PauseRequestedEvent:
         required_event = self._human_input_required_event(form_entity)
-        pause_requested_event = PauseRequestedEvent(reason=required_event)
-        return pause_requested_event
+        return PauseRequestedEvent(reason=required_event)
 
     def resolve_default_values(self) -> Mapping[str, Any]:
         variable_pool = self.graph_runtime_state.variable_pool
         resolved_defaults: dict[str, Any] = {}
-        for input in self._node_data.inputs:
-            if (default_value := input.default) is None:
+        for form_input in self._node_data.inputs:
+            if (default_value := form_input.default) is None:
                 continue
             if default_value.type == PlaceholderType.CONSTANT:
                 continue
@@ -170,16 +173,17 @@ class HumanInputNode(Node[HumanInputNodeData]):
             if resolved_value is None:
                 # TODO: How should we handle this?
                 continue
-            resolved_defaults[input.output_variable_name] = (
+            resolved_defaults[form_input.output_variable_name] = (
                 WorkflowRuntimeTypeConverter().value_to_json_encodable_recursive(
-                    resolved_value.value
+                    resolved_value.value,
                 )
             )
 
         return resolved_defaults
 
     def _human_input_required_event(
-        self, form_entity: HumanInputFormStateProtocol
+        self,
+        form_entity: HumanInputFormStateProtocol,
     ) -> HumanInputRequired:
         node_data = self._node_data
         resolved_default_values = self.resolve_default_values()
@@ -195,8 +199,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
 
     @override
     def _run(self) -> Generator[NodeEventBase, None, None]:
-        """
-        Execute the human input node.
+        """Execute the human input node.
 
         This method will:
         1. Generate a unique form ID
@@ -205,6 +208,13 @@ class HumanInputNode(Node[HumanInputNodeData]):
         4. Send form via configured delivery methods
         5. Suspend workflow execution
         6. Wait for form submission to resume
+
+        Yields:
+            Node events describing form suspension, timeout, or submitted output.
+
+        Raises:
+            AssertionError: If a submitted form is missing its selected action id.
+
         """
         form = self._runtime.get_form(node_id=self.id)
         if form is None:
@@ -223,10 +233,10 @@ class HumanInputNode(Node[HumanInputNodeData]):
             yield self._form_to_pause_event(form_entity)
             return
 
-        if form.status in {
+        if form.status in frozenset((
             HumanInputFormStatus.TIMEOUT,
             HumanInputFormStatus.EXPIRED,
-        } or form.expiration_time <= datetime.now(UTC).replace(tzinfo=None):
+        )) or form.expiration_time <= datetime.now(UTC).replace(tzinfo=None):
             yield HumanInputFormTimeoutEvent(
                 node_title=self._node_data.title,
                 expiration_time=form.expiration_time,
@@ -236,7 +246,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
                     status=WorkflowNodeExecutionStatus.SUCCEEDED,
                     outputs={self._OUTPUT_FIELD_ACTION_ID: ""},
                     edge_source_handle=self._TIMEOUT_HANDLE,
-                )
+                ),
             )
             return
 
@@ -246,10 +256,11 @@ class HumanInputNode(Node[HumanInputNodeData]):
 
         selected_action_id = form.selected_action_id
         if selected_action_id is None:
-            raise AssertionError(
+            msg = (
                 f"selected_action_id should not be None when form submitted, "
                 f"form_id={form.id}"
             )
+            raise AssertionError(msg)
         submitted_data = form.submitted_data or {}
         outputs: dict[str, Any] = dict(submitted_data)
         outputs[self._OUTPUT_FIELD_ACTION_ID] = selected_action_id
@@ -274,17 +285,20 @@ class HumanInputNode(Node[HumanInputNodeData]):
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
                 outputs=outputs,
                 edge_source_handle=selected_action_id,
-            )
+            ),
         )
 
     def render_form_content_before_submission(self) -> str:
-        """
-        Process form content by substituting variables.
+        """Process form content by substituting variables.
 
         This method should:
         1. Parse the form_content markdown
         2. Substitute {{#node_name.var_name#}} with actual values
         3. Keep {{#$output.field_name#}} placeholders for form inputs
+
+        Returns:
+            Rendered markdown with runtime variable references resolved.
+
         """
         rendered_form_content = self.graph_runtime_state.variable_pool.convert_template(
             self._node_data.form_content,
@@ -297,9 +311,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
         outputs: Mapping[str, Any],
         field_names: Sequence[str],
     ) -> str:
-        """
-        Replace {{#$output.xxx#}} placeholders with submitted values.
-        """
+        """Replace {{#$output.xxx#}} placeholders with submitted values."""
         rendered_content = form_content
         for field_name in field_names:
             placeholder = "{{#$output." + field_name + "#}}"
@@ -322,11 +334,16 @@ class HumanInputNode(Node[HumanInputNodeData]):
         node_id: str,
         node_data: HumanInputNodeData,
     ) -> Mapping[str, Sequence[str]]:
-        """
-        Extract variable selectors referenced in form content and input default values.
+        """Extract variable selectors referenced in form content
+        and input default values.
 
         This method should parse:
         1. Variables referenced in form_content ({{#node_name.var_name#}})
         2. Variables referenced in input default values
+
+        Returns:
+            Mapping of local reference keys to the referenced variable selectors.
+
         """
+        _ = graph_config
         return node_data.extract_variable_selector_to_variable_mapping(node_id)

--- a/src/graphon/nodes/if_else/entities.py
+++ b/src/graphon/nodes/if_else/entities.py
@@ -8,16 +8,12 @@ from graphon.utils.condition.entities import Condition
 
 
 class IfElseNodeData(BaseNodeData):
-    """
-    If Else Node Data.
-    """
+    """If Else Node Data."""
 
     type: NodeType = BuiltinNodeTypes.IF_ELSE
 
     class Case(BaseModel):
-        """
-        Case entity representing a single logical condition group
-        """
+        """Case entity representing a single logical condition group"""
 
         case_id: str
         logical_operator: Literal["and", "or"]

--- a/src/graphon/nodes/if_else/if_else_node.py
+++ b/src/graphon/nodes/if_else/if_else_node.py
@@ -27,10 +27,7 @@ class IfElseNode(Node[IfElseNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run node
-        :return:
-        """
+        """Evaluate the configured cases and return the matching branch result."""
         node_inputs: dict[str, Sequence[Mapping[str, Any]]] = {"conditions": []}
 
         process_data: dict[str, list] = {"condition_results": []}
@@ -87,7 +84,7 @@ class IfElseNode(Node[IfElseNodeData]):
 
             node_inputs["conditions"] = input_conditions
 
-        except Exception as e:
+        except (TypeError, ValueError) as e:
             return NodeRunResult(
                 status=WorkflowNodeExecutionStatus.FAILED,
                 inputs=node_inputs,
@@ -97,15 +94,13 @@ class IfElseNode(Node[IfElseNodeData]):
 
         outputs = {"result": final_result, "selected_case_id": selected_case_id}
 
-        data = NodeRunResult(
+        return NodeRunResult(
             status=WorkflowNodeExecutionStatus.SUCCEEDED,
             inputs=node_inputs,
             process_data=process_data,
             edge_source_handle=selected_case_id or "false",  # Use case ID or 'default'
             outputs=outputs,
         )
-
-        return data
 
     @classmethod
     @override
@@ -133,7 +128,7 @@ def _should_not_use_old_function(
     variable_pool: VariablePool,
     conditions: list[Condition],
     operator: Literal["and", "or"],
-):
+) -> bool:
     return condition_processor.process_conditions(
         variable_pool=variable_pool,
         conditions=conditions,

--- a/src/graphon/nodes/iteration/entities.py
+++ b/src/graphon/nodes/iteration/entities.py
@@ -18,9 +18,7 @@ class ErrorHandleMode(StrEnum):
 
 
 class IterationNodeData(BaseIterationNodeData):
-    """
-    Iteration Node Data.
-    """
+    """Iteration Node Data."""
 
     type: NodeType = BuiltinNodeTypes.ITERATION
     parent_loop_id: str | None = None  # redundant field, not used currently
@@ -37,38 +35,28 @@ class IterationNodeData(BaseIterationNodeData):
 
 
 class IterationStartNodeData(BaseNodeData):
-    """
-    Iteration Start Node Data.
-    """
+    """Iteration Start Node Data."""
 
     type: NodeType = BuiltinNodeTypes.ITERATION_START
 
 
 class IterationState(BaseIterationState):
-    """
-    Iteration State.
-    """
+    """Iteration State."""
 
     outputs: list[Any] = Field(default_factory=list)
     current_output: Any = None
 
     class MetaData(BaseIterationState.MetaData):
-        """
-        Data.
-        """
+        """Data."""
 
         iterator_length: int
 
     def get_last_output(self) -> Any:
-        """
-        Get last output.
-        """
+        """Get last output."""
         if self.outputs:
             return self.outputs[-1]
         return None
 
     def get_current_output(self) -> Any:
-        """
-        Get current output.
-        """
+        """Get current output."""
         return self.current_output

--- a/src/graphon/nodes/iteration/iteration_node.py
+++ b/src/graphon/nodes/iteration/iteration_node.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, NewType, override
 from typing_extensions import TypeIs
 
 from graphon.entities.graph_config import NodeConfigDictAdapter
+from graphon.entities.graph_init_params import GraphInitParams
 from graphon.enums import (
     BuiltinNodeTypes,
     NodeExecutionType,
@@ -37,6 +38,7 @@ from graphon.node_events.node import StreamCompletedEvent
 from graphon.nodes.base.node import Node
 from graphon.nodes.base.usage_tracking_mixin import LLMUsageTrackingMixin
 from graphon.nodes.iteration.entities import ErrorHandleMode, IterationNodeData
+from graphon.runtime.graph_runtime_state import ChildGraphNotFoundError
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import ArrayAnySegment, ArraySegment, NoneSegment
 from graphon.variables.variables import IntegerVariable
@@ -61,9 +63,7 @@ EmptyArraySegment = NewType("EmptyArraySegment", ArraySegment)
 
 
 class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
-    """
-    Iteration Node.
-    """
+    """Iteration Node."""
 
     node_type = BuiltinNodeTypes.ITERATION
     execution_type = NodeExecutionType.CONTAINER
@@ -71,8 +71,10 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
+        _ = filters
         return {
             "type": "iteration",
             "config": {
@@ -143,30 +145,31 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
 
     def _get_iterator_variable(self) -> ArraySegment | NoneSegment:
         variable = self.graph_runtime_state.variable_pool.get(
-            self.node_data.iterator_selector
+            self.node_data.iterator_selector,
         )
 
         if not variable:
-            raise IteratorVariableNotFoundError(
-                f"iterator variable {self.node_data.iterator_selector} not found"
-            )
+            msg = f"iterator variable {self.node_data.iterator_selector} not found"
+            raise IteratorVariableNotFoundError(msg)
 
         if not isinstance(variable, ArraySegment) and not isinstance(
-            variable, NoneSegment
+            variable,
+            NoneSegment,
         ):
-            raise InvalidIteratorValueError(
-                f"invalid iterator value: {variable}, please provide a list."
-            )
+            msg = f"invalid iterator value: {variable}, please provide a list."
+            raise InvalidIteratorValueError(msg)
 
         return variable
 
     def _is_empty_iteration(
-        self, variable: ArraySegment | NoneSegment
+        self,
+        variable: ArraySegment | NoneSegment,
     ) -> TypeIs[NoneSegment | EmptyArraySegment]:
         return isinstance(variable, NoneSegment) or len(variable.value) == 0
 
     def _handle_empty_iteration(
-        self, variable: ArraySegment | NoneSegment
+        self,
+        variable: ArraySegment | NoneSegment,
     ) -> Generator[NodeEventBase, None, None]:
         # Try our best to preserve the type information.
         if isinstance(variable, ArraySegment):
@@ -180,26 +183,27 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                 # TODO(QuantumGhost): is it possible to compute the type of `output`
                 # from graph definition?
                 outputs={"output": output},
-            )
+            ),
         )
 
     def _validate_and_get_iterator_list(
-        self, variable: ArraySegment
+        self,
+        variable: ArraySegment,
     ) -> Sequence[object]:
         iterator_list_value = variable.to_object()
 
         if not isinstance(iterator_list_value, list):
-            raise InvalidIteratorValueError(
+            msg = (
                 f"Invalid iterator value: {iterator_list_value}, please provide a list."
             )
+            raise InvalidIteratorValueError(msg)
 
         return iterator_list_value
 
     def _validate_start_node(self) -> None:
         if not self.node_data.start_node_id:
-            raise StartNodeIdNotFoundError(
-                f"field start_node_id in iteration {self._node_id} not found"
-            )
+            msg = f"field start_node_id in iteration {self._node_id} not found"
+            raise StartNodeIdNotFoundError(msg)
 
     def _execute_iterations(
         self,
@@ -233,7 +237,8 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                     )
                 finally:
                     self._merge_graph_engine_usage(
-                        usage_accumulator=usage_accumulator, graph_engine=graph_engine
+                        usage_accumulator=usage_accumulator,
+                        graph_engine=graph_engine,
                     )
                 iter_run_map[str(index)] = (
                     datetime.now(UTC).replace(tzinfo=None) - iter_start_at
@@ -303,7 +308,8 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                     iter_run_map[str(index)] = iteration_duration
 
                     usage_accumulator[0] = self._merge_usage(
-                        usage_accumulator[0], iteration_usage
+                        usage_accumulator[0],
+                        iteration_usage,
                     )
                     merged_usage_indexes.add(index)
 
@@ -328,7 +334,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                             usage_accumulator=usage_accumulator,
                             merged_usage_indexes=merged_usage_indexes,
                         )
-                        raise e
+                        raise
 
                     # Handle errors based on error_handle_mode
                     match self.node_data.error_handle_mode:
@@ -337,7 +343,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                             for f in future_to_index:
                                 if f != future:
                                     f.cancel()
-                            raise IterationNodeError(str(e))
+                            raise IterationNodeError(str(e)) from e
                         case ErrorHandleMode.CONTINUE_ON_ERROR:
                             outputs[index] = None
                         case ErrorHandleMode.REMOVE_ABNORMAL_OUTPUT:
@@ -356,14 +362,16 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         if graph_engine is None:
             return
         usage_accumulator[0] = IterationNode._merge_usage(
-            usage_accumulator[0], graph_engine.graph_runtime_state.llm_usage
+            usage_accumulator[0],
+            graph_engine.graph_runtime_state.llm_usage,
         )
 
     def _abort_parallel_siblings(
         self,
         *,
         future_to_index: Mapping[
-            Future[tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]], int
+            Future[tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]],
+            int,
         ],
         current_future: Future[
             tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]
@@ -385,7 +393,8 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         self,
         *,
         future_to_index: Mapping[
-            Future[tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]], int
+            Future[tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]],
+            int,
         ],
         current_future: Future[
             tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]
@@ -425,7 +434,6 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
             started_child_engines[index] = graph_engine
 
         return self._execute_parallel_iteration_with_graph_engine(
-            index=index,
             graph_engine=graph_engine,
         )
 
@@ -437,27 +445,26 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         """Execute a single iteration in parallel mode and return results."""
         graph_engine = self._create_graph_engine(index, item)
         return self._execute_parallel_iteration_with_graph_engine(
-            index=index, graph_engine=graph_engine
+            graph_engine=graph_engine,
         )
 
     def _execute_parallel_iteration_with_graph_engine(
         self,
         *,
-        index: int,
         graph_engine: "GraphEngine",
     ) -> tuple[float, list[GraphNodeEventBase], object | None, LLMUsage]:
         """Execute a prepared child engine in parallel mode and return results."""
         iter_start_at = datetime.now(UTC).replace(tzinfo=None)
-        events: list[GraphNodeEventBase] = []
         outputs_temp: list[object] = []
 
         # Collect events instead of yielding them directly
-        for event in self._run_single_iter(
-            variable_pool=graph_engine.graph_runtime_state.variable_pool,
-            outputs=outputs_temp,
-            graph_engine=graph_engine,
-        ):
-            events.append(event)
+        events = list(
+            self._run_single_iter(
+                variable_pool=graph_engine.graph_runtime_state.variable_pool,
+                outputs=outputs_temp,
+                graph_engine=graph_engine,
+            ),
+        )
 
         # Get the output value from the temporary outputs list
         output_value = outputs_temp[0] if outputs_temp else None
@@ -509,17 +516,20 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                     WorkflowNodeExecutionMetadataKey.CURRENCY: usage.currency,
                 },
                 llm_usage=usage,
-            )
+            ),
         )
 
     def _flatten_outputs_if_needed(self, outputs: list[object]) -> list[object]:
-        """
-        Flatten the outputs list if all elements are lists.
+        """Flatten the outputs list if all elements are lists.
         This maintains backward compatibility with version 1.8.1 behavior.
 
         If flatten_output is False, returns outputs as-is (nested structure).
         If flatten_output is True (default), flattens the list if all
         elements are lists.
+
+        Returns:
+            Either the original outputs or a flattened list, depending on settings.
+
         """
         # If flatten_output is disabled, return outputs as-is
         if not self.node_data.flatten_output:
@@ -585,7 +595,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                     WorkflowNodeExecutionMetadataKey.CURRENCY: usage.currency,
                 },
                 llm_usage=usage,
-            )
+            ),
         )
 
     @classmethod
@@ -622,7 +632,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
             # variable selector to variable mapping
             try:
                 typed_sub_node_config = NodeConfigDictAdapter.validate_python(
-                    sub_node_config
+                    sub_node_config,
                 )
                 node_type = typed_sub_node_config["data"].type
                 node_mapping = Node.get_node_type_classes_mapping()
@@ -633,7 +643,8 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
 
                 sub_node_variable_mapping = (
                     node_cls.extract_variable_selector_to_variable_mapping(
-                        graph_config=graph_config, config=typed_sub_node_config
+                        graph_config=graph_config,
+                        config=typed_sub_node_config,
                     )
                 )
             except NotImplementedError:
@@ -649,19 +660,17 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
             variable_mapping.update(sub_node_variable_mapping)
 
         # remove variable out from iteration
-        variable_mapping = {
+        return {
             key: value
             for key, value in variable_mapping.items()
             if value[0] not in iteration_node_ids
         }
 
-        return variable_mapping
-
     def _append_iteration_info_to_event(
         self,
         event: GraphNodeEventBase,
         iter_run_index: int,
-    ):
+    ) -> None:
         event.in_iteration_id = self._node_id
         iter_metadata = {
             WorkflowNodeExecutionMetadataKey.ITERATION_ID: self._node_id,
@@ -683,49 +692,42 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         # get current iteration index
         index_variable = variable_pool.get([self._node_id, "index"])
         if not isinstance(index_variable, IntegerVariable):
-            raise IterationIndexNotFoundError(
-                f"iteration {self._node_id} current index not found"
-            )
+            msg = f"iteration {self._node_id} current index not found"
+            raise IterationIndexNotFoundError(msg)
         current_index = index_variable.value
+        stop_iteration = False
         for event in rst:
-            if (
-                isinstance(event, GraphNodeEventBase)
-                and event.node_type == BuiltinNodeTypes.ITERATION_START
-            ):
-                continue
+            match event:
+                case GraphNodeEventBase(node_type=BuiltinNodeTypes.ITERATION_START):
+                    continue
+                case GraphNodeEventBase():
+                    self._append_iteration_info_to_event(
+                        event=event,
+                        iter_run_index=current_index,
+                    )
+                    yield event
+                case GraphRunSucceededEvent() | GraphRunPartialSucceededEvent():
+                    result = variable_pool.get(self.node_data.output_selector)
+                    outputs.append(None if result is None else result.to_object())
+                    stop_iteration = True
+                case GraphRunAbortedEvent(reason=reason):
+                    raise ChildGraphAbortedError(reason or _DEFAULT_CHILD_ABORT_REASON)
+                case GraphRunFailedEvent(error=error):
+                    match self.node_data.error_handle_mode:
+                        case ErrorHandleMode.TERMINATED:
+                            raise IterationNodeError(error)
+                        case ErrorHandleMode.CONTINUE_ON_ERROR:
+                            outputs.append(None)
+                            stop_iteration = True
+                        case ErrorHandleMode.REMOVE_ABNORMAL_OUTPUT:
+                            stop_iteration = True
 
-            if isinstance(event, GraphNodeEventBase):
-                self._append_iteration_info_to_event(
-                    event=event, iter_run_index=current_index
-                )
-                yield event
-            elif isinstance(
-                event, (GraphRunSucceededEvent, GraphRunPartialSucceededEvent)
-            ):
-                result = variable_pool.get(self.node_data.output_selector)
-                if result is None:
-                    outputs.append(None)
-                else:
-                    outputs.append(result.to_object())
-                return
-            elif isinstance(event, GraphRunAbortedEvent):
-                raise ChildGraphAbortedError(
-                    event.reason or _DEFAULT_CHILD_ABORT_REASON
-                )
-            elif isinstance(event, GraphRunFailedEvent):
-                match self.node_data.error_handle_mode:
-                    case ErrorHandleMode.TERMINATED:
-                        raise IterationNodeError(event.error)
-                    case ErrorHandleMode.CONTINUE_ON_ERROR:
-                        outputs.append(None)
-                        return
-                    case ErrorHandleMode.REMOVE_ABNORMAL_OUTPUT:
-                        return
+            if stop_iteration:
+                break
 
-    def _create_graph_engine(self, index: int, item: object):
-        from graphon.entities.graph_init_params import GraphInitParams
-        from graphon.runtime.graph_runtime_state import ChildGraphNotFoundError
+        return
 
+    def _create_graph_engine(self, index: int, item: object) -> Any:
         # Create GraphInitParams for child graph execution.
         graph_init_params = GraphInitParams(
             workflow_id=self.workflow_id,
@@ -735,7 +737,7 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         )
         # Create a deep copy of the variable pool for each iteration
         variable_pool_copy = self.graph_runtime_state.variable_pool.model_copy(
-            deep=True
+            deep=True,
         )
 
         # append iteration variable (item, index) to variable pool
@@ -743,9 +745,8 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
         variable_pool_copy.add([self._node_id, "item"], item)
         root_node_id = self.node_data.start_node_id
         if root_node_id is None:
-            raise StartNodeIdNotFoundError(
-                f"field start_node_id in iteration {self._node_id} not found"
-            )
+            msg = f"field start_node_id in iteration {self._node_id} not found"
+            raise StartNodeIdNotFoundError(msg)
 
         try:
             return self.graph_runtime_state.create_child_engine(
@@ -755,4 +756,5 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
                 variable_pool=variable_pool_copy,
             )
         except ChildGraphNotFoundError as exc:
-            raise IterationGraphNotFoundError("iteration graph not found") from exc
+            msg = "iteration graph not found"
+            raise IterationGraphNotFoundError(msg) from exc

--- a/src/graphon/nodes/iteration/iteration_start_node.py
+++ b/src/graphon/nodes/iteration/iteration_start_node.py
@@ -7,9 +7,7 @@ from graphon.nodes.iteration.entities import IterationStartNodeData
 
 
 class IterationStartNode(Node[IterationStartNodeData]):
-    """
-    Iteration Start Node.
-    """
+    """Iteration Start Node."""
 
     node_type = BuiltinNodeTypes.ITERATION_START
 
@@ -20,7 +18,5 @@ class IterationStartNode(Node[IterationStartNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run the node.
-        """
+        """Run the node."""
         return NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED)

--- a/src/graphon/nodes/list_operator/node.py
+++ b/src/graphon/nodes/list_operator/node.py
@@ -1,3 +1,4 @@
+import operator
 from collections.abc import Callable, Sequence
 from typing import Any, override
 
@@ -36,12 +37,55 @@ type _SUPPORTED_TYPES_ALIAS = (
 def _negation[T](filter_: Callable[[T], bool]) -> Callable[[T], bool]:
     """Returns the negation of a given filter function. If the original filter
     returns `True` for a value, the negated filter will return `False`, and vice versa.
+
+    Returns:
+        A predicate that inverts the boolean result of `filter_`.
+
     """
 
     def wrapper(value: T) -> bool:
         return not filter_(value)
 
     return wrapper
+
+
+def _extract_file_name(file: File) -> str:
+    return file.filename or ""
+
+
+def _extract_file_type(file: File) -> str:
+    return str(file.type)
+
+
+def _extract_file_extension(file: File) -> str:
+    return file.extension or ""
+
+
+def _extract_file_mime_type(file: File) -> str:
+    return file.mime_type or ""
+
+
+def _extract_file_transfer_method(file: File) -> str:
+    return str(file.transfer_method)
+
+
+def _extract_file_url(file: File) -> str:
+    return file.remote_url or ""
+
+
+def _extract_file_related_id(file: File) -> str:
+    return file.related_id or ""
+
+
+_FILE_STRING_EXTRACTORS: dict[str, Callable[[File], str]] = {
+    "name": _extract_file_name,
+    "type": _extract_file_type,
+    "extension": _extract_file_extension,
+    "mime_type": _extract_file_mime_type,
+    "transfer_method": _extract_file_transfer_method,
+    "url": _extract_file_url,
+    "related_id": _extract_file_related_id,
+}
 
 
 class ListOperatorNode(Node[ListOperatorNodeData]):
@@ -145,40 +189,41 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
         for condition in self.node_data.filter_by.conditions:
             if isinstance(variable, ArrayStringSegment):
                 if not isinstance(condition.value, str):
-                    raise InvalidFilterValueError(
-                        f"Invalid filter value: {condition.value}"
-                    )
+                    msg = f"Invalid filter value: {condition.value}"
+                    raise InvalidFilterValueError(msg)
                 value = self.graph_runtime_state.variable_pool.convert_template(
-                    condition.value
+                    condition.value,
                 ).text
                 filter_func = _get_string_filter_func(
-                    condition=condition.comparison_operator, value=value
+                    condition=condition.comparison_operator,
+                    value=value,
                 )
                 result = list(filter(filter_func, variable.value))
                 variable = variable.model_copy(update={"value": result})
             elif isinstance(variable, ArrayNumberSegment):
                 if not isinstance(condition.value, str):
-                    raise InvalidFilterValueError(
-                        f"Invalid filter value: {condition.value}"
-                    )
+                    msg = f"Invalid filter value: {condition.value}"
+                    raise InvalidFilterValueError(msg)
                 value = self.graph_runtime_state.variable_pool.convert_template(
-                    condition.value
+                    condition.value,
                 ).text
                 filter_func = _get_number_filter_func(
-                    condition=condition.comparison_operator, value=float(value)
+                    condition=condition.comparison_operator,
+                    value=float(value),
                 )
                 result = list(filter(filter_func, variable.value))
                 variable = variable.model_copy(update={"value": result})
             elif isinstance(variable, ArrayFileSegment):
                 if isinstance(condition.value, str):
                     value = self.graph_runtime_state.variable_pool.convert_template(
-                        condition.value
+                        condition.value,
                     ).text
                 elif isinstance(condition.value, bool):
-                    raise ValueError(
+                    msg = (
                         "File filter expects a string value, "
                         f"got {type(condition.value)}"
                     )
+                    raise TypeError(msg)
                 else:
                     value = condition.value
                 filter_func = _get_file_filter_func(
@@ -190,12 +235,14 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
                 variable = variable.model_copy(update={"value": result})
             else:
                 if not isinstance(condition.value, bool):
-                    raise ValueError(
+                    msg = (
                         "Boolean filter expects a boolean value, "
                         f"got {type(condition.value)}"
                     )
+                    raise TypeError(msg)
                 filter_func = _get_boolean_filter_func(
-                    condition=condition.comparison_operator, value=condition.value
+                    condition=condition.comparison_operator,
+                    value=condition.value,
                 )
                 result = list(filter(filter_func, variable.value))
                 variable = variable.model_copy(update={"value": result})
@@ -203,10 +250,12 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
 
     def _apply_order(self, variable: _SUPPORTED_TYPES_ALIAS) -> _SUPPORTED_TYPES_ALIAS:
         if isinstance(
-            variable, (ArrayStringSegment, ArrayNumberSegment, ArrayBooleanSegment)
+            variable,
+            (ArrayStringSegment, ArrayNumberSegment, ArrayBooleanSegment),
         ):
             result = sorted(
-                variable.value, reverse=self.node_data.order_by.value == Order.DESC
+                variable.value,
+                reverse=self.node_data.order_by.value == Order.DESC,
             )
             variable = variable.model_copy(update={"value": result})
         else:
@@ -224,19 +273,20 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
         return variable.model_copy(update={"value": result})
 
     def _extract_slice(
-        self, variable: _SUPPORTED_TYPES_ALIAS
+        self,
+        variable: _SUPPORTED_TYPES_ALIAS,
     ) -> _SUPPORTED_TYPES_ALIAS:
         value = int(
             self.graph_runtime_state.variable_pool.convert_template(
-                self.node_data.extract_by.serial
-            ).text
+                self.node_data.extract_by.serial,
+            ).text,
         )
         if value < 1:
-            raise ValueError(f"Invalid serial index: must be >= 1, got {value}")
+            msg = f"Invalid serial index: must be >= 1, got {value}"
+            raise ValueError(msg)
         if value > len(variable.value):
-            raise InvalidKeyError(
-                f"Invalid serial index: must be <= {len(variable.value)}, got {value}"
-            )
+            msg = f"Invalid serial index: must be <= {len(variable.value)}, got {value}"
+            raise InvalidKeyError(msg)
         value -= 1
         result = variable.value[value]
         return variable.model_copy(update={"value": [result]})
@@ -247,57 +297,50 @@ def _get_file_extract_number_func(*, key: str) -> Callable[[File], int]:
         case "size":
             return lambda x: x.size
         case _:
-            raise InvalidKeyError(f"Invalid key: {key}")
+            msg = f"Invalid key: {key}"
+            raise InvalidKeyError(msg)
 
 
 def _get_file_extract_string_func(*, key: str) -> Callable[[File], str]:
-    match key:
-        case "name":
-            return lambda x: x.filename or ""
-        case "type":
-            return lambda x: str(x.type)
-        case "extension":
-            return lambda x: x.extension or ""
-        case "mime_type":
-            return lambda x: x.mime_type or ""
-        case "transfer_method":
-            return lambda x: str(x.transfer_method)
-        case "url":
-            return lambda x: x.remote_url or ""
-        case "related_id":
-            return lambda x: x.related_id or ""
-        case _:
-            raise InvalidKeyError(f"Invalid key: {key}")
+    extractor = _FILE_STRING_EXTRACTORS.get(key)
+    if extractor is None:
+        msg = f"Invalid key: {key}"
+        raise InvalidKeyError(msg)
+    return extractor
 
 
 def _get_string_filter_func(*, condition: str, value: str) -> Callable[[str], bool]:
     match condition:
         case "contains":
-            return _contains(value)
+            filter_func = _contains(value)
         case "start with":
-            return _startswith(value)
+            filter_func = _startswith(value)
         case "end with":
-            return _endswith(value)
+            filter_func = _endswith(value)
         case "is":
-            return _is(value)
+            filter_func = _is(value)
         case "in":
-            return _in(value)
+            filter_func = _in(value)
         case "empty":
-            return lambda x: x == ""
+            filter_func = operator.not_
         case "not contains":
-            return _negation(_contains(value))
+            filter_func = _negation(_contains(value))
         case "is not":
-            return _negation(_is(value))
+            filter_func = _negation(_is(value))
         case "not in":
-            return _negation(_in(value))
+            filter_func = _negation(_in(value))
         case "not empty":
-            return lambda x: x != ""
+            filter_func = bool
         case _:
-            raise InvalidConditionError(f"Invalid condition: {condition}")
+            msg = f"Invalid condition: {condition}"
+            raise InvalidConditionError(msg)
+    return filter_func
 
 
 def _get_sequence_filter_func(
-    *, condition: str, value: Sequence[str]
+    *,
+    condition: str,
+    value: Sequence[str],
 ) -> Callable[[str], bool]:
     match condition:
         case "in":
@@ -305,11 +348,14 @@ def _get_sequence_filter_func(
         case "not in":
             return _negation(_in(value))
         case _:
-            raise InvalidConditionError(f"Invalid condition: {condition}")
+            msg = f"Invalid condition: {condition}"
+            raise InvalidConditionError(msg)
 
 
 def _get_number_filter_func(
-    *, condition: str, value: float
+    *,
+    condition: str,
+    value: float,
 ) -> Callable[[int | float], bool]:
     match condition:
         case "=":
@@ -325,11 +371,14 @@ def _get_number_filter_func(
         case "≥":
             return _ge(value)
         case _:
-            raise InvalidConditionError(f"Invalid condition: {condition}")
+            msg = f"Invalid condition: {condition}"
+            raise InvalidConditionError(msg)
 
 
 def _get_boolean_filter_func(
-    *, condition: FilterOperator, value: bool
+    *,
+    condition: FilterOperator,
+    value: bool,
 ) -> Callable[[bool], bool]:
     match condition:
         case FilterOperator.IS:
@@ -337,30 +386,40 @@ def _get_boolean_filter_func(
         case FilterOperator.IS_NOT:
             return _negation(_is(value))
         case _:
-            raise InvalidConditionError(f"Invalid condition: {condition}")
+            msg = f"Invalid condition: {condition}"
+            raise InvalidConditionError(msg)
 
 
 def _get_file_filter_func(
-    *, key: str, condition: str, value: str | Sequence[str]
+    *,
+    key: str,
+    condition: str,
+    value: str | Sequence[str],
 ) -> Callable[[File], bool]:
-    if key in {"name", "extension", "mime_type", "url", "related_id"} and isinstance(
-        value, str
-    ):
+    if key in frozenset((
+        "name",
+        "extension",
+        "mime_type",
+        "url",
+        "related_id",
+    )) and isinstance(value, str):
         extract_func = _get_file_extract_string_func(key=key)
         return lambda x: _get_string_filter_func(condition=condition, value=value)(
-            extract_func(x)
+            extract_func(x),
         )
-    if key in {"type", "transfer_method"}:
+    if key in frozenset(("type", "transfer_method")):
         extract_func = _get_file_extract_string_func(key=key)
         return lambda x: _get_sequence_filter_func(condition=condition, value=value)(
-            extract_func(x)
+            extract_func(x),
         )
     if key == "size" and isinstance(value, str):
         extract_number = _get_file_extract_number_func(key=key)
         return lambda x: _get_number_filter_func(
-            condition=condition, value=float(value)
+            condition=condition,
+            value=float(value),
         )(extract_number(x))
-    raise InvalidKeyError(f"Invalid key: {key}")
+    msg = f"Invalid key: {key}"
+    raise InvalidKeyError(msg)
 
 
 def _contains(value: str) -> Callable[[str], bool]:
@@ -407,9 +466,14 @@ def _ge(value: float) -> Callable[[int | float], bool]:
     return lambda x: x >= value
 
 
-def _order_file(*, order: Order, order_by: str = "", array: Sequence[File]):
+def _order_file(
+    *,
+    order: Order,
+    order_by: str = "",
+    array: Sequence[File],
+) -> list[File]:
     extract_func: Callable[[File], Any]
-    if order_by in {
+    if order_by in frozenset((
         "name",
         "type",
         "extension",
@@ -417,10 +481,11 @@ def _order_file(*, order: Order, order_by: str = "", array: Sequence[File]):
         "transfer_method",
         "url",
         "related_id",
-    }:
+    )):
         extract_func = _get_file_extract_string_func(key=order_by)
-        return sorted(array, key=lambda x: extract_func(x), reverse=order == Order.DESC)
+        return sorted(array, key=extract_func, reverse=order == Order.DESC)
     if order_by == "size":
         extract_func = _get_file_extract_number_func(key=order_by)
-        return sorted(array, key=lambda x: extract_func(x), reverse=order == Order.DESC)
-    raise InvalidKeyError(f"Invalid order key: {order_by}")
+        return sorted(array, key=extract_func, reverse=order == Order.DESC)
+    msg = f"Invalid order key: {order_by}"
+    raise InvalidKeyError(msg)

--- a/src/graphon/nodes/llm/entities.py
+++ b/src/graphon/nodes/llm/entities.py
@@ -38,7 +38,7 @@ class VisionConfig(BaseModel):
 
     @field_validator("configs", mode="before")
     @classmethod
-    def convert_none_configs(cls, v: Any):
+    def convert_none_configs(cls, v: Any) -> Any:
         if v is None:
             return VisionConfigOptions()
         return v
@@ -49,7 +49,7 @@ class PromptConfig(BaseModel):
 
     @field_validator("jinja2_variables", mode="before")
     @classmethod
-    def convert_none_jinja2_variables(cls, v: Any):
+    def convert_none_jinja2_variables(cls, v: Any) -> Any:
         if v is None:
             return []
         return v
@@ -99,7 +99,7 @@ class LLMNodeData(BaseNodeData):
 
     @field_validator("prompt_config", mode="before")
     @classmethod
-    def convert_none_prompt_config(cls, v: Any):
+    def convert_none_prompt_config(cls, v: Any) -> Any:
         if v is None:
             return PromptConfig()
         return v

--- a/src/graphon/nodes/llm/exc.py
+++ b/src/graphon/nodes/llm/exc.py
@@ -27,7 +27,7 @@ class NoPromptFoundError(LLMNodeError):
 
 
 class TemplateTypeNotSupportError(LLMNodeError):
-    def __init__(self, *, type_name: str):
+    def __init__(self, *, type_name: str) -> None:
         super().__init__(f"Prompt type {type_name} is not supported.")
 
 
@@ -36,10 +36,10 @@ class MemoryRolePrefixRequiredError(LLMNodeError):
 
 
 class FileTypeNotSupportError(LLMNodeError):
-    def __init__(self, *, type_name: str):
+    def __init__(self, *, type_name: str) -> None:
         super().__init__(f"{type_name} type is not supported by this model")
 
 
 class UnsupportedPromptContentTypeError(LLMNodeError):
-    def __init__(self, *, type_name: str):
+    def __init__(self, *, type_name: str) -> None:
         super().__init__(f"Prompt content type {type_name} is not supported.")

--- a/src/graphon/nodes/llm/file_saver.py
+++ b/src/graphon/nodes/llm/file_saver.py
@@ -78,7 +78,7 @@ class FileSaverImpl(LLMFileSaver):
         tool_file_manager: ToolFileManagerProtocol,
         file_reference_factory: FileReferenceFactoryProtocol,
         http_client: HttpClientProtocol | None = None,
-    ):
+    ) -> None:
         self._tool_file_manager = tool_file_manager
         self._file_reference_factory = file_reference_factory
         self._http_client = http_client or get_http_client()
@@ -89,10 +89,14 @@ class FileSaverImpl(LLMFileSaver):
         data = http_response.content
         mime_type_from_header = http_response.headers.get("Content-Type")
         mime_type, extension = _extract_content_type_and_extension(
-            url, mime_type_from_header
+            url,
+            mime_type_from_header,
         )
         return self.save_binary_string(
-            data, mime_type, file_type, extension_override=extension
+            data,
+            mime_type,
+            file_type,
+            extension_override=extension,
         )
 
     def save_binary_string(
@@ -119,7 +123,7 @@ class FileSaverImpl(LLMFileSaver):
                 "tool_file_id": str(tool_file.id),
                 "related_id": str(tool_file.id),
                 "storage_key": tool_file.file_key,
-            }
+            },
         )
 
 
@@ -128,6 +132,10 @@ def _get_extension(mime_type: str, extension_override: str | None = None) -> str
 
     If the `extension_override` parameter is set, this function should honor it and
     return its value.
+
+    Returns:
+        The chosen filename extension, including a leading dot when applicable.
+
     """
     if extension_override is not None:
         return extension_override
@@ -135,10 +143,15 @@ def _get_extension(mime_type: str, extension_override: str | None = None) -> str
 
 
 def _extract_content_type_and_extension(
-    url: str, content_type_header: str | None
+    url: str,
+    content_type_header: str | None,
 ) -> tuple[str, str]:
     """_extract_content_type_and_extension tries to
     guess content type of file from url and `Content-Type` header in response.
+
+    Returns:
+        A tuple of resolved MIME type and file extension.
+
     """
     if content_type_header:
         extension = mimetypes.guess_extension(content_type_header) or DEFAULT_EXTENSION
@@ -152,11 +165,12 @@ def _validate_extension_override(extension_override: str | None) -> str | None:
     # `extension_override` is allow to be `None or `""`.
     if extension_override is None:
         return None
-    if extension_override == "":
-        return ""
+    if not extension_override:
+        return extension_override
     if not extension_override.startswith("."):
+        msg = "extension_override should start with '.' if not None or empty."
         raise ValueError(
-            "extension_override should start with '.' if not None or empty.",
+            msg,
             extension_override,
         )
     return extension_override

--- a/src/graphon/nodes/llm/llm_utils.py
+++ b/src/graphon/nodes/llm/llm_utils.py
@@ -22,7 +22,6 @@ from graphon.model_runtime.entities.message_entities import (
 )
 from graphon.model_runtime.entities.model_entities import (
     AIModelEntity,
-    ModelFeature,
     ModelPropertyKey,
 )
 from graphon.model_runtime.memory.prompt_message_memory import PromptMessageMemory
@@ -60,10 +59,11 @@ MAX_RESOLVED_VALUE_LENGTH = 1024
 def fetch_model_schema(*, model_instance: PreparedLLMProtocol) -> AIModelEntity:
     model_schema = model_instance.get_model_schema()
     if not model_schema:
-        raise ValueError(
+        msg = (
             "Model schema not found for "
             f"{getattr(model_instance, 'model_name', 'unknown model')}"
         )
+        raise ValueError(msg)
     return model_schema
 
 
@@ -77,7 +77,8 @@ def fetch_files(variable_pool: VariablePool, selector: Sequence[str]) -> Sequenc
         return variable.value
     if isinstance(variable, NoneSegment | ArrayAnySegment):
         return []
-    raise InvalidVariableTypeError(f"Invalid variable type: {type(variable)}")
+    msg = f"Invalid variable type: {type(variable)}"
+    raise InvalidVariableTypeError(msg)
 
 
 def convert_history_messages_to_text(
@@ -130,6 +131,83 @@ def fetch_memory_text(
     )
 
 
+def _update_completion_prompt_content(
+    *,
+    prompt_messages: list[PromptMessage],
+    memory_text: str,
+    sys_query: str | None,
+) -> None:
+    prompt_content = prompt_messages[0].content
+    if isinstance(prompt_content, str):
+        prompt_content = str(prompt_content)
+        if "#histories#" in prompt_content:
+            prompt_content = prompt_content.replace("#histories#", memory_text)
+        else:
+            prompt_content = memory_text + "\n" + prompt_content
+        prompt_messages[0].content = prompt_content
+        if sys_query:
+            prompt_messages[0].content = str(prompt_messages[0].content).replace(
+                "#sys.query#",
+                sys_query,
+            )
+        return
+
+    if isinstance(prompt_content, list):
+        for content_item in prompt_content:
+            if isinstance(content_item, TextPromptMessageContent):
+                if "#histories#" in content_item.data:
+                    content_item.data = content_item.data.replace(
+                        "#histories#",
+                        memory_text,
+                    )
+                else:
+                    content_item.data = memory_text + "\n" + content_item.data
+        if sys_query:
+            for content_item in prompt_content:
+                if isinstance(content_item, TextPromptMessageContent):
+                    content_item.data = sys_query + "\n" + content_item.data
+        return
+
+    msg = "Invalid prompt content type"
+    raise ValueError(msg)
+
+
+def _filter_prompt_messages(
+    *,
+    prompt_messages: list[PromptMessage],
+    model_schema: AIModelEntity,
+) -> list[PromptMessage]:
+    filtered_prompt_messages: list[PromptMessage] = []
+    for prompt_message in prompt_messages:
+        if isinstance(prompt_message.content, list):
+            prompt_message_content: list[PromptMessageContentUnionTypes] = []
+            for content_item in prompt_message.content:
+                if not model_schema.supports_prompt_content_type(content_item.type):
+                    continue
+                prompt_message_content.append(content_item)
+            if not prompt_message_content:
+                continue
+            if (
+                len(prompt_message_content) == 1
+                and prompt_message_content[0].type == PromptMessageContentType.TEXT
+            ):
+                prompt_message.content = prompt_message_content[0].data
+            else:
+                prompt_message.content = prompt_message_content
+            filtered_prompt_messages.append(prompt_message)
+        elif not prompt_message.is_empty():
+            filtered_prompt_messages.append(prompt_message)
+
+    if len(filtered_prompt_messages) == 0:
+        msg = (
+            "No prompt found in the LLM configuration. "
+            "Please ensure a prompt is properly configured before proceeding."
+        )
+        raise NoPromptFoundError(msg)
+
+    return filtered_prompt_messages
+
+
 def fetch_prompt_messages(
     *,
     sys_query: str | None = None,
@@ -151,92 +229,66 @@ def fetch_prompt_messages(
     prompt_messages: list[PromptMessage] = []
     model_schema = fetch_model_schema(model_instance=model_instance)
 
-    if isinstance(prompt_template, list):
-        prompt_messages.extend(
-            handle_list_messages(
-                messages=prompt_template,
-                context=context,
-                jinja2_variables=jinja2_variables,
-                variable_pool=variable_pool,
-                vision_detail_config=vision_detail,
-                template_renderer=template_renderer,
+    match prompt_template:
+        case list():
+            prompt_messages.extend(
+                handle_list_messages(
+                    messages=prompt_template,
+                    context=context,
+                    jinja2_variables=jinja2_variables,
+                    variable_pool=variable_pool,
+                    vision_detail_config=vision_detail,
+                    template_renderer=template_renderer,
+                ),
             )
-        )
+            prompt_messages.extend(
+                handle_memory_chat_mode(
+                    memory=memory,
+                    memory_config=memory_config,
+                    model_instance=model_instance,
+                ),
+            )
 
-        prompt_messages.extend(
-            handle_memory_chat_mode(
+            if sys_query:
+                prompt_messages.extend(
+                    handle_list_messages(
+                        messages=[
+                            LLMNodeChatModelMessage(
+                                text=sys_query,
+                                role=PromptMessageRole.USER,
+                                edition_type="basic",
+                            ),
+                        ],
+                        context="",
+                        jinja2_variables=[],
+                        variable_pool=variable_pool,
+                        vision_detail_config=vision_detail,
+                        template_renderer=template_renderer,
+                    ),
+                )
+        case LLMNodeCompletionModelPromptTemplate():
+            prompt_messages.extend(
+                handle_completion_template(
+                    template=prompt_template,
+                    context=context,
+                    jinja2_variables=jinja2_variables,
+                    variable_pool=variable_pool,
+                    template_renderer=template_renderer,
+                ),
+            )
+
+            memory_text = handle_memory_completion_mode(
                 memory=memory,
                 memory_config=memory_config,
                 model_instance=model_instance,
             )
-        )
-
-        if sys_query:
-            prompt_messages.extend(
-                handle_list_messages(
-                    messages=[
-                        LLMNodeChatModelMessage(
-                            text=sys_query,
-                            role=PromptMessageRole.USER,
-                            edition_type="basic",
-                        )
-                    ],
-                    context="",
-                    jinja2_variables=[],
-                    variable_pool=variable_pool,
-                    vision_detail_config=vision_detail,
-                    template_renderer=template_renderer,
-                )
+            _update_completion_prompt_content(
+                prompt_messages=prompt_messages,
+                memory_text=memory_text,
+                sys_query=sys_query,
             )
-    elif isinstance(prompt_template, LLMNodeCompletionModelPromptTemplate):
-        prompt_messages.extend(
-            handle_completion_template(
-                template=prompt_template,
-                context=context,
-                jinja2_variables=jinja2_variables,
-                variable_pool=variable_pool,
-                template_renderer=template_renderer,
-            )
-        )
-
-        memory_text = handle_memory_completion_mode(
-            memory=memory,
-            memory_config=memory_config,
-            model_instance=model_instance,
-        )
-        prompt_content = prompt_messages[0].content
-        if isinstance(prompt_content, str):
-            prompt_content = str(prompt_content)
-            if "#histories#" in prompt_content:
-                prompt_content = prompt_content.replace("#histories#", memory_text)
-            else:
-                prompt_content = memory_text + "\n" + prompt_content
-            prompt_messages[0].content = prompt_content
-        elif isinstance(prompt_content, list):
-            for content_item in prompt_content:
-                if isinstance(content_item, TextPromptMessageContent):
-                    if "#histories#" in content_item.data:
-                        content_item.data = content_item.data.replace(
-                            "#histories#", memory_text
-                        )
-                    else:
-                        content_item.data = memory_text + "\n" + content_item.data
-        else:
-            raise ValueError("Invalid prompt content type")
-
-        if sys_query:
-            if isinstance(prompt_content, str):
-                prompt_messages[0].content = str(prompt_messages[0].content).replace(
-                    "#sys.query#", sys_query
-                )
-            elif isinstance(prompt_content, list):
-                for content_item in prompt_content:
-                    if isinstance(content_item, TextPromptMessageContent):
-                        content_item.data = sys_query + "\n" + content_item.data
-            else:
-                raise ValueError("Invalid prompt content type")
-    else:
-        raise TemplateTypeNotSupportError(type_name=str(type(prompt_template)))
+        case _:
+            raise TemplateTypeNotSupportError(type_name=str(type(prompt_template)))
 
     _append_file_prompts(
         prompt_messages=prompt_messages,
@@ -250,57 +302,13 @@ def fetch_prompt_messages(
         vision_enabled=vision_enabled,
         vision_detail=vision_detail,
     )
-
-    filtered_prompt_messages: list[PromptMessage] = []
-    for prompt_message in prompt_messages:
-        if isinstance(prompt_message.content, list):
-            prompt_message_content: list[PromptMessageContentUnionTypes] = []
-            for content_item in prompt_message.content:
-                if not model_schema.features:
-                    if content_item.type == PromptMessageContentType.TEXT:
-                        prompt_message_content.append(content_item)
-                    continue
-
-                if (
-                    (
-                        content_item.type == PromptMessageContentType.IMAGE
-                        and ModelFeature.VISION not in model_schema.features
-                    )
-                    or (
-                        content_item.type == PromptMessageContentType.DOCUMENT
-                        and ModelFeature.DOCUMENT not in model_schema.features
-                    )
-                    or (
-                        content_item.type == PromptMessageContentType.VIDEO
-                        and ModelFeature.VIDEO not in model_schema.features
-                    )
-                    or (
-                        content_item.type == PromptMessageContentType.AUDIO
-                        and ModelFeature.AUDIO not in model_schema.features
-                    )
-                ):
-                    continue
-                prompt_message_content.append(content_item)
-            if not prompt_message_content:
-                continue
-            if (
-                len(prompt_message_content) == 1
-                and prompt_message_content[0].type == PromptMessageContentType.TEXT
-            ):
-                prompt_message.content = prompt_message_content[0].data
-            else:
-                prompt_message.content = prompt_message_content
-            filtered_prompt_messages.append(prompt_message)
-        elif not prompt_message.is_empty():
-            filtered_prompt_messages.append(prompt_message)
-
-    if len(filtered_prompt_messages) == 0:
-        raise NoPromptFoundError(
-            "No prompt found in the LLM configuration. "
-            "Please ensure a prompt is properly configured before proceeding."
-        )
-
-    return filtered_prompt_messages, stop
+    return (
+        _filter_prompt_messages(
+            prompt_messages=prompt_messages,
+            model_schema=model_schema,
+        ),
+        stop,
+    )
 
 
 def handle_list_messages(
@@ -325,7 +333,7 @@ def handle_list_messages(
                 combine_message_content_with_role(
                     contents=[TextPromptMessageContent(data=result_text)],
                     role=message.role,
-                )
+                ),
             )
             continue
 
@@ -336,29 +344,31 @@ def handle_list_messages(
             if isinstance(segment, ArrayFileSegment):
                 file_contents.extend(
                     file_manager.to_prompt_message_content(
-                        file, image_detail_config=vision_detail_config
+                        file,
+                        image_detail_config=vision_detail_config,
                     )
                     for file in segment.value
                     if file.type
-                    in {
+                    in frozenset((
                         FileType.IMAGE,
                         FileType.VIDEO,
                         FileType.AUDIO,
                         FileType.DOCUMENT,
-                    }
+                    ))
                 )
             elif isinstance(segment, FileSegment):
                 file = segment.value
-                if file.type in {
+                if file.type in frozenset((
                     FileType.IMAGE,
                     FileType.VIDEO,
                     FileType.AUDIO,
                     FileType.DOCUMENT,
-                }:
+                )):
                     file_contents.append(
                         file_manager.to_prompt_message_content(
-                            file, image_detail_config=vision_detail_config
-                        )
+                            file,
+                            image_detail_config=vision_detail_config,
+                        ),
                     )
 
         if segment_group.text:
@@ -366,13 +376,14 @@ def handle_list_messages(
                 combine_message_content_with_role(
                     contents=[TextPromptMessageContent(data=segment_group.text)],
                     role=message.role,
-                )
+                ),
             )
         if file_contents:
             prompt_messages.append(
                 combine_message_content_with_role(
-                    contents=file_contents, role=message.role
-                )
+                    contents=file_contents,
+                    role=message.role,
+                ),
             )
 
     return prompt_messages
@@ -388,7 +399,8 @@ def render_jinja2_message(
     if not template:
         return ""
     if template_renderer is None:
-        raise ValueError("template_renderer is required for jinja2 prompt rendering")
+        msg = "template_renderer is required for jinja2 prompt rendering"
+        raise ValueError(msg)
 
     jinja2_inputs: dict[str, Any] = {}
     for jinja2_variable in jinja2_variables:
@@ -421,7 +433,7 @@ def handle_completion_template(
         combine_message_content_with_role(
             contents=[TextPromptMessageContent(data=result_text)],
             role=PromptMessageRole.USER,
-        )
+        ),
     ]
 
 
@@ -438,7 +450,8 @@ def combine_message_content_with_role(
         case PromptMessageRole.SYSTEM:
             return SystemPromptMessage(content=contents)
         case _:
-            raise NotImplementedError(f"Role {role} is not supported")
+            msg = f"Role {role} is not supported"
+            raise NotImplementedError(msg)
 
 
 def calculate_rest_token(
@@ -451,7 +464,7 @@ def calculate_rest_token(
     runtime_model_parameters = model_instance.parameters
 
     model_context_tokens = runtime_model_schema.model_properties.get(
-        ModelPropertyKey.CONTEXT_SIZE
+        ModelPropertyKey.CONTEXT_SIZE,
     )
     if model_context_tokens:
         curr_message_tokens = model_instance.get_llm_num_tokens(prompt_messages)
@@ -483,7 +496,8 @@ def handle_memory_chat_mode(
     if not memory or not memory_config:
         return []
     rest_tokens = calculate_rest_token(
-        prompt_messages=[], model_instance=model_instance
+        prompt_messages=[],
+        model_instance=model_instance,
     )
     return memory.get_history_prompt_messages(
         max_token_limit=rest_tokens,
@@ -503,12 +517,12 @@ def handle_memory_completion_mode(
         return ""
 
     rest_tokens = calculate_rest_token(
-        prompt_messages=[], model_instance=model_instance
+        prompt_messages=[],
+        model_instance=model_instance,
     )
     if not memory_config.role_prefix:
-        raise MemoryRolePrefixRequiredError(
-            "Memory role prefix is required for completion model."
-        )
+        msg = "Memory role prefix is required for completion model."
+        raise MemoryRolePrefixRequiredError(msg)
 
     return fetch_memory_text(
         memory=memory,
@@ -543,7 +557,7 @@ def _append_file_prompts(
         existing_contents = prompt_messages[-1].content
         assert isinstance(existing_contents, list)
         prompt_messages[-1] = UserPromptMessage(
-            content=file_prompts + existing_contents
+            content=file_prompts + existing_contents,
         )
     else:
         prompt_messages.append(UserPromptMessage(content=file_prompts))
@@ -557,6 +571,10 @@ def _coerce_resolved_value(raw: str) -> int | float | bool | str:
     the ``temperature`` parameter).  This helper attempts a JSON parse so that
     ``"0.7"`` → ``0.7``, ``"true"`` → ``True``, etc.  Plain strings that are not
     valid JSON literals are returned as-is.
+
+    Returns:
+        The parsed numeric or boolean literal, or the original string.
+
     """
     stripped = raw.strip()
     if not stripped:
@@ -588,6 +606,10 @@ def resolve_completion_params_variables(
       are never concatenated into raw HTTP headers or SQL queries.
     - Numeric/boolean coercion is applied so that variables holding ``"0.7"`` are
       restored to their native type rather than sent as a bare string.
+
+    Returns:
+        Completion params with referenced variables resolved and coerced when possible.
+
     """
     resolved: dict[str, Any] = {}
     for key, value in completion_params.items():

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -13,7 +13,6 @@ from graphon.entities.graph_config import NodeConfigDict
 from graphon.entities.graph_init_params import GraphInitParams
 from graphon.enums import (
     BuiltinNodeTypes,
-    NodeType,
     WorkflowNodeExecutionMetadataKey,
     WorkflowNodeExecutionStatus,
 )
@@ -40,7 +39,7 @@ from graphon.model_runtime.entities.message_entities import (
     TextPromptMessageContent,
     UserPromptMessage,
 )
-from graphon.model_runtime.entities.model_entities import ModelFeature, ModelPropertyKey
+from graphon.model_runtime.entities.model_entities import ModelPropertyKey
 from graphon.model_runtime.memory.prompt_message_memory import PromptMessageMemory
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from graphon.node_events.base import (
@@ -118,7 +117,7 @@ class LLMNode(Node[LLMNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -133,9 +132,9 @@ class LLMNode(Node[LLMNodeData]):
         retriever_attachment_loader: RetrieverAttachmentLoaderProtocol | None = None,
         jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
         default_query_selector: Sequence[str] | None = None,
-    ):
+    ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -176,7 +175,7 @@ class LLMNode(Node[LLMNodeData]):
         try:
             # init messages template
             self.node_data.prompt_template = self._transform_chat_messages(
-                self.node_data.prompt_template
+                self.node_data.prompt_template,
             )
 
             # fetch variables and fetch values from variable pool
@@ -222,7 +221,8 @@ class LLMNode(Node[LLMNodeData]):
             model_instance = self._model_instance
             # Resolve variable references in string-typed completion params
             model_instance.parameters = llm_utils.resolve_completion_params_variables(
-                model_instance.parameters, variable_pool
+                model_instance.parameters,
+                variable_pool,
             )
             model_name = model_instance.model_name
             model_provider = model_instance.provider
@@ -238,7 +238,7 @@ class LLMNode(Node[LLMNodeData]):
                     and self._default_query_selector
                     and (
                         query_variable := variable_pool.get(
-                            self._default_query_selector
+                            self._default_query_selector,
                         )
                     )
                 ):
@@ -271,7 +271,6 @@ class LLMNode(Node[LLMNodeData]):
                 file_saver=self._llm_file_saver,
                 file_outputs=self._file_outputs,
                 node_id=self._node_id,
-                node_type=self.node_type,
                 reasoning_format=self.node_data.reasoning_format,
             )
 
@@ -295,7 +294,8 @@ class LLMNode(Node[LLMNodeData]):
                     else:
                         # Extract clean text from <think> tags
                         clean_text, _ = LLMNode._split_reasoning(
-                            result_text, self.node_data.reasoning_format
+                            result_text,
+                            self.node_data.reasoning_format,
                         )
 
                     # Process structured output if available from the event.
@@ -346,12 +346,14 @@ class LLMNode(Node[LLMNodeData]):
                     process_data=process_data,
                     outputs=outputs,
                     metadata={
-                        WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: usage.total_tokens,
+                        WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: (
+                            usage.total_tokens
+                        ),
                         WorkflowNodeExecutionMetadataKey.TOTAL_PRICE: usage.total_price,
                         WorkflowNodeExecutionMetadataKey.CURRENCY: usage.currency,
                     },
                     llm_usage=usage,
-                )
+                ),
             )
         except ValueError as e:
             yield StreamCompletedEvent(
@@ -362,7 +364,7 @@ class LLMNode(Node[LLMNodeData]):
                     process_data=process_data,
                     error_type=type(e).__name__,
                     llm_usage=usage,
-                )
+                ),
             )
         except Exception as e:
             logger.exception("error while executing llm node")
@@ -374,7 +376,7 @@ class LLMNode(Node[LLMNodeData]):
                     process_data=process_data,
                     error_type=type(e).__name__,
                     llm_usage=usage,
-                )
+                ),
             )
 
     @staticmethod
@@ -388,7 +390,6 @@ class LLMNode(Node[LLMNodeData]):
         file_saver: LLMFileSaver,
         file_outputs: list[File],
         node_id: str,
-        node_type: NodeType,
         reasoning_format: Literal["separated", "tagged"] = "tagged",
     ) -> Generator[NodeEventBase | LLMStructuredOutput, None, None]:
         model_parameters = model_instance.parameters
@@ -423,7 +424,6 @@ class LLMNode(Node[LLMNodeData]):
             file_saver=file_saver,
             file_outputs=file_outputs,
             node_id=node_id,
-            node_type=node_type,
             model_instance=model_instance,
             reasoning_format=reasoning_format,
             request_start_time=request_start_time,
@@ -437,7 +437,6 @@ class LLMNode(Node[LLMNodeData]):
         file_saver: LLMFileSaver,
         file_outputs: list[File],
         node_id: str,
-        node_type: NodeType,
         model_instance: PreparedLLMProtocol | object,
         reasoning_format: Literal["separated", "tagged"] = "tagged",
         request_start_time: float | None = None,
@@ -448,14 +447,13 @@ class LLMNode(Node[LLMNodeData]):
             if request_start_time is not None:
                 duration = time.perf_counter() - request_start_time
                 invoke_result.usage.latency = round(duration, 3)
-            event = LLMNode.handle_blocking_result(
+            yield LLMNode.handle_blocking_result(
                 invoke_result=invoke_result,
                 saver=file_saver,
                 file_outputs=file_outputs,
                 reasoning_format=reasoning_format,
                 request_latency=duration,
             )
-            yield event
             return
 
         # For streaming mode
@@ -521,14 +519,18 @@ class LLMNode(Node[LLMNodeData]):
                         finish_reason = result.delta.finish_reason
         except Exception as e:
             is_structured_output_parse_error = getattr(
-                model_instance, "is_structured_output_parse_error", None
+                model_instance,
+                "is_structured_output_parse_error",
+                None,
             )
             if callable(is_structured_output_parse_error) and (
                 is_structured_output_parse_error(e)
             ):
-                raise LLMNodeError(f"Failed to parse structured output: {e}") from e
+                msg = f"Failed to parse structured output: {e}"
+                raise LLMNodeError(msg) from e
             if type(e).__name__ == "OutputParserError":
-                raise LLMNodeError(f"Failed to parse structured output: {e}") from e
+                msg = f"Failed to parse structured output: {e}"
+                raise LLMNodeError(msg) from e
             raise
 
         # Extract reasoning content from <think> tags in the main text
@@ -541,7 +543,8 @@ class LLMNode(Node[LLMNodeData]):
         else:
             # Extract clean text and reasoning from <think> tags
             clean_text, reasoning_content = LLMNode._split_reasoning(
-                full_text, reasoning_format
+                full_text,
+                reasoning_format,
             )
 
         # Calculate streaming metrics
@@ -567,15 +570,15 @@ class LLMNode(Node[LLMNodeData]):
 
     @staticmethod
     def _image_file_to_markdown(file: File, /):
-        text_chunk = f"![]({file.generate_url()})"
-        return text_chunk
+        return f"![]({file.generate_url()})"
 
     @classmethod
     def _split_reasoning(
-        cls, text: str, reasoning_format: Literal["separated", "tagged"] = "tagged"
+        cls,
+        text: str,
+        reasoning_format: Literal["separated", "tagged"] = "tagged",
     ) -> tuple[str, str]:
-        """
-        Split reasoning content from text based on reasoning_format strategy.
+        """Split reasoning content from text based on reasoning_format strategy.
 
         Args:
             text: Full text that may contain <think> blocks
@@ -586,8 +589,8 @@ class LLMNode(Node[LLMNodeData]):
 
         Returns:
             tuple of (clean_text, reasoning_content)
-        """
 
+        """
         if reasoning_format == "tagged":
             return text, ""
 
@@ -635,17 +638,14 @@ class LLMNode(Node[LLMNodeData]):
         for variable_selector in node_data.prompt_config.jinja2_variables or []:
             variable_name = variable_selector.variable
             variable = self.graph_runtime_state.variable_pool.get(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
             if variable is None:
-                raise VariableNotFoundError(
-                    f"Variable {variable_selector.variable} not found"
-                )
+                msg = f"Variable {variable_selector.variable} not found"
+                raise VariableNotFoundError(msg)
 
             def parse_dict(input_dict: Mapping[str, Any]) -> str:
-                """
-                Parse dict into string
-                """
+                """Parse dict into string"""
                 # check if it's a context structure
                 if (
                     "metadata" in input_dict
@@ -657,7 +657,7 @@ class LLMNode(Node[LLMNodeData]):
                 # else, parse the dict
                 try:
                     return json.dumps(input_dict, ensure_ascii=False)
-                except Exception:
+                except (TypeError, ValueError, OverflowError):
                     return str(input_dict)
 
             if isinstance(variable, ArraySegment):
@@ -687,22 +687,21 @@ class LLMNode(Node[LLMNodeData]):
             for prompt in prompt_template:
                 variable_template_parser = VariableTemplateParser(template=prompt.text)
                 variable_selectors.extend(
-                    variable_template_parser.extract_variable_selectors()
+                    variable_template_parser.extract_variable_selectors(),
                 )
         elif isinstance(prompt_template, CompletionModelPromptTemplate):
             variable_template_parser = VariableTemplateParser(
-                template=prompt_template.text
+                template=prompt_template.text,
             )
             variable_selectors = variable_template_parser.extract_variable_selectors()
 
         for variable_selector in variable_selectors:
             variable = self.graph_runtime_state.variable_pool.get(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
             if variable is None:
-                raise VariableNotFoundError(
-                    f"Variable {variable_selector.variable} not found"
-                )
+                msg = f"Variable {variable_selector.variable} not found"
+                raise VariableNotFoundError(msg)
             if isinstance(variable, NoneSegment):
                 inputs[variable_selector.variable] = ""
             inputs[variable_selector.variable] = variable.to_object()
@@ -710,23 +709,25 @@ class LLMNode(Node[LLMNodeData]):
         memory = node_data.memory
         if memory and memory.query_prompt_template:
             query_variable_selectors = VariableTemplateParser(
-                template=memory.query_prompt_template
+                template=memory.query_prompt_template,
             ).extract_variable_selectors()
             for variable_selector in query_variable_selectors:
                 variable = self.graph_runtime_state.variable_pool.get(
-                    variable_selector.value_selector
+                    variable_selector.value_selector,
                 )
                 if variable is None:
-                    raise VariableNotFoundError(
-                        f"Variable {variable_selector.variable} not found"
-                    )
+                    msg = f"Variable {variable_selector.variable} not found"
+                    raise VariableNotFoundError(msg)
                 if isinstance(variable, NoneSegment):
                     continue
                 inputs[variable_selector.variable] = variable.to_object()
 
         return inputs
 
-    def _fetch_context(self, node_data: LLMNodeData):
+    def _fetch_context(
+        self,
+        node_data: LLMNodeData,
+    ) -> Generator[RunRetrieverResourceEvent, None, None]:
         if not node_data.context.enabled:
             return
 
@@ -734,7 +735,7 @@ class LLMNode(Node[LLMNodeData]):
             return
 
         context_value_variable = self.graph_runtime_state.variable_pool.get(
-            node_data.context.variable_selector
+            node_data.context.variable_selector,
         )
         if context_value_variable:
             if isinstance(context_value_variable, StringSegment):
@@ -752,9 +753,8 @@ class LLMNode(Node[LLMNodeData]):
                         context_str += item + "\n"
                     else:
                         if "content" not in item:
-                            raise InvalidContextStructureError(
-                                f"Invalid context structure: {item}"
-                            )
+                            msg = f"Invalid context structure: {item}"
+                            raise InvalidContextStructureError(msg)
 
                         if item.get("summary"):
                             context_str += item["summary"] + "\n"
@@ -771,8 +771,8 @@ class LLMNode(Node[LLMNodeData]):
                             if self._retriever_attachment_loader is not None:
                                 context_files.extend(
                                     self._retriever_attachment_loader.load(
-                                        segment_id=segment_id
-                                    )
+                                        segment_id=segment_id,
+                                    ),
                                 )
                 yield RunRetrieverResourceEvent(
                     retriever_resources=original_retriever_resource,
@@ -781,7 +781,8 @@ class LLMNode(Node[LLMNodeData]):
                 )
 
     def _convert_to_original_retriever_resource(
-        self, context_dict: dict
+        self,
+        context_dict: dict,
     ) -> dict[str, Any] | None:
         if (
             "metadata" in context_dict
@@ -845,7 +846,7 @@ class LLMNode(Node[LLMNodeData]):
                     variable_pool=variable_pool,
                     vision_detail_config=vision_detail,
                     jinja2_template_renderer=jinja2_template_renderer,
-                )
+                ),
             )
 
             # Get memory messages for chat mode
@@ -872,7 +873,7 @@ class LLMNode(Node[LLMNodeData]):
                         variable_pool=variable_pool,
                         vision_detail_config=vision_detail,
                         jinja2_template_renderer=jinja2_template_renderer,
-                    )
+                    ),
                 )
 
         elif isinstance(prompt_template, LLMNodeCompletionModelPromptTemplate):
@@ -884,7 +885,7 @@ class LLMNode(Node[LLMNodeData]):
                     jinja2_variables=jinja2_variables,
                     variable_pool=variable_pool,
                     jinja2_template_renderer=jinja2_template_renderer,
-                )
+                ),
             )
 
             # Get memory text for completion model
@@ -908,18 +909,21 @@ class LLMNode(Node[LLMNodeData]):
                     if isinstance(content_item, TextPromptMessageContent):
                         if "#histories#" in content_item.data:
                             content_item.data = content_item.data.replace(
-                                "#histories#", memory_text
+                                "#histories#",
+                                memory_text,
                             )
                         else:
                             content_item.data = memory_text + "\n" + content_item.data
             else:
-                raise ValueError("Invalid prompt content type")
+                msg = "Invalid prompt content type"
+                raise TypeError(msg)
 
             # Add current query to the prompt message
             if sys_query:
                 if isinstance(prompt_content, str):
                     prompt_content = str(prompt_messages[0].content).replace(
-                        "#sys.query#", sys_query
+                        "#sys.query#",
+                        sys_query,
                     )
                     prompt_messages[0].content = prompt_content
                 elif isinstance(prompt_content, list):
@@ -927,7 +931,8 @@ class LLMNode(Node[LLMNodeData]):
                         if isinstance(content_item, TextPromptMessageContent):
                             content_item.data = sys_query + "\n" + content_item.data
                 else:
-                    raise ValueError("Invalid prompt content type")
+                    msg = "Invalid prompt content type"
+                    raise TypeError(msg)
         else:
             raise TemplateTypeNotSupportError(type_name=str(type(prompt_template)))
 
@@ -936,7 +941,8 @@ class LLMNode(Node[LLMNodeData]):
             file_prompts = []
             for file in sys_files:
                 file_prompt = file_manager.to_prompt_message_content(
-                    file, image_detail_config=vision_detail
+                    file,
+                    image_detail_config=vision_detail,
                 )
                 file_prompts.append(file_prompt)
             # If last prompt is a user prompt, add files into its contents,
@@ -947,7 +953,7 @@ class LLMNode(Node[LLMNodeData]):
                 and isinstance(prompt_messages[-1].content, list)
             ):
                 prompt_messages[-1] = UserPromptMessage(
-                    content=file_prompts + prompt_messages[-1].content
+                    content=file_prompts + prompt_messages[-1].content,
                 )
             else:
                 prompt_messages.append(UserPromptMessage(content=file_prompts))
@@ -957,7 +963,8 @@ class LLMNode(Node[LLMNodeData]):
             file_prompts = []
             for file in context_files:
                 file_prompt = file_manager.to_prompt_message_content(
-                    file, image_detail_config=vision_detail
+                    file,
+                    image_detail_config=vision_detail,
                 )
                 file_prompts.append(file_prompt)
             # If last prompt is a user prompt, add files into its contents,
@@ -968,7 +975,7 @@ class LLMNode(Node[LLMNodeData]):
                 and isinstance(prompt_messages[-1].content, list)
             ):
                 prompt_messages[-1] = UserPromptMessage(
-                    content=file_prompts + prompt_messages[-1].content
+                    content=file_prompts + prompt_messages[-1].content,
                 )
             else:
                 prompt_messages.append(UserPromptMessage(content=file_prompts))
@@ -979,32 +986,7 @@ class LLMNode(Node[LLMNodeData]):
             if isinstance(prompt_message.content, list):
                 prompt_message_content: list[PromptMessageContentUnionTypes] = []
                 for content_item in prompt_message.content:
-                    # Skip content if features are not defined
-                    if not model_schema.features:
-                        if content_item.type != PromptMessageContentType.TEXT:
-                            continue
-                        prompt_message_content.append(content_item)
-                        continue
-
-                    # Skip content if corresponding feature is not supported
-                    if (
-                        (
-                            content_item.type == PromptMessageContentType.IMAGE
-                            and ModelFeature.VISION not in model_schema.features
-                        )
-                        or (
-                            content_item.type == PromptMessageContentType.DOCUMENT
-                            and ModelFeature.DOCUMENT not in model_schema.features
-                        )
-                        or (
-                            content_item.type == PromptMessageContentType.VIDEO
-                            and ModelFeature.VIDEO not in model_schema.features
-                        )
-                        or (
-                            content_item.type == PromptMessageContentType.AUDIO
-                            and ModelFeature.AUDIO not in model_schema.features
-                        )
-                    ):
+                    if not model_schema.supports_prompt_content_type(content_item.type):
                         continue
                     prompt_message_content.append(content_item)
                 if (
@@ -1019,10 +1001,11 @@ class LLMNode(Node[LLMNodeData]):
             filtered_prompt_messages.append(prompt_message)
 
         if len(filtered_prompt_messages) == 0:
-            raise NoPromptFoundError(
+            msg = (
                 "No prompt found in the LLM configuration. "
                 "Please ensure a prompt is properly configured before proceeding."
             )
+            raise NoPromptFoundError(msg)
 
         return filtered_prompt_messages, stop
 
@@ -1043,23 +1026,22 @@ class LLMNode(Node[LLMNodeData]):
             for prompt in prompt_template:
                 if prompt.edition_type != "jinja2":
                     variable_template_parser = VariableTemplateParser(
-                        template=prompt.text
+                        template=prompt.text,
                     )
                     variable_selectors.extend(
-                        variable_template_parser.extract_variable_selectors()
+                        variable_template_parser.extract_variable_selectors(),
                     )
         elif isinstance(prompt_template, LLMNodeCompletionModelPromptTemplate):
             if prompt_template.edition_type != "jinja2":
                 variable_template_parser = VariableTemplateParser(
-                    template=prompt_template.text
+                    template=prompt_template.text,
                 )
                 variable_selectors = (
                     variable_template_parser.extract_variable_selectors()
                 )
         else:
-            raise InvalidVariableTypeError(
-                f"Invalid prompt template type: {type(prompt_template)}"
-            )
+            msg = f"Invalid prompt template type: {type(prompt_template)}"
+            raise InvalidVariableTypeError(msg)
 
         variable_mapping: dict[str, Any] = {}
         for variable_selector in variable_selectors:
@@ -1070,7 +1052,7 @@ class LLMNode(Node[LLMNodeData]):
         memory = node_data.memory
         if memory and memory.query_prompt_template:
             query_variable_selectors = VariableTemplateParser(
-                template=memory.query_prompt_template
+                template=memory.query_prompt_template,
             ).extract_variable_selectors()
             for variable_selector in query_variable_selectors:
                 variable_mapping[variable_selector.variable] = (
@@ -1101,17 +1083,15 @@ class LLMNode(Node[LLMNodeData]):
                         variable_selector.value_selector
                     )
 
-        variable_mapping = {
-            node_id + "." + key: value for key, value in variable_mapping.items()
-        }
-
-        return variable_mapping
+        return {node_id + "." + key: value for key, value in variable_mapping.items()}
 
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
+        _ = filters
         return {
             "type": "llm",
             "config": {
@@ -1122,8 +1102,8 @@ class LLMNode(Node[LLMNodeData]):
                                 "role": "system",
                                 "text": "You are a helpful AI assistant.",
                                 "edition_type": "basic",
-                            }
-                        ]
+                            },
+                        ],
                     },
                     "completion_model": {
                         "conversation_histories_role": {
@@ -1142,7 +1122,7 @@ class LLMNode(Node[LLMNodeData]):
                         },
                         "stop": ["Human:"],
                     },
-                }
+                },
             },
         }
 
@@ -1180,26 +1160,28 @@ class LLMNode(Node[LLMNodeData]):
                 for segment in segment_group.value:
                     if isinstance(segment, ArrayFileSegment):
                         for file in segment.value:
-                            if file.type in {
+                            if file.type in frozenset((
                                 FileType.IMAGE,
                                 FileType.VIDEO,
                                 FileType.AUDIO,
                                 FileType.DOCUMENT,
-                            }:
+                            )):
                                 file_content = file_manager.to_prompt_message_content(
-                                    file, image_detail_config=vision_detail_config
+                                    file,
+                                    image_detail_config=vision_detail_config,
                                 )
                                 file_contents.append(file_content)
                     elif isinstance(segment, FileSegment):
                         file = segment.value
-                        if file.type in {
+                        if file.type in frozenset((
                             FileType.IMAGE,
                             FileType.VIDEO,
                             FileType.AUDIO,
                             FileType.DOCUMENT,
-                        }:
+                        )):
                             file_content = file_manager.to_prompt_message_content(
-                                file, image_detail_config=vision_detail_config
+                                file,
+                                image_detail_config=vision_detail_config,
                             )
                             file_contents.append(file_content)
 
@@ -1215,7 +1197,8 @@ class LLMNode(Node[LLMNodeData]):
                 if file_contents:
                     # Create message with image contents
                     prompt_message = _combine_message_content_with_role(
-                        contents=file_contents, role=message.role
+                        contents=file_contents,
+                        role=message.role,
                     )
                     prompt_messages.append(prompt_message)
 
@@ -1248,7 +1231,8 @@ class LLMNode(Node[LLMNodeData]):
         else:
             # Extract clean text and reasoning from <think> tags
             clean_text, reasoning_content = LLMNode._split_reasoning(
-                full_text, reasoning_format
+                full_text,
+                reasoning_format,
             )
 
         event = ModelInvokeCompletedEvent(
@@ -1280,8 +1264,12 @@ class LLMNode(Node[LLMNodeData]):
             then saved to storage.
 
         Currently, only image files are supported.
+
+        Returns:
+            The persisted graph-owned `File` describing the saved image output.
+
         """
-        if content.url != "":
+        if content.url:
             saved_file = file_saver.save_remote_url(content.url, FileType.IMAGE)
         else:
             saved_file = file_saver.save_binary_string(
@@ -1296,27 +1284,37 @@ class LLMNode(Node[LLMNodeData]):
         *,
         structured_output: Mapping[str, Any],
     ) -> dict[str, Any]:
-        """
-        Fetch the structured output schema from the node data.
+        """Fetch the structured output schema from the node data.
 
         Returns:
             dict[str, Any]: The structured output schema
+
+        Raises:
+            LLMNodeError: If the schema payload is missing, invalid JSON,
+                or not a JSON object.
+
         """
         if not structured_output:
-            raise LLMNodeError("Please provide a valid structured output schema")
+            msg = "Please provide a valid structured output schema"
+            raise LLMNodeError(msg)
         structured_output_schema = json.dumps(
-            structured_output.get("schema", {}), ensure_ascii=False
+            structured_output.get("schema", {}),
+            ensure_ascii=False,
         )
         if not structured_output_schema:
-            raise LLMNodeError("Please provide a valid structured output schema")
+            msg = "Please provide a valid structured output schema"
+            raise LLMNodeError(msg)
 
         try:
             schema = json.loads(structured_output_schema)
             if not isinstance(schema, dict):
-                raise LLMNodeError("structured_output_schema must be a JSON object")
+                msg = "structured_output_schema must be a JSON object"
+                raise LLMNodeError(msg)
+        except json.JSONDecodeError as error:
+            msg = "structured_output_schema is not valid JSON format"
+            raise LLMNodeError(msg) from error
+        else:
             return schema
-        except json.JSONDecodeError:
-            raise LLMNodeError("structured_output_schema is not valid JSON format")
 
     @staticmethod
     def _save_multimodal_output_and_convert_result_to_markdown(
@@ -1331,8 +1329,12 @@ class LLMNode(Node[LLMNodeData]):
         If the messages contain non-textual content (e.g., multimedia like
         images or videos), it will be saved separately, and the
         corresponding Markdown representation will be yielded to the caller.
-        """
 
+        Yields:
+            Text or Markdown fragments as soon as each intermediate content
+                item is ready.
+
+        """
         # NOTE(QuantumGhost): This function should yield results to the
         # caller immediately whenever new content or partial content is
         # available. Avoid any intermediate buffering of results.
@@ -1372,7 +1374,7 @@ def _combine_message_content_with_role(
     *,
     contents: str | list[PromptMessageContentUnionTypes] | None = None,
     role: PromptMessageRole,
-):
+) -> PromptMessage:
     match role:
         case PromptMessageRole.USER:
             return UserPromptMessage(content=contents)
@@ -1381,7 +1383,8 @@ def _combine_message_content_with_role(
         case PromptMessageRole.SYSTEM:
             return SystemPromptMessage(content=contents)
         case _:
-            raise NotImplementedError(f"Role {role} is not supported")
+            msg = f"Role {role} is not supported"
+            raise NotImplementedError(msg)
 
 
 def _render_jinja2_message(
@@ -1390,7 +1393,7 @@ def _render_jinja2_message(
     jinja2_variables: Sequence[VariableSelector],
     variable_pool: VariablePool,
     jinja2_template_renderer: Jinja2TemplateRenderer | None,
-):
+) -> str:
     if not template:
         return ""
 
@@ -1401,9 +1404,10 @@ def _render_jinja2_message(
             variable.to_object() if variable else ""
         )
     if jinja2_template_renderer is None:
-        raise TemplateRenderError(
+        msg = (
             "LLMNode requires an injected jinja2_template_renderer for jinja2 prompts."
         )
+        raise TemplateRenderError(msg)
     return jinja2_template_renderer.render_template(template, jinja2_inputs)
 
 
@@ -1417,7 +1421,7 @@ def _calculate_rest_token(
     runtime_model_parameters = model_instance.parameters
 
     model_context_tokens = runtime_model_schema.model_properties.get(
-        ModelPropertyKey.CONTEXT_SIZE
+        ModelPropertyKey.CONTEXT_SIZE,
     )
     if model_context_tokens:
         curr_message_tokens = model_instance.get_llm_num_tokens(prompt_messages)
@@ -1476,9 +1480,8 @@ def _handle_memory_completion_mode(
             model_instance=model_instance,
         )
         if not memory_config.role_prefix:
-            raise MemoryRolePrefixRequiredError(
-                "Memory role prefix is required for completion model."
-            )
+            msg = "Memory role prefix is required for completion model."
+            raise MemoryRolePrefixRequiredError(msg)
         memory_text = llm_utils.fetch_memory_text(
             memory=memory,
             max_token_limit=rest_tokens,
@@ -1506,9 +1509,11 @@ def _handle_completion_template(
         context: Context string
         jinja2_variables: Variables for jinja2 template rendering
         variable_pool: Variable pool for template conversion
+        jinja2_template_renderer: Optional renderer for jinja2 templates
 
     Returns:
         Sequence of prompt messages
+
     """
     prompt_messages = []
     if template.edition_type == "jinja2":

--- a/src/graphon/nodes/llm/protocols.py
+++ b/src/graphon/nodes/llm/protocols.py
@@ -17,7 +17,9 @@ class ModelFactory(Protocol):
     """Port for creating prepared graph-facing LLM runtimes for execution."""
 
     def init_model_instance(
-        self, provider_name: str, model_name: str
+        self,
+        provider_name: str,
+        model_name: str,
     ) -> PreparedLLMProtocol:
         """Create a prepared LLM runtime that is ready for graph execution."""
         ...

--- a/src/graphon/nodes/loop/entities.py
+++ b/src/graphon/nodes/loop/entities.py
@@ -31,9 +31,7 @@ def _is_valid_var_type(seg_type: SegmentType) -> SegmentType:
 
 
 class LoopVariableData(BaseModel):
-    """
-    Loop Variable Data.
-    """
+    """Loop Variable Data."""
 
     label: str
     var_type: Annotated[SegmentType, AfterValidator(_is_valid_var_type)]
@@ -47,61 +45,49 @@ class LoopNodeData(BaseLoopNodeData):
     break_conditions: list[Condition]  # Conditions to break the loop
     logical_operator: Literal["and", "or"]
     loop_variables: list[LoopVariableData] | None = Field(
-        default_factory=list[LoopVariableData]
+        default_factory=list[LoopVariableData],
     )
     outputs: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("outputs", mode="before")
     @classmethod
-    def validate_outputs(cls, v):
+    def validate_outputs(cls, v: Any) -> dict[str, Any]:
         if v is None:
             return {}
         return v
 
 
 class LoopStartNodeData(BaseNodeData):
-    """
-    Loop Start Node Data.
-    """
+    """Loop Start Node Data."""
 
     type: NodeType = BuiltinNodeTypes.LOOP_START
 
 
 class LoopEndNodeData(BaseNodeData):
-    """
-    Loop End Node Data.
-    """
+    """Loop End Node Data."""
 
     type: NodeType = BuiltinNodeTypes.LOOP_END
 
 
 class LoopState(BaseLoopState):
-    """
-    Loop State.
-    """
+    """Loop State."""
 
     outputs: list[Any] = Field(default_factory=list)
     current_output: Any = None
 
     class MetaData(BaseLoopState.MetaData):
-        """
-        Data.
-        """
+        """Data."""
 
         loop_length: int
 
     def get_last_output(self) -> Any:
-        """
-        Get last output.
-        """
+        """Get last output."""
         if self.outputs:
             return self.outputs[-1]
         return None
 
     def get_current_output(self) -> Any:
-        """
-        Get current output.
-        """
+        """Get current output."""
         return self.current_output
 
 

--- a/src/graphon/nodes/loop/loop_end_node.py
+++ b/src/graphon/nodes/loop/loop_end_node.py
@@ -7,9 +7,7 @@ from graphon.nodes.loop.entities import LoopEndNodeData
 
 
 class LoopEndNode(Node[LoopEndNodeData]):
-    """
-    Loop End Node.
-    """
+    """Loop End Node."""
 
     node_type = BuiltinNodeTypes.LOOP_END
 
@@ -20,7 +18,5 @@ class LoopEndNode(Node[LoopEndNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run the node.
-        """
+        """Run the node."""
         return NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED)

--- a/src/graphon/nodes/loop/loop_node.py
+++ b/src/graphon/nodes/loop/loop_node.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal, override
 
 from graphon.entities.graph_config import NodeConfigDictAdapter
+from graphon.entities.graph_init_params import GraphInitParams
 from graphon.enums import (
     BuiltinNodeTypes,
     NodeExecutionType,
@@ -51,12 +52,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CHILD_ABORT_REASON = "child graph aborted"
+_JSON_ARRAY_LOOP_TYPES = frozenset((
+    SegmentType.ARRAY_NUMBER,
+    SegmentType.ARRAY_OBJECT,
+    SegmentType.ARRAY_STRING,
+))
 
 
 class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
-    """
-    Loop Node.
-    """
+    """Loop Node."""
 
     node_type = BuiltinNodeTypes.LOOP
     execution_type = NodeExecutionType.CONTAINER
@@ -77,7 +81,8 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
         inputs = {"loop_count": loop_count}
 
         if not self.node_data.start_node_id:
-            raise ValueError(f"field start_node_id in loop {self._node_id} not found")
+            msg = f"field start_node_id in loop {self._node_id} not found"
+            raise ValueError(msg)
 
         root_node_id = self.node_data.start_node_id
 
@@ -89,7 +94,8 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                 Callable[[LoopVariableData], Segment | None],
             ] = {
                 "constant": lambda var: self._get_segment_for_constant(
-                    var.var_type, var.value
+                    var.var_type,
+                    var.value,
                 ),
                 "variable": lambda var: (
                     self.graph_runtime_state.variable_pool.get(var.value)
@@ -99,24 +105,26 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             }
             for loop_variable in self.node_data.loop_variables:
                 if loop_variable.value_type not in value_processor:
-                    raise ValueError(
+                    msg = (
                         f"Invalid value type '{loop_variable.value_type}' "
                         f"for loop variable {loop_variable.label}"
                     )
+                    raise ValueError(msg)
 
                 processed_segment = value_processor[loop_variable.value_type](
-                    loop_variable
+                    loop_variable,
                 )
                 if not processed_segment:
-                    raise ValueError(
-                        f"Invalid value for loop variable {loop_variable.label}"
-                    )
+                    msg = f"Invalid value for loop variable {loop_variable.label}"
+                    raise ValueError(msg)
                 variable_selector = [self._node_id, loop_variable.label]
                 variable = segment_to_variable(
-                    segment=processed_segment, selector=variable_selector
+                    segment=processed_segment,
+                    selector=variable_selector,
                 )
                 self.graph_runtime_state.variable_pool.add(
-                    variable_selector, variable.value
+                    variable_selector,
+                    variable.value,
                 )
                 loop_variable_selectors[loop_variable.label] = variable_selector
                 inputs[loop_variable.label] = processed_segment.value
@@ -126,11 +134,13 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
 
         loop_duration_map: dict[str, float] = {}
         single_loop_variable_map: dict[
-            str, dict[str, Any]
+            str,
+            dict[str, Any],
         ] = {}  # single loop variable output
         loop_usage = LLMUsage.empty_usage()
         loop_node_ids = self._extract_loop_node_ids_from_config(
-            self.graph_config, self._node_id
+            self.graph_config,
+            self._node_id,
         )
 
         # Start Loop event
@@ -159,19 +169,22 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                 # Clear stale variables from previous loop iterations to avoid
                 # streaming old values
                 self._clear_loop_subgraph_variables(loop_node_ids)
-                graph_engine = self._create_graph_engine(
-                    start_at=start_at, root_node_id=root_node_id
-                )
+                graph_engine = self._create_graph_engine(root_node_id=root_node_id)
+                loop_state = {"reach_break_node": False}
 
                 loop_start_time = datetime.now(UTC).replace(tzinfo=None)
                 try:
-                    reach_break_node = yield from self._run_single_loop(
-                        graph_engine=graph_engine, current_index=i
+                    yield from self._run_single_loop(
+                        graph_engine=graph_engine,
+                        current_index=i,
+                        loop_state=loop_state,
                     )
                 finally:
                     loop_usage = self._merge_usage(
-                        loop_usage, graph_engine.graph_runtime_state.llm_usage
+                        loop_usage,
+                        graph_engine.graph_runtime_state.llm_usage,
                     )
+                reach_break_node = loop_state["reach_break_node"]
                 # Track loop duration
                 loop_duration_map[str(i)] = (
                     datetime.now(UTC).replace(tzinfo=None) - loop_start_time
@@ -182,11 +195,13 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                     if key == "answer":
                         # Concatenate answer outputs with newline
                         existing_answer = self.graph_runtime_state.get_output(
-                            "answer", ""
+                            "answer",
+                            "",
                         )
                         if existing_answer:
                             self.graph_runtime_state.set_output(
-                                "answer", f"{existing_answer}{value}"
+                                "answer",
+                                f"{existing_answer}{value}",
                             )
                         else:
                             self.graph_runtime_state.set_output("answer", value)
@@ -244,7 +259,9 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                     WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: (
                         loop_duration_map
                     ),
-                    WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: single_loop_variable_map,
+                    WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: (
+                        single_loop_variable_map
+                    ),
                 },
             )
 
@@ -259,16 +276,21 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                             loop_usage.total_price
                         ),
                         WorkflowNodeExecutionMetadataKey.CURRENCY: loop_usage.currency,
-                        WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: loop_duration_map,
-                        WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: single_loop_variable_map,
+                        WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: (
+                            loop_duration_map
+                        ),
+                        WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: (
+                            single_loop_variable_map
+                        ),
                     },
                     outputs=self.node_data.outputs,
                     inputs=inputs,
                     llm_usage=loop_usage,
-                )
+                ),
             )
 
         except Exception as e:
+            logger.exception("Loop node %s failed", self._node_id)
             self._accumulate_usage(loop_usage)
             yield LoopFailedEvent(
                 start_at=start_at,
@@ -283,8 +305,12 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                     ),
                     WorkflowNodeExecutionMetadataKey.CURRENCY: loop_usage.currency,
                     "completed_reason": "error",
-                    WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: loop_duration_map,
-                    WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: single_loop_variable_map,
+                    WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: (
+                        loop_duration_map
+                    ),
+                    WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: (
+                        single_loop_variable_map
+                    ),
                 },
                 error=str(e),
             )
@@ -301,11 +327,15 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                             loop_usage.total_price
                         ),
                         WorkflowNodeExecutionMetadataKey.CURRENCY: loop_usage.currency,
-                        WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: loop_duration_map,
-                        WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: single_loop_variable_map,
+                        WorkflowNodeExecutionMetadataKey.LOOP_DURATION_MAP: (
+                            loop_duration_map
+                        ),
+                        WorkflowNodeExecutionMetadataKey.LOOP_VARIABLE_MAP: (
+                            single_loop_variable_map
+                        ),
                     },
                     llm_usage=loop_usage,
-                )
+                ),
             )
 
     def _run_single_loop(
@@ -313,30 +343,36 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
         *,
         graph_engine: "GraphEngine",
         current_index: int,
-    ) -> Generator[NodeEventBase | GraphNodeEventBase, None, bool]:
-        reach_break_node = False
+        loop_state: dict[str, bool],
+    ) -> Generator[NodeEventBase | GraphNodeEventBase, None, None]:
+        loop_state["reach_break_node"] = False
         for event in graph_engine.run():
-            if isinstance(event, GraphNodeEventBase):
-                self._append_loop_info_to_event(
-                    event=event, loop_run_index=current_index
-                )
-
-            if (
-                isinstance(event, GraphNodeEventBase)
-                and event.node_type == BuiltinNodeTypes.LOOP_START
-            ):
-                continue
-            if isinstance(event, GraphNodeEventBase):
-                yield event
-            if (
-                isinstance(event, NodeRunSucceededEvent)
-                and event.node_type == BuiltinNodeTypes.LOOP_END
-            ):
-                reach_break_node = True
-            if isinstance(event, GraphRunAbortedEvent):
-                raise RuntimeError(event.reason or _DEFAULT_CHILD_ABORT_REASON)
-            if isinstance(event, GraphRunFailedEvent):
-                raise Exception(event.error)
+            match event:
+                case GraphNodeEventBase(node_type=BuiltinNodeTypes.LOOP_START):
+                    self._append_loop_info_to_event(
+                        event=event,
+                        loop_run_index=current_index,
+                    )
+                    continue
+                case NodeRunSucceededEvent(node_type=BuiltinNodeTypes.LOOP_END):
+                    self._append_loop_info_to_event(
+                        event=event,
+                        loop_run_index=current_index,
+                    )
+                    yield event
+                    loop_state["reach_break_node"] = True
+                case GraphNodeEventBase():
+                    self._append_loop_info_to_event(
+                        event=event,
+                        loop_run_index=current_index,
+                    )
+                    yield event
+                case GraphRunAbortedEvent(reason=reason):
+                    raise RuntimeError(reason or _DEFAULT_CHILD_ABORT_REASON)
+                case GraphRunFailedEvent(error=error):
+                    raise RuntimeError(error)
+                case _:
+                    pass
 
         for loop_var in self.node_data.loop_variables or []:
             key, sel = loop_var.label, [self._node_id, loop_var.label]
@@ -344,13 +380,11 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             self.node_data.outputs[key] = segment.value if segment else None
         self.node_data.outputs["loop_round"] = current_index + 1
 
-        return reach_break_node
-
     def _append_loop_info_to_event(
         self,
         event: GraphNodeEventBase,
         loop_run_index: int,
-    ):
+    ) -> None:
         event.in_loop_id = self._node_id
         loop_metadata = {
             WorkflowNodeExecutionMetadataKey.LOOP_ID: self._node_id,
@@ -362,8 +396,7 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             event.node_run_result.metadata = {**current_metadata, **loop_metadata}
 
     def _clear_loop_subgraph_variables(self, loop_node_ids: set[str]) -> None:
-        """
-        Remove variables produced by loop sub-graph nodes from previous iterations.
+        """Remove variables produced by loop sub-graph nodes from previous iterations.
 
         Keeping stale variables causes a freshly created response coordinator in the
         next iteration to fall back to outdated values when no stream chunks exist.
@@ -398,7 +431,7 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             # variable selector to variable mapping
             try:
                 typed_sub_node_config = NodeConfigDictAdapter.validate_python(
-                    sub_node_config
+                    sub_node_config,
                 )
                 node_type = typed_sub_node_config["data"].type
                 node_mapping = Node.get_node_type_classes_mapping()
@@ -409,7 +442,8 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
 
                 sub_node_variable_mapping = (
                     node_cls.extract_variable_selector_to_variable_mapping(
-                        graph_config=graph_config, config=typed_sub_node_config
+                        graph_config=graph_config,
+                        config=typed_sub_node_config,
                     )
                 )
             except NotImplementedError:
@@ -434,27 +468,29 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                 variable_mapping[f"{node_id}.{loop_variable.label}"] = selector
 
         # remove variable out from loop
-        variable_mapping = {
+        return {
             key: value
             for key, value in variable_mapping.items()
             if value[0] not in loop_node_ids
         }
 
-        return variable_mapping
-
     @classmethod
     def _extract_loop_node_ids_from_config(
-        cls, graph_config: Mapping[str, Any], loop_node_id: str
+        cls,
+        graph_config: Mapping[str, Any],
+        loop_node_id: str,
     ) -> set[str]:
-        """
-        Extract node IDs that belong to a specific loop from graph configuration.
+        """Extract node IDs that belong to a specific loop from graph configuration.
 
         This method statically analyzes the graph configuration to find all nodes
         that are part of the specified loop, without creating actual node instances.
 
         :param graph_config: the complete graph configuration
         :param loop_node_id: the ID of the loop node
-        :return: set of node IDs that belong to the loop
+
+        Returns:
+            The set of node IDs that belong to the target loop.
+
         """
         loop_node_ids = set()
 
@@ -471,7 +507,8 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
 
     @staticmethod
     def _get_segment_for_constant(
-        var_type: SegmentType, original_value: Any
+        var_type: SegmentType,
+        original_value: Any,
     ) -> Segment:
         """Get the appropriate segment type for a constant value."""
         # TODO: Refactor for maintainability:
@@ -481,11 +518,7 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
         #    for better encapsulation
         if not var_type.is_array_type() or var_type == SegmentType.ARRAY_BOOLEAN:
             value = original_value
-        elif var_type in [
-            SegmentType.ARRAY_NUMBER,
-            SegmentType.ARRAY_OBJECT,
-            SegmentType.ARRAY_STRING,
-        ]:
+        elif var_type in _JSON_ARRAY_LOOP_TYPES:
             if original_value and isinstance(original_value, str):
                 value = json.loads(original_value)
             else:
@@ -496,7 +529,8 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
                 )
                 value = []
         else:
-            raise AssertionError("this statement should be unreachable.")
+            msg = "this statement should be unreachable."
+            raise AssertionError(msg)
         try:
             return build_segment_with_type(var_type, value=value)
         except TypeMismatchError as type_exc:
@@ -506,12 +540,10 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             try:
                 value = json.loads(original_value)
             except ValueError:
-                raise type_exc
+                raise type_exc from None
             return build_segment_with_type(var_type, value)
 
-    def _create_graph_engine(self, start_at: datetime, root_node_id: str):
-        from graphon.entities.graph_init_params import GraphInitParams
-
+    def _create_graph_engine(self, root_node_id: str) -> Any:
         # Create GraphInitParams for child graph execution.
         graph_init_params = GraphInitParams(
             workflow_id=self.workflow_id,

--- a/src/graphon/nodes/loop/loop_start_node.py
+++ b/src/graphon/nodes/loop/loop_start_node.py
@@ -7,9 +7,7 @@ from graphon.nodes.loop.entities import LoopStartNodeData
 
 
 class LoopStartNode(Node[LoopStartNodeData]):
-    """
-    Loop Start Node.
-    """
+    """Loop Start Node."""
 
     node_type = BuiltinNodeTypes.LOOP_START
 
@@ -20,7 +18,5 @@ class LoopStartNode(Node[LoopStartNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run the node.
-        """
+        """Run the node."""
         return NodeRunResult(status=WorkflowNodeExecutionStatus.SUCCEEDED)

--- a/src/graphon/nodes/parameter_extractor/entities.py
+++ b/src/graphon/nodes/parameter_extractor/entities.py
@@ -27,25 +27,42 @@ _VALID_PARAMETER_TYPES = frozenset([
     _OLD_BOOL_TYPE_NAME,  # old boolean type used by Parameter Extractor node
     _OLD_SELECT_TYPE_NAME,  # string type with enumeration choices.
 ])
+_LEGACY_PARAMETER_TYPE_MAP: dict[str, SegmentType] = {
+    _OLD_BOOL_TYPE_NAME: SegmentType.BOOLEAN,
+    _OLD_SELECT_TYPE_NAME: SegmentType.STRING,
+}
 
 
 def _validate_type(parameter_type: str) -> SegmentType:
     if parameter_type not in _VALID_PARAMETER_TYPES:
-        raise ValueError(
-            f"type {parameter_type} is not allowd to use in Parameter Extractor node."
-        )
-
-    if parameter_type == _OLD_BOOL_TYPE_NAME:
-        return SegmentType.BOOLEAN
-    if parameter_type == _OLD_SELECT_TYPE_NAME:
-        return SegmentType.STRING
+        msg = f"type {parameter_type} is not allowd to use in Parameter Extractor node."
+        raise ValueError(msg)
+    legacy_type = _LEGACY_PARAMETER_TYPE_MAP.get(parameter_type)
+    if legacy_type is not None:
+        return legacy_type
     return SegmentType(parameter_type)
 
 
+def _build_parameter_schema(parameter: "ParameterConfig") -> dict[str, Any]:
+    parameter_schema: dict[str, Any] = {"description": parameter.description}
+
+    if parameter.type == SegmentType.STRING:
+        parameter_schema["type"] = "string"
+    elif parameter.type.is_array_type():
+        element_type = parameter.element_type()
+        parameter_schema["type"] = "array"
+        parameter_schema["items"] = {"type": element_type.value}
+    else:
+        parameter_schema["type"] = parameter.type
+
+    if parameter.options:
+        parameter_schema["enum"] = parameter.options
+
+    return parameter_schema
+
+
 class ParameterConfig(BaseModel):
-    """
-    Parameter Config.
-    """
+    """Parameter Config."""
 
     name: str
     type: Annotated[SegmentType, BeforeValidator(_validate_type)]
@@ -55,13 +72,13 @@ class ParameterConfig(BaseModel):
 
     @field_validator("name", mode="before")
     @classmethod
-    def validate_name(cls, value) -> str:
+    def validate_name(cls, value: Any) -> str:
         if not value:
-            raise ValueError("Parameter name is required")
+            msg = "Parameter name is required"
+            raise ValueError(msg)
         if value in {"__reason", "__is_success"}:
-            raise ValueError(
-                "Invalid parameter name, __reason and __is_success are reserved"
-            )
+            msg = "Invalid parameter name, __reason and __is_success are reserved"
+            raise ValueError(msg)
         return str(value)
 
     def is_array_type(self) -> bool:
@@ -70,7 +87,11 @@ class ParameterConfig(BaseModel):
     def element_type(self) -> SegmentType:
         """Return the element type of the parameter.
 
+        Returns:
+            The element `SegmentType` for the array parameter.
+
         Raises a ValueError if the parameter's type is not an array type.
+
         """
         element_type = self.type.element_type()
         # At this point, self.type is guaranteed to be one of `ARRAY_STRING`,
@@ -84,9 +105,7 @@ class ParameterConfig(BaseModel):
 
 
 class ParameterExtractorNodeData(BaseNodeData):
-    """
-    Parameter Extractor Node Data.
-    """
+    """Parameter Extractor Node Data."""
 
     type: NodeType = BuiltinNodeTypes.PARAMETER_EXTRACTOR
     model: ModelConfig
@@ -99,15 +118,11 @@ class ParameterExtractorNodeData(BaseNodeData):
 
     @field_validator("reasoning_mode", mode="before")
     @classmethod
-    def set_reasoning_mode(cls, v) -> str:
+    def set_reasoning_mode(cls, v: Any) -> str:
         return v or "function_call"
 
-    def get_parameter_json_schema(self):
-        """
-        Get parameter json schema.
-
-        :return: parameter json schema
-        """
+    def get_parameter_json_schema(self) -> dict[str, Any]:
+        """Build the JSON schema used to validate extracted parameters."""
         parameters: dict[str, Any] = {
             "type": "object",
             "properties": {},
@@ -115,24 +130,9 @@ class ParameterExtractorNodeData(BaseNodeData):
         }
 
         for parameter in self.parameters:
-            parameter_schema: dict[str, Any] = {"description": parameter.description}
-
-            if parameter.type == SegmentType.STRING:
-                parameter_schema["type"] = "string"
-            elif parameter.type.is_array_type():
-                parameter_schema["type"] = "array"
-                element_type = parameter.type.element_type()
-                if element_type is None:
-                    raise AssertionError("element type should not be None.")
-                parameter_schema["items"] = {"type": element_type.value}
-            else:
-                parameter_schema["type"] = parameter.type
-
-            if parameter.options:
-                parameter_schema["enum"] = parameter.options
-
-            parameters["properties"][parameter.name] = parameter_schema
-
+            parameters["properties"][parameter.name] = _build_parameter_schema(
+                parameter,
+            )
             if parameter.required:
                 parameters["required"].append(parameter.name)
 

--- a/src/graphon/nodes/parameter_extractor/exc.py
+++ b/src/graphon/nodes/parameter_extractor/exc.py
@@ -63,7 +63,7 @@ class InvalidValueTypeError(ParameterExtractorNodeError):
         expected_type: SegmentType,
         actual_type: SegmentType | None,
         value: Any,
-    ):
+    ) -> None:
         message = (
             f"Invalid value for parameter {parameter_name}, "
             f"expected segment type: {expected_type}, "

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -46,7 +46,7 @@ from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.factory import build_segment_with_type
 from graphon.variables.types import ArrayValidation, SegmentType
 
-from .entities import ParameterExtractorNodeData
+from .entities import ParameterConfig, ParameterExtractorNodeData
 from .exc import (
     InvalidModelModeError,
     InvalidModelTypeError,
@@ -75,16 +75,34 @@ if TYPE_CHECKING:
     from graphon.entities.graph_init_params import GraphInitParams
     from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
+_JSON_OPEN_TOKENS = frozenset(("{", "["))
+_JSON_CLOSE_TOKENS = frozenset(("}", "]"))
+_EMPTY_STRING_SEGMENT_TYPES = frozenset((
+    SegmentType.STRING,
+    SegmentType.SECRET,
+))
+_EMPTY_STRING_PARAMETER_TYPES = frozenset(("string", "select"))
+_TRANSFORM_RESULT_UNSET = object()
+_VALUE_TRANSFORMER_NAMES: dict[SegmentType, str] = {
+    SegmentType.NUMBER: "_transform_number_value",
+    SegmentType.BOOLEAN: "_transform_boolean_value",
+    SegmentType.STRING: "_transform_string_value",
+}
+_ARRAY_ITEM_TRANSFORMER_NAMES: dict[SegmentType, str] = {
+    SegmentType.NUMBER: "_transform_number_value",
+    SegmentType.STRING: "_transform_string_value",
+    SegmentType.OBJECT: "_transform_object_value",
+    SegmentType.BOOLEAN: "_transform_boolean_item_value",
+}
 
-def extract_json(text):
-    """
-    From a given JSON started from '{' or '[' extract the complete JSON object.
-    """
+
+def extract_json(text: str) -> str | None:
+    """From a given JSON started from '{' or '[' extract the complete JSON object."""
     stack = []
     for i, c in enumerate(text):
-        if c in {"{", "["}:
+        if c in _JSON_OPEN_TOKENS:
             stack.append(c)
-        elif c in {"}", "]"}:
+        elif c in _JSON_CLOSE_TOKENS:
             # check if stack is empty
             if not stack:
                 return text[:i]
@@ -99,9 +117,7 @@ def extract_json(text):
 
 
 class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
-    """
-    Parameter Extractor Node.
-    """
+    """Parameter Extractor Node."""
 
     node_type = BuiltinNodeTypes.PARAMETER_EXTRACTOR
 
@@ -112,7 +128,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -124,7 +140,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         prompt_message_serializer: PromptMessageSerializerProtocol,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -137,8 +153,10 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
+        _ = filters
         return {
             "model": {
                 "prompt_templates": {
@@ -148,9 +166,9 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                             "assistant_prefix": "Assistant",
                         },
                         "stop": ["Human:"],
-                    }
-                }
-            }
+                    },
+                },
+            },
         }
 
     @classmethod
@@ -160,9 +178,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        """
-        Run the node.
-        """
+        """Run the node."""
         node_data = self.node_data
         variable = self.graph_runtime_state.variable_pool.get(node_data.query)
         query = variable.text if variable else ""
@@ -181,19 +197,22 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         model_instance = self._model_instance
         # Resolve variable references in string-typed completion params
         model_instance.parameters = llm_utils.resolve_completion_params_variables(
-            model_instance.parameters, variable_pool
+            model_instance.parameters,
+            variable_pool,
         )
         try:
             model_schema = llm_utils.fetch_model_schema(model_instance=model_instance)
         except ValueError as exc:
-            raise ModelSchemaNotFoundError("Model schema not found") from exc
+            msg = "Model schema not found"
+            raise ModelSchemaNotFoundError(msg) from exc
         if model_schema.model_type != ModelType.LLM:
-            raise InvalidModelTypeError("Model is not a Large Language Model")
+            msg = "Model is not a Large Language Model"
+            raise InvalidModelTypeError(msg)
         memory = self._memory
 
         if (
             set(model_schema.features or [])
-            & {ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL}
+            & frozenset((ModelFeature.TOOL_CALL, ModelFeature.MULTI_TOOL_CALL))
             and node_data.reasoning_mode == "function_call"
         ):
             # use function call
@@ -262,6 +281,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                 metadata={},
             )
         except Exception as e:
+            logger.exception("Failed to invoke parameter extractor model")
             return NodeRunResult(
                 status=WorkflowNodeExecutionStatus.FAILED,
                 inputs=inputs,
@@ -333,9 +353,8 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
 
         text = invoke_result.message.get_text_content()
         if not isinstance(text, str):
-            raise InvalidTextContentTypeError(
-                f"Invalid text content type: {type(text)}. Expected str."
-            )
+            msg = f"Invalid text content type: {type(text)}. Expected str."
+            raise InvalidTextContentTypeError(msg)
 
         usage = invoke_result.usage
         tool_call = (
@@ -356,11 +375,10 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         files: Sequence[File],
         vision_detail: ImagePromptMessageContent.DETAIL | None = None,
     ) -> tuple[list[PromptMessage], list[PromptMessageTool]]:
-        """
-        Generate function call prompt.
-        """
+        """Generate function call prompt."""
         query = FUNCTION_CALLING_EXTRACTOR_USER_TEMPLATE.format(
-            content=query, structure=json.dumps(node_data.get_parameter_json_schema())
+            content=query,
+            structure=json.dumps(node_data.get_parameter_json_schema()),
         )
 
         rest_token = self._calculate_rest_token(
@@ -371,7 +389,11 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
             context="",
         )
         prompt_template = self._get_function_calling_prompt_template(
-            node_data, query, variable_pool, memory, rest_token
+            node_data,
+            query,
+            variable_pool,
+            memory,
+            rest_token,
         )
         prompt_messages = self._compile_prompt_messages(
             model_instance=model_instance,
@@ -390,22 +412,22 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         # add function call messages before last user message
         example_messages = []
         for example in FUNCTION_CALLING_EXTRACTOR_EXAMPLE:
-            id = uuid.uuid4().hex
+            tool_call_id = uuid.uuid4().hex
             example_messages.extend([
                 UserPromptMessage(content=example["user"]["query"]),
                 AssistantPromptMessage(
                     content=example["assistant"]["text"],
                     tool_calls=[
                         AssistantPromptMessage.ToolCall(
-                            id=id,
+                            id=tool_call_id,
                             type="function",
                             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
                                 name=example["assistant"]["function_call"]["name"],
                                 arguments=json.dumps(
-                                    example["assistant"]["function_call"]["parameters"]
+                                    example["assistant"]["function_call"]["parameters"],
                                 ),
                             ),
-                        )
+                        ),
                     ],
                 ),
                 ToolPromptMessage(
@@ -413,7 +435,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                         "Great! You have called the function with the correct "
                         "parameters."
                     ),
-                    tool_call_id=id,
+                    tool_call_id=tool_call_id,
                 ),
                 AssistantPromptMessage(
                     content="I have extracted the parameters, let's move on.",
@@ -445,9 +467,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         files: Sequence[File],
         vision_detail: ImagePromptMessageContent.DETAIL | None = None,
     ) -> list[PromptMessage]:
-        """
-        Generate prompt engineering prompt.
-        """
+        """Generate prompt engineering prompt."""
         if data.model.mode == LLMMode.COMPLETION:
             return self._generate_prompt_engineering_completion_prompt(
                 node_data=data,
@@ -468,7 +488,8 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                 files=files,
                 vision_detail=vision_detail,
             )
-        raise InvalidModelModeError(f"Invalid model mode: {data.model.mode}")
+        msg = f"Invalid model mode: {data.model.mode}"
+        raise InvalidModelModeError(msg)
 
     def _generate_prompt_engineering_completion_prompt(
         self,
@@ -480,9 +501,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         files: Sequence[File],
         vision_detail: ImagePromptMessageContent.DETAIL | None = None,
     ) -> list[PromptMessage]:
-        """
-        Generate completion prompt.
-        """
+        """Generate completion prompt."""
         rest_token = self._calculate_rest_token(
             node_data=node_data,
             query=query,
@@ -515,9 +534,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         files: Sequence[File],
         vision_detail: ImagePromptMessageContent.DETAIL | None = None,
     ) -> list[PromptMessage]:
-        """
-        Generate chat prompt.
-        """
+        """Generate chat prompt."""
         rest_token = self._calculate_rest_token(
             node_data=node_data,
             query=query,
@@ -528,7 +545,8 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         prompt_template = self._get_prompt_engineering_prompt_template(
             node_data=node_data,
             query=CHAT_GENERATE_JSON_USER_MESSAGE_TEMPLATE.format(
-                structure=json.dumps(node_data.get_parameter_json_schema()), text=query
+                structure=json.dumps(node_data.get_parameter_json_schema()),
+                text=query,
             ),
             variable_pool=variable_pool,
             memory=memory,
@@ -557,34 +575,37 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                     content=CHAT_GENERATE_JSON_USER_MESSAGE_TEMPLATE.format(
                         structure=json.dumps(example["user"]["json"]),
                         text=example["user"]["query"],
-                    )
+                    ),
                 ),
                 AssistantPromptMessage(
                     content=json.dumps(example["assistant"]["json"]),
                 ),
             ])
 
-        prompt_messages = (
+        return (
             prompt_messages[:last_user_message_idx]
             + example_messages
             + prompt_messages[last_user_message_idx:]
         )
 
-        return prompt_messages
-
-    def _validate_result(self, data: ParameterExtractorNodeData, result: dict):
+    def _validate_result(
+        self,
+        data: ParameterExtractorNodeData,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
         if len(data.parameters) != len(result):
-            raise InvalidNumberOfParametersError("Invalid number of parameters")
+            msg = "Invalid number of parameters"
+            raise InvalidNumberOfParametersError(msg)
 
         for parameter in data.parameters:
             if parameter.required and parameter.name not in result:
-                raise RequiredParameterMissingError(
-                    f"Parameter {parameter.name} is required"
-                )
+                msg = f"Parameter {parameter.name} is required"
+                raise RequiredParameterMissingError(msg)
 
             param_value = result.get(parameter.name)
             if not parameter.type.is_valid(
-                param_value, array_validation=ArrayValidation.ALL
+                param_value,
+                array_validation=ArrayValidation.ALL,
             ):
                 inferred_type = SegmentType.infer_segment_type(param_value)
                 raise InvalidValueTypeError(
@@ -598,15 +619,13 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                 and parameter.options
                 and param_value not in parameter.options
             ):
-                raise InvalidSelectValueError(
-                    f"Invalid `select` value for parameter {parameter.name}"
-                )
+                msg = f"Invalid `select` value for parameter {parameter.name}"
+                raise InvalidSelectValueError(msg)
         return result
 
     @staticmethod
     def _transform_number(value: float | str | bool) -> int | float | None:
-        """
-        Attempts to transform the input into an integer or float.
+        """Attempts to transform the input into an integer or float.
 
         Returns:
             int or float: The transformed number if the conversion is successful.
@@ -617,98 +636,132 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
             `0`, respectively.
             This behavior ensures compatibility with existing workflows that may
             use boolean types as integers.
-        """
-        if isinstance(value, bool):
-            return int(value)
-        if isinstance(value, (int, float)):
-            return value
-        if isinstance(value, str):
-            if "." in value:
-                try:
-                    return float(value)
-                except ValueError:
-                    return None
-            else:
-                try:
-                    return int(value)
-                except ValueError:
-                    return None
-        else:
-            return None
 
-    def _transform_result(self, data: ParameterExtractorNodeData, result: dict):
         """
-        Transform result into standard format.
-        """
+        transformed_value: int | float | None = None
+        match value:
+            case bool():
+                transformed_value = int(value)
+            case int() | float():
+                transformed_value = value
+            case str():
+                transform = float if "." in value else int
+                try:
+                    transformed_value = transform(value)
+                except ValueError:
+                    transformed_value = None
+        return transformed_value
+
+    def _transform_result(
+        self,
+        data: ParameterExtractorNodeData,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Transform result into standard format."""
         transformed_result: dict[str, Any] = {}
         for parameter in data.parameters:
-            if parameter.name in result:
-                param_value = result[parameter.name]
-                # transform value
-                if parameter.type == SegmentType.NUMBER:
-                    transformed = self._transform_number(param_value)
-                    if transformed is not None:
-                        transformed_result[parameter.name] = transformed
-                elif parameter.type == SegmentType.BOOLEAN:
-                    if isinstance(result[parameter.name], (bool, int)):
-                        transformed_result[parameter.name] = bool(
-                            result[parameter.name]
-                        )
-                    # elif isinstance(result[parameter.name], str):
-                    #     if result[parameter.name].lower() in ["true", "false"]:
-                    #         transformed_result[parameter.name] = bool(
-                    #             result[parameter.name].lower() == "true"
-                    #         )
-                elif parameter.type == SegmentType.STRING:
-                    if isinstance(param_value, str):
-                        transformed_result[parameter.name] = param_value
-                elif parameter.is_array_type():
-                    if isinstance(param_value, list):
-                        nested_type = parameter.element_type()
-                        assert nested_type is not None
-                        segment_value = build_segment_with_type(
-                            segment_type=SegmentType(parameter.type), value=[]
-                        )
-                        transformed_result[parameter.name] = segment_value
-                        for item in param_value:
-                            if nested_type == SegmentType.NUMBER:
-                                transformed = self._transform_number(item)
-                                if transformed is not None:
-                                    segment_value.value.append(transformed)
-                            elif nested_type == SegmentType.STRING:
-                                if isinstance(item, str):
-                                    segment_value.value.append(item)
-                            elif nested_type == SegmentType.OBJECT:
-                                if isinstance(item, dict):
-                                    segment_value.value.append(item)
-                            elif nested_type == SegmentType.BOOLEAN:
-                                if isinstance(item, bool):
-                                    segment_value.value.append(item)
-
-            if parameter.name not in transformed_result:
-                if parameter.type.is_array_type():
-                    transformed_result[parameter.name] = build_segment_with_type(
-                        segment_type=SegmentType(parameter.type), value=[]
-                    )
-                elif parameter.type in (SegmentType.STRING, SegmentType.SECRET):
-                    transformed_result[parameter.name] = ""
-                elif parameter.type == SegmentType.NUMBER:
-                    transformed_result[parameter.name] = 0
-                elif parameter.type == SegmentType.BOOLEAN:
-                    transformed_result[parameter.name] = False
-                else:
-                    raise AssertionError("this statement should be unreachable.")
+            transformed_value = self._transform_parameter_value(
+                parameter=parameter,
+                param_value=result.get(parameter.name, _TRANSFORM_RESULT_UNSET),
+            )
+            if transformed_value is _TRANSFORM_RESULT_UNSET:
+                transformed_result[parameter.name] = (
+                    self._build_default_parameter_value(parameter.type)
+                )
+                continue
+            transformed_result[parameter.name] = transformed_value
 
         return transformed_result
 
-    def _extract_complete_json_response(self, result: str) -> dict | None:
-        """
-        Extract complete json response.
-        """
+    def _transform_parameter_value(
+        self,
+        *,
+        parameter: ParameterConfig,
+        param_value: Any,
+    ) -> Any:
+        if param_value is _TRANSFORM_RESULT_UNSET:
+            return _TRANSFORM_RESULT_UNSET
+        if parameter.type.is_array_type():
+            return self._transform_array_parameter_value(
+                parameter_type=parameter.type,
+                element_type=parameter.element_type(),
+                param_value=param_value,
+            )
 
+        handler_name = _VALUE_TRANSFORMER_NAMES.get(parameter.type)
+        if handler_name is None:
+            return _TRANSFORM_RESULT_UNSET
+        return getattr(self, handler_name)(param_value)
+
+    def _transform_array_parameter_value(
+        self,
+        *,
+        parameter_type: SegmentType,
+        element_type: SegmentType,
+        param_value: Any,
+    ) -> Any:
+        if not isinstance(param_value, list):
+            return _TRANSFORM_RESULT_UNSET
+
+        segment_value = build_segment_with_type(segment_type=parameter_type, value=[])
+        handler_name = _ARRAY_ITEM_TRANSFORMER_NAMES.get(element_type)
+        if handler_name is None:
+            return segment_value
+
+        for item in param_value:
+            transformed_item = getattr(self, handler_name)(item)
+            if transformed_item is not _TRANSFORM_RESULT_UNSET:
+                segment_value.value.append(transformed_item)
+        return segment_value
+
+    def _transform_number_value(self, value: Any) -> Any:
+        transformed = self._transform_number(value)
+        if transformed is None:
+            return _TRANSFORM_RESULT_UNSET
+        return transformed
+
+    @staticmethod
+    def _transform_boolean_value(value: Any) -> Any:
+        if isinstance(value, (bool, int)):
+            return bool(value)
+        return _TRANSFORM_RESULT_UNSET
+
+    @staticmethod
+    def _transform_boolean_item_value(value: Any) -> Any:
+        if isinstance(value, bool):
+            return value
+        return _TRANSFORM_RESULT_UNSET
+
+    @staticmethod
+    def _transform_string_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return value
+        return _TRANSFORM_RESULT_UNSET
+
+    @staticmethod
+    def _transform_object_value(value: Any) -> Any:
+        if isinstance(value, dict):
+            return value
+        return _TRANSFORM_RESULT_UNSET
+
+    @staticmethod
+    def _build_default_parameter_value(parameter_type: SegmentType) -> Any:
+        if parameter_type.is_array_type():
+            return build_segment_with_type(segment_type=parameter_type, value=[])
+        if parameter_type in _EMPTY_STRING_SEGMENT_TYPES:
+            return ""
+        if parameter_type == SegmentType.NUMBER:
+            return 0
+        if parameter_type == SegmentType.BOOLEAN:
+            return False
+        msg = "this statement should be unreachable."
+        raise AssertionError(msg)
+
+    def _extract_complete_json_response(self, result: str) -> dict | None:
+        """Extract complete json response."""
         # extract json from the text
         for idx in range(len(result)):
-            if result[idx] == "{" or result[idx] == "[":
+            if result[idx] in _JSON_OPEN_TOKENS:
                 json_str = extract_json(result[idx:])
                 if json_str:
                     with contextlib.suppress(Exception):
@@ -719,18 +772,17 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         return None
 
     def _extract_json_from_tool_call(
-        self, tool_call: AssistantPromptMessage.ToolCall
+        self,
+        tool_call: AssistantPromptMessage.ToolCall,
     ) -> dict | None:
-        """
-        Extract json from tool call.
-        """
+        """Extract json from tool call."""
         if not tool_call or not tool_call.function.arguments:
             return None
 
         result = tool_call.function.arguments
         # extract json from the arguments
         for idx in range(len(result)):
-            if result[idx] == "{" or result[idx] == "[":
+            if result[idx] in _JSON_OPEN_TOKENS:
                 json_str = extract_json(result[idx:])
                 if json_str:
                     with contextlib.suppress(Exception):
@@ -741,17 +793,18 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         logger.info("extra error: %s", result)
         return None
 
-    def _generate_default_result(self, data: ParameterExtractorNodeData):
-        """
-        Generate default result.
-        """
+    def _generate_default_result(
+        self,
+        data: ParameterExtractorNodeData,
+    ) -> dict[str, Any]:
+        """Generate default result."""
         result: dict[str, Any] = {}
         for parameter in data.parameters:
             if parameter.type == "number":
                 result[parameter.name] = 0
             elif parameter.type == "boolean":
                 result[parameter.name] = False
-            elif parameter.type in {"string", "select"}:
+            elif parameter.type in _EMPTY_STRING_PARAMETER_TYPES:
                 result[parameter.name] = ""
 
         return result
@@ -778,14 +831,17 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
             system_prompt_messages = LLMNodeChatModelMessage(
                 role=PromptMessageRole.SYSTEM,
                 text=FUNCTION_CALLING_EXTRACTOR_SYSTEM_PROMPT.format(
-                    histories=memory_str, instruction=instruction
+                    histories=memory_str,
+                    instruction=instruction,
                 ),
             )
             user_prompt_message = LLMNodeChatModelMessage(
-                role=PromptMessageRole.USER, text=input_text
+                role=PromptMessageRole.USER,
+                text=input_text,
             )
             return [system_prompt_messages, user_prompt_message]
-        raise InvalidModelModeError(f"Model mode {node_data.model.mode} not support.")
+        msg = f"Model mode {node_data.model.mode} not support."
+        raise InvalidModelModeError(msg)
 
     def _get_prompt_engineering_prompt_template(
         self,
@@ -809,24 +865,28 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
             system_prompt_messages = LLMNodeChatModelMessage(
                 role=PromptMessageRole.SYSTEM,
                 text=CHAT_GENERATE_JSON_PROMPT.format(
-                    histories=memory_str, instruction=instruction
+                    histories=memory_str,
+                    instruction=instruction,
                 ),
             )
             user_prompt_message = LLMNodeChatModelMessage(
-                role=PromptMessageRole.USER, text=input_text
+                role=PromptMessageRole.USER,
+                text=input_text,
             )
             return [system_prompt_messages, user_prompt_message]
         if node_data.model.mode == LLMMode.COMPLETION:
             return LLMNodeCompletionModelPromptTemplate(
                 text=COMPLETION_GENERATE_JSON_PROMPT
                 .format(histories=memory_str, text=input_text, instruction=instruction)
-                .replace("{γγγ", "")
-                .replace("}γγγ", "")
+                .replace("{γγγ", "")  # noqa: RUF001
+                .replace("}γγγ", "")  # noqa: RUF001
                 .replace(
-                    "{ structure }", json.dumps(node_data.get_parameter_json_schema())
+                    "{ structure }",
+                    json.dumps(node_data.get_parameter_json_schema()),
                 ),
             )
-        raise InvalidModelModeError(f"Model mode {node_data.model.mode} not support.")
+        msg = f"Model mode {node_data.model.mode} not support."
+        raise InvalidModelModeError(msg)
 
     def _calculate_rest_token(
         self,
@@ -839,21 +899,30 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         try:
             model_schema = llm_utils.fetch_model_schema(model_instance=model_instance)
         except ValueError as exc:
-            raise ModelSchemaNotFoundError("Model schema not found") from exc
+            msg = "Model schema not found"
+            raise ModelSchemaNotFoundError(msg) from exc
 
         prompt_template: (
             list[LLMNodeChatModelMessage] | LLMNodeCompletionModelPromptTemplate
         )
-        if set(model_schema.features or []) & {
+        if set(model_schema.features or []) & frozenset((
             ModelFeature.TOOL_CALL,
             ModelFeature.MULTI_TOOL_CALL,
-        }:
+        )):
             prompt_template = self._get_function_calling_prompt_template(
-                node_data, query, variable_pool, None, 2000
+                node_data,
+                query,
+                variable_pool,
+                None,
+                2000,
             )
         else:
             prompt_template = self._get_prompt_engineering_prompt_template(
-                node_data, query, variable_pool, None, 2000
+                node_data,
+                query,
+                variable_pool,
+                None,
+                2000,
             )
 
         prompt_messages = self._compile_prompt_messages(
@@ -865,7 +934,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         )
         rest_tokens = 2000
         model_context_tokens = model_schema.model_properties.get(
-            ModelPropertyKey.CONTEXT_SIZE
+            ModelPropertyKey.CONTEXT_SIZE,
         )
         if model_context_tokens:
             curr_message_tokens = (
@@ -881,7 +950,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
                     max_tokens = (
                         model_instance.parameters.get(parameter_rule.name)
                         or model_instance.parameters.get(
-                            parameter_rule.use_template or ""
+                            parameter_rule.use_template or "",
                         )
                     ) or 0
 
@@ -935,13 +1004,9 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
 
         if node_data.instruction:
             selectors = variable_template_parser.extract_selectors_from_template(
-                node_data.instruction
+                node_data.instruction,
             )
             for selector in selectors:
                 variable_mapping[selector.variable] = selector.value_selector
 
-        variable_mapping = {
-            node_id + "." + key: value for key, value in variable_mapping.items()
-        }
-
-        return variable_mapping
+        return {node_id + "." + key: value for key, value in variable_mapping.items()}

--- a/src/graphon/nodes/parameter_extractor/prompts.py
+++ b/src/graphon/nodes/parameter_extractor/prompts.py
@@ -100,7 +100,7 @@ FUNCTION_CALLING_EXTRACTOR_EXAMPLE: list[dict[str, Any]] = [
                             "type": "string",
                             "description": "The food to eat",
                             "required": True,
-                        }
+                        },
                     },
                     "required": ["food"],
                 },
@@ -152,10 +152,10 @@ COMPLETION_GENERATE_JSON_PROMPT = (
     "### Structure\n"
     "Here is the structure of the expected output, I should always follow the "
     "output structure.\n"
-    "{{γγγ\n"
+    "{{γγγ\n"  # noqa: RUF001
     "  'properties1': 'relevant text extracted from input',\n"
     "  'properties2': 'relevant text extracted from input',\n"
-    "}}γγγ\n\n"
+    "}}γγγ\n\n"  # noqa: RUF001
     "### Input Text\n"
     "Inside <text></text> XML tags, there is a text that I should extract "
     "parameters and convert to a JSON object.\n"
@@ -211,7 +211,7 @@ CHAT_EXAMPLE = [
                         "type": "string",
                         "description": ("The location to get the weather information"),
                         "required": True,
-                    }
+                    },
                 },
                 "required": ["location"],
             },
@@ -231,7 +231,7 @@ CHAT_EXAMPLE = [
                         "type": "string",
                         "description": "The food to eat",
                         "required": True,
-                    }
+                    },
                 },
                 "required": ["food"],
             },

--- a/src/graphon/nodes/protocols.py
+++ b/src/graphon/nodes/protocols.py
@@ -19,7 +19,8 @@ class ToolFileManagerProtocol(Protocol):
     ) -> Any: ...
 
     def get_file_generator_by_tool_file_id(
-        self, tool_file_id: str
+        self,
+        tool_file_id: str,
     ) -> tuple[Generator | None, File | None]: ...
 
 

--- a/src/graphon/nodes/question_classifier/question_classifier_node.py
+++ b/src/graphon/nodes/question_classifier/question_classifier_node.py
@@ -76,7 +76,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -89,9 +89,9 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         memory: PromptMessageMemory | None = None,
         llm_file_saver: LLMFileSaver,
         prompt_message_serializer: PromptMessageSerializerProtocol | None = None,
-    ):
+    ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -131,13 +131,14 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         model_instance = self._model_instance
         # Resolve variable references in string-typed completion params
         model_instance.parameters = llm_utils.resolve_completion_params_variables(
-            model_instance.parameters, variable_pool
+            model_instance.parameters,
+            variable_pool,
         )
         memory = self._memory
         # fetch instruction
         node_data.instruction = node_data.instruction or ""
         node_data.instruction = variable_pool.convert_template(
-            node_data.instruction
+            node_data.instruction,
         ).text
 
         files = (
@@ -198,7 +199,6 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
                 file_saver=self._llm_file_saver,
                 file_outputs=self._file_outputs,
                 node_id=self._node_id,
-                node_type=self.node_type,
             )
 
             for event in generator:
@@ -210,7 +210,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
 
             rendered_classes = [
                 c.model_copy(
-                    update={"name": variable_pool.convert_template(c.name).text}
+                    update={"name": variable_pool.convert_template(c.name).text},
                 )
                 for c in node_data.classes
             ]
@@ -233,14 +233,15 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
                 category_id_result = result_text_json["category_id"]
                 classes = rendered_classes
                 classes_map = {class_.id: class_.name for class_ in classes}
-                category_ids = [_class.id for _class in classes]
+                category_ids = [class_.id for class_ in classes]
                 if category_id_result in category_ids:
                     category_name = classes_map[category_id_result]
                     category_id = category_id_result
             process_data = {
                 "model_mode": node_data.model.mode,
                 "prompts": self._prompt_message_serializer.serialize(
-                    model_mode=node_data.model.mode, prompt_messages=prompt_messages
+                    model_mode=node_data.model.mode,
+                    prompt_messages=prompt_messages,
                 ),
                 "usage": jsonable_encoder(usage),
                 "finish_reason": finish_reason,
@@ -293,39 +294,31 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         node_id: str,
         node_data: QuestionClassifierNodeData,
     ) -> Mapping[str, Sequence[str]]:
-        # graph_config is not used in this node type
+        _ = graph_config
         variable_mapping = {"query": node_data.query_variable_selector}
         variable_selectors: list[VariableSelector] = []
         if node_data.instruction:
             variable_template_parser = VariableTemplateParser(
-                template=node_data.instruction
+                template=node_data.instruction,
             )
             variable_selectors.extend(
-                variable_template_parser.extract_variable_selectors()
+                variable_template_parser.extract_variable_selectors(),
             )
         for variable_selector in variable_selectors:
             variable_mapping[variable_selector.variable] = list(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
 
-        variable_mapping = {
-            node_id + "." + key: value for key, value in variable_mapping.items()
-        }
-
-        return variable_mapping
+        return {node_id + "." + key: value for key, value in variable_mapping.items()}
 
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
-        """
-        Get default config of node.
-        :param filters: filter by node config parameters (not used in this
-            implementation).
-        :return:
-        """
-        # filters parameter is not used in this node type
+        """Build the default question-classifier node config."""
+        _ = filters
         return {"type": "question-classifier", "config": {"instructions": ""}}
 
     def _calculate_rest_token(
@@ -356,7 +349,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         rest_tokens = 2000
 
         model_context_tokens = model_schema.model_properties.get(
-            ModelPropertyKey.CONTEXT_SIZE
+            ModelPropertyKey.CONTEXT_SIZE,
         )
         if model_context_tokens:
             curr_message_tokens = model_instance.get_llm_num_tokens(prompt_messages)
@@ -370,7 +363,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
                     max_tokens = (
                         model_instance.parameters.get(parameter_rule.name)
                         or model_instance.parameters.get(
-                            parameter_rule.use_template or ""
+                            parameter_rule.use_template or "",
                         )
                     ) or 0
 
@@ -385,7 +378,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         query: str,
         memory: PromptMessageMemory | None,
         max_token_limit: int = 2000,
-    ):
+    ) -> list[LLMNodeChatModelMessage] | LLMNodeCompletionModelPromptTemplate:
         model_mode = LLMMode(node_data.model.mode)
         classes = node_data.classes
         categories = []
@@ -411,7 +404,8 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             )
             prompt_messages.append(system_prompt_messages)
             user_prompt_message_1 = LLMNodeChatModelMessage(
-                role=PromptMessageRole.USER, text=QUESTION_CLASSIFIER_USER_PROMPT_1
+                role=PromptMessageRole.USER,
+                text=QUESTION_CLASSIFIER_USER_PROMPT_1,
             )
             prompt_messages.append(user_prompt_message_1)
             assistant_prompt_message_1 = LLMNodeChatModelMessage(
@@ -420,7 +414,8 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             )
             prompt_messages.append(assistant_prompt_message_1)
             user_prompt_message_2 = LLMNodeChatModelMessage(
-                role=PromptMessageRole.USER, text=QUESTION_CLASSIFIER_USER_PROMPT_2
+                role=PromptMessageRole.USER,
+                text=QUESTION_CLASSIFIER_USER_PROMPT_2,
             )
             prompt_messages.append(user_prompt_message_2)
             assistant_prompt_message_2 = LLMNodeChatModelMessage(
@@ -445,7 +440,8 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
                     input_text=input_text,
                     categories=json.dumps(categories, ensure_ascii=False),
                     classification_instructions=instruction,
-                )
+                ),
             )
 
-        raise InvalidModelTypeError(f"Model mode {model_mode} not support.")
+        msg = f"Model mode {model_mode} not support."
+        raise InvalidModelTypeError(msg)

--- a/src/graphon/nodes/start/entities.py
+++ b/src/graphon/nodes/start/entities.py
@@ -8,9 +8,7 @@ from graphon.variables.input_entities import VariableEntity
 
 
 class StartNodeData(BaseNodeData):
-    """
-    Start Node Data
-    """
+    """Start Node Data"""
 
     type: NodeType = BuiltinNodeTypes.START
     variables: Sequence[VariableEntity] = Field(default_factory=list)

--- a/src/graphon/nodes/start/start_node.py
+++ b/src/graphon/nodes/start/start_node.py
@@ -25,11 +25,11 @@ class StartNode(Node[StartNodeData]):
     @override
     def _run(self) -> NodeRunResult:
         node_inputs = dict(
-            self.graph_runtime_state.variable_pool.get_by_prefix(self.id)
+            self.graph_runtime_state.variable_pool.get_by_prefix(self.id),
         )
         self._validate_and_normalize_json_object_inputs(node_inputs)
         outputs = dict(
-            self.graph_runtime_state.variable_pool.flatten(unprefixed_node_id=self.id)
+            self.graph_runtime_state.variable_pool.flatten(unprefixed_node_id=self.id),
         )
         outputs.update(node_inputs)
 
@@ -40,7 +40,8 @@ class StartNode(Node[StartNodeData]):
         )
 
     def _validate_and_normalize_json_object_inputs(
-        self, node_inputs: dict[str, Any]
+        self,
+        node_inputs: dict[str, Any],
     ) -> None:
         for variable in self.node_data.variables:
             if variable.type != VariableEntityType.JSON_OBJECT:
@@ -50,14 +51,16 @@ class StartNode(Node[StartNodeData]):
             value = node_inputs.get(key)
 
             if value is None and variable.required:
-                raise ValueError(f"{key} is required in input form")
+                msg = f"{key} is required in input form"
+                raise ValueError(msg)
 
             # If no value provided, skip further processing for this key
             if not value:
                 continue
 
             if not isinstance(value, dict):
-                raise ValueError(f"JSON object for '{key}' must be an object")
+                msg = f"JSON object for '{key}' must be an object"
+                raise TypeError(msg)
 
             # Overwrite with normalized dict to ensure downstream consistency
             node_inputs[key] = value
@@ -70,6 +73,5 @@ class StartNode(Node[StartNodeData]):
             try:
                 Draft7Validator(schema).validate(value)
             except ValidationError as e:
-                raise ValueError(
-                    f"JSON object for '{key}' does not match schema: {e.message}"
-                )
+                msg = f"JSON object for '{key}' does not match schema: {e.message}"
+                raise ValueError(msg) from e

--- a/src/graphon/nodes/template_transform/entities.py
+++ b/src/graphon/nodes/template_transform/entities.py
@@ -4,9 +4,7 @@ from graphon.nodes.base.entities import VariableSelector
 
 
 class TemplateTransformNodeData(BaseNodeData):
-    """
-    Template Transform Node Data.
-    """
+    """Template Transform Node Data."""
 
     type: NodeType = BuiltinNodeTypes.TEMPLATE_TRANSFORM
     variables: list[VariableSelector]

--- a/src/graphon/nodes/template_transform/template_transform_node.py
+++ b/src/graphon/nodes/template_transform/template_transform_node.py
@@ -27,7 +27,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
@@ -36,7 +36,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
         max_output_length: int | None = None,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -44,7 +44,8 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
         self._jinja2_template_renderer = jinja2_template_renderer
 
         if max_output_length is not None and max_output_length <= 0:
-            raise ValueError("max_output_length must be a positive integer")
+            msg = "max_output_length must be a positive integer"
+            raise ValueError(msg)
         self._max_output_length = (
             max_output_length or DEFAULT_TEMPLATE_TRANSFORM_MAX_OUTPUT_LENGTH
         )
@@ -52,13 +53,11 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
     @classmethod
     @override
     def get_default_config(
-        cls, filters: Mapping[str, object] | None = None
+        cls,
+        filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
-        """
-        Get default config of node.
-        :param filters: filter by node config parameters.
-        :return:
-        """
+        """Build the default template-transform node config."""
+        _ = filters
         return {
             "type": "template-transform",
             "config": {
@@ -79,13 +78,14 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
         for variable_selector in self.node_data.variables:
             variable_name = variable_selector.variable
             value = self.graph_runtime_state.variable_pool.get(
-                variable_selector.value_selector
+                variable_selector.value_selector,
             )
             variables[variable_name] = value.to_object() if value else None
         # Run code
         try:
             rendered = self._jinja2_template_renderer.render_template(
-                self.node_data.template, variables
+                self.node_data.template,
+                variables,
             )
         except TemplateRenderError as e:
             return NodeRunResult(

--- a/src/graphon/nodes/tool/entities.py
+++ b/src/graphon/nodes/tool/entities.py
@@ -7,11 +7,18 @@ from pydantic_core.core_schema import ValidationInfo
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import BuiltinNodeTypes, NodeType
 
+_SUPPORTED_TOOL_CONFIGURATION_VALUE_TYPES = (str, int, float, bool)
+_SUPPORTED_TOOL_INPUT_CONSTANT_VALUE_TYPES = (str, int, float, bool, dict, list)
+_SUPPORTED_TOOL_CONFIGURATION_VALUE_TYPE_NAMES = ", ".join(
+    value_type.__name__ for value_type in _SUPPORTED_TOOL_CONFIGURATION_VALUE_TYPES
+)
+_SUPPORTED_TOOL_INPUT_CONSTANT_VALUE_TYPE_NAMES = ", ".join(
+    value_type.__name__ for value_type in _SUPPORTED_TOOL_INPUT_CONSTANT_VALUE_TYPES
+)
+
 
 class ToolProviderType(StrEnum):
-    """
-    Graph-owned enum for persisted tool provider kinds.
-    """
+    """Graph-owned enum for persisted tool provider kinds."""
 
     PLUGIN = auto()
     BUILT_IN = "builtin"
@@ -34,50 +41,84 @@ class ToolEntity(BaseModel):
 
     @field_validator("tool_configurations", mode="before")
     @classmethod
-    def validate_tool_configurations(cls, value, values: ValidationInfo):
-        if not isinstance(value, dict):
-            raise ValueError("tool_configurations must be a dictionary")
+    def validate_tool_configurations(
+        cls,
+        value: Any,
+        values: ValidationInfo,
+    ) -> dict[str, Any]:
+        _ = values
+        match value:
+            case dict():
+                configurations = value
+            case _:
+                msg = "tool_configurations must be a dictionary"
+                raise ValueError(msg)
 
-        for key in values.data.get("tool_configurations", {}):
-            value = values.data.get("tool_configurations", {}).get(key)
-            if not isinstance(value, str | int | float | bool):
-                raise ValueError(f"{key} must be a string")
+        for key, config_value in configurations.items():
+            match config_value:
+                case str() | int() | float() | bool():
+                    pass
+                case _:
+                    msg = (
+                        f"{key} must be one of: "
+                        f"{_SUPPORTED_TOOL_CONFIGURATION_VALUE_TYPE_NAMES}"
+                    )
+                    raise ValueError(msg)
 
-        return value
+        return configurations
 
 
 class ToolNodeData(BaseNodeData, ToolEntity):
     type: NodeType = BuiltinNodeTypes.TOOL
 
     class ToolInput(BaseModel):
+        """Persisted tool input value and its binding mode."""
+
         # TODO: check this type
         value: Any | list[str]
         type: Literal["mixed", "variable", "constant"]
 
         @field_validator("type", mode="before")
         @classmethod
-        def check_type(cls, value, validation_info: ValidationInfo):
+        def check_type(
+            cls,
+            value: Any,
+            validation_info: ValidationInfo,
+        ) -> Literal["mixed", "variable", "constant"]:
             typ = value
             value = validation_info.data.get("value")
 
             if value is None:
                 return typ
 
-            if typ == "mixed" and not isinstance(value, str):
-                raise ValueError("value must be a string")
-            if typ == "variable":
-                if not isinstance(value, list):
-                    raise ValueError("value must be a list")
-                for val in value:
-                    if not isinstance(val, str):
-                        raise ValueError("value must be a list of strings")
-            elif typ == "constant" and not isinstance(
-                value, (allowed_types := (str, int, float, bool, dict, list))
-            ):
-                raise ValueError(
-                    f"value must be one of: "
-                    f"{', '.join(t.__name__ for t in allowed_types)}"
-                )
+            match typ:
+                case "mixed":
+                    match value:
+                        case str():
+                            pass
+                        case _:
+                            msg = "value must be a string"
+                            raise ValueError(msg)
+                case "variable":
+                    match value:
+                        case list() if all(isinstance(val, str) for val in value):
+                            pass
+                        case list():
+                            msg = "value must be a list of strings"
+                            raise ValueError(msg)
+                        case _:
+                            msg = "value must be a list"
+                            raise ValueError(msg)
+                case "constant":
+                    match value:
+                        case str() | int() | float() | bool() | dict() | list():
+                            pass
+                        case _:
+                            msg = (
+                                f"value must be one of: "
+                                f"{_SUPPORTED_TOOL_INPUT_CONSTANT_VALUE_TYPE_NAMES}"
+                            )
+                            raise ValueError(msg)
             return typ
 
     tool_parameters: dict[str, ToolInput]
@@ -88,7 +129,7 @@ class ToolNodeData(BaseNodeData, ToolEntity):
 
     @field_validator("tool_parameters", mode="before")
     @classmethod
-    def filter_none_tool_inputs(cls, value):
+    def filter_none_tool_inputs(cls, value: Any) -> Any:
         if not isinstance(value, dict):
             return value
 
@@ -99,8 +140,11 @@ class ToolNodeData(BaseNodeData, ToolEntity):
         }
 
     @staticmethod
-    def _has_valid_value(tool_input):
+    def _has_valid_value(tool_input: Any) -> bool:
         """Check if the value is valid"""
-        if isinstance(tool_input, dict):
-            return tool_input.get("value") is not None
-        return getattr(tool_input, "value", None) is not None
+        match tool_input:
+            case dict():
+                result = tool_input.get("value") is not None
+            case _:
+                result = getattr(tool_input, "value", None) is not None
+        return result

--- a/src/graphon/nodes/tool/tool_node.py
+++ b/src/graphon/nodes/tool/tool_node.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator, Mapping, Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, override
 
 from graphon.entities.graph_config import NodeConfigDict
@@ -10,7 +11,7 @@ from graphon.enums import (
 from graphon.file.enums import FileTransferMethod
 from graphon.file.file_factory import get_file_type_by_mime_type
 from graphon.file.models import File
-from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.graph_events.node import NodeRunStartedEvent
 from graphon.node_events.base import (
     NodeEventBase,
     NodeRunResult,
@@ -43,33 +44,54 @@ if TYPE_CHECKING:
     from graphon.runtime.variable_pool import VariablePool
 
 
+_MESSAGE_HANDLER_NAMES: dict[ToolRuntimeMessage.MessageType, str] = {
+    ToolRuntimeMessage.MessageType.IMAGE_LINK: "_handle_linked_file_message",
+    ToolRuntimeMessage.MessageType.BINARY_LINK: "_handle_linked_file_message",
+    ToolRuntimeMessage.MessageType.IMAGE: "_handle_linked_file_message",
+    ToolRuntimeMessage.MessageType.BLOB: "_handle_blob_message",
+    ToolRuntimeMessage.MessageType.TEXT: "_handle_text_message",
+    ToolRuntimeMessage.MessageType.JSON: "_handle_json_message",
+    ToolRuntimeMessage.MessageType.LINK: "_handle_link_message",
+    ToolRuntimeMessage.MessageType.VARIABLE: "_handle_variable_message",
+    ToolRuntimeMessage.MessageType.FILE: "_handle_file_message",
+    ToolRuntimeMessage.MessageType.LOG: "_handle_log_message",
+}
+
+
+@dataclass(slots=True)
+class _ToolMessageState:
+    text: str = ""
+    files: list[File] = field(default_factory=list)
+    json_values: list[dict | list] = field(default_factory=list)
+    variables: dict[str, Any] = field(default_factory=dict)
+
+
 class ToolNode(Node[ToolNodeData]):
-    """
-    Tool Node
-    """
+    """Tool Node"""
 
     node_type = BuiltinNodeTypes.TOOL
 
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
         *,
         tool_file_manager_factory: ToolFileManagerProtocol,
         runtime: ToolNodeRuntimeProtocol | None = None,
-    ):
+    ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
         self._tool_file_manager_factory = tool_file_manager_factory
         if runtime is None:
-            raise ValueError("runtime is required")
+            msg = "runtime is required"
+            raise ValueError(msg)
         self._runtime = runtime
 
     @classmethod
@@ -78,15 +100,13 @@ class ToolNode(Node[ToolNodeData]):
         return "1"
 
     @override
-    def populate_start_event(self, event) -> None:
+    def populate_start_event(self, event: NodeRunStartedEvent) -> None:
         event.provider_id = self.node_data.provider_id
         event.provider_type = self.node_data.provider_type
 
     @override
     def _run(self) -> Generator[NodeEventBase, None, None]:
-        """
-        Run the tool node
-        """
+        """Run the tool node"""
         # fetch tool icon
         tool_info = {
             "provider_type": self.node_data.provider_type.value,
@@ -119,13 +139,13 @@ class ToolNode(Node[ToolNodeData]):
                     metadata={WorkflowNodeExecutionMetadataKey.TOOL_INFO: tool_info},
                     error=f"Failed to get tool runtime: {e!s}",
                     error_type=type(e).__name__,
-                )
+                ),
             )
             return
 
         # get parameters
         tool_parameters = self._runtime.get_runtime_parameters(
-            tool_runtime=tool_runtime
+            tool_runtime=tool_runtime,
         )
         parameters = self._generate_parameters(
             tool_parameters=tool_parameters,
@@ -153,13 +173,13 @@ class ToolNode(Node[ToolNodeData]):
                     metadata={WorkflowNodeExecutionMetadataKey.TOOL_INFO: tool_info},
                     error=f"Failed to invoke tool: {e!s}",
                     error_type=type(e).__name__,
-                )
+                ),
             )
             return
 
         try:
             # convert tool messages
-            _ = yield from self._transform_message(
+            yield from self._transform_message(
                 messages=message_stream,
                 tool_info=tool_info,
                 parameters_for_log=parameters_for_log,
@@ -174,7 +194,7 @@ class ToolNode(Node[ToolNodeData]):
                     metadata={WorkflowNodeExecutionMetadataKey.TOOL_INFO: tool_info},
                     error=str(e),
                     error_type=type(e).__name__,
-                )
+                ),
             )
 
     def _generate_parameters(
@@ -185,8 +205,7 @@ class ToolNode(Node[ToolNodeData]):
         node_data: ToolNodeData,
         for_log: bool = False,
     ) -> dict[str, Any]:
-        """
-        Generate parameters based on the given tool parameters,
+        """Generate parameters based on the given tool parameters,
         variable pool, and node data.
 
         Args:
@@ -194,9 +213,14 @@ class ToolNode(Node[ToolNodeData]):
             parameters.
             variable_pool (VariablePool): The variable pool containing the variables.
             node_data (ToolNodeData): The data associated with the tool node.
+            for_log (bool): Whether to produce log-friendly parameter values.
 
         Returns:
             Mapping[str, Any]: A dictionary containing the generated parameters.
+
+        Raises:
+            ToolParameterError: If a required variable is missing or a tool
+                input type is unknown.
 
         """
         tool_parameters_dictionary = {
@@ -214,16 +238,16 @@ class ToolNode(Node[ToolNodeData]):
                 variable = variable_pool.get(tool_input.value)
                 if variable is None:
                     if parameter.required:
-                        raise ToolParameterError(
-                            f"Variable {tool_input.value} does not exist"
-                        )
+                        msg = f"Variable {tool_input.value} does not exist"
+                        raise ToolParameterError(msg)
                     continue
                 parameter_value = variable.value
-            elif tool_input.type in {"mixed", "constant"}:
+            elif tool_input.type in frozenset(("mixed", "constant")):
                 segment_group = variable_pool.convert_template(str(tool_input.value))
                 parameter_value = segment_group.log if for_log else segment_group.text
             else:
-                raise ToolParameterError(f"Unknown tool input type '{tool_input.type}'")
+                msg = f"Unknown tool input type '{tool_input.type}'"
+                raise ToolParameterError(msg)
             result[parameter_name] = parameter_value
 
         return result
@@ -236,188 +260,271 @@ class ToolNode(Node[ToolNodeData]):
         node_id: str,
         tool_runtime: ToolRuntimeHandle,
         **_: Any,
-    ) -> Generator[NodeEventBase, None, LLMUsage]:
-        """
-        Convert graph-owned tool runtime messages into node outputs.
-        """
-        text = ""
-        files: list[File] = []
-        json: list[dict | list] = []
-
-        variables: dict[str, Any] = {}
+    ) -> Generator[NodeEventBase, None, None]:
+        """Convert graph-owned tool runtime messages into node outputs."""
+        state = _ToolMessageState()
 
         for message in messages:
-            if message.type in {
-                ToolRuntimeMessage.MessageType.IMAGE_LINK,
-                ToolRuntimeMessage.MessageType.BINARY_LINK,
-                ToolRuntimeMessage.MessageType.IMAGE,
-            }:
-                assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
+            handler_name = _MESSAGE_HANDLER_NAMES.get(message.type)
+            if handler_name is None:
+                continue
+            yield from getattr(self, handler_name)(
+                message=message,
+                state=state,
+                node_id=node_id,
+                tool_info=tool_info,
+            )
 
-                url = message.message.text
-                if message.meta:
-                    transfer_method = message.meta.get(
-                        "transfer_method", FileTransferMethod.TOOL_FILE
-                    )
-                    tool_file_id = message.meta.get("tool_file_id")
-                else:
-                    transfer_method = FileTransferMethod.TOOL_FILE
-                    tool_file_id = None
-                if not isinstance(tool_file_id, str) or not tool_file_id:
-                    raise ToolFileError("tool message is missing tool_file_id metadata")
+        yield from self._emit_final_stream_events(state)
 
-                _stream, tool_file = (
-                    self._tool_file_manager_factory.get_file_generator_by_tool_file_id(
-                        tool_file_id
-                    )
-                )
-                if not tool_file:
-                    raise ToolFileError(f"tool file {tool_file_id} not found")
-                if tool_file.mime_type is None:
-                    raise ToolFileError(
-                        f"tool file {tool_file_id} is missing mime type"
-                    )
+        usage = self._runtime.get_usage(tool_runtime=tool_runtime)
+        metadata = self._build_completion_metadata(tool_info=tool_info, usage=usage)
 
-                file_mapping: dict[str, Any] = {
-                    "tool_file_id": tool_file_id,
-                    "type": get_file_type_by_mime_type(tool_file.mime_type),
-                    "transfer_method": transfer_method,
-                    "url": url,
-                }
-                file = self._runtime.build_file_reference(mapping=file_mapping)
-                files.append(file)
-            elif message.type == ToolRuntimeMessage.MessageType.BLOB:
-                # get tool file id
-                assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
-                assert message.meta
+        yield StreamCompletedEvent(
+            node_run_result=NodeRunResult(
+                status=WorkflowNodeExecutionStatus.SUCCEEDED,
+                outputs={
+                    "text": state.text,
+                    "files": ArrayFileSegment(value=state.files),
+                    "json": self._normalize_json_output(state),
+                    **state.variables,
+                },
+                metadata=metadata,
+                inputs=parameters_for_log,
+                llm_usage=usage,
+            ),
+        )
 
-                tool_file_id = message.meta.get("tool_file_id")
-                if not isinstance(tool_file_id, str) or not tool_file_id:
-                    raise ToolFileError(
-                        "tool blob message is missing tool_file_id metadata"
-                    )
-                _stream, tool_file = (
-                    self._tool_file_manager_factory.get_file_generator_by_tool_file_id(
-                        tool_file_id
-                    )
-                )
-                if not tool_file:
-                    raise ToolFileError(f"tool file {tool_file_id} not exists")
+    def _resolve_tool_file(self, tool_file_id: str, *, missing_message: str) -> File:
+        _stream, tool_file = (
+            self._tool_file_manager_factory.get_file_generator_by_tool_file_id(
+                tool_file_id,
+            )
+        )
+        if not tool_file:
+            raise ToolFileError(missing_message)
+        return tool_file
 
-                blob_file_mapping: dict[str, Any] = {
-                    "tool_file_id": tool_file_id,
-                    "transfer_method": FileTransferMethod.TOOL_FILE,
-                }
+    def _handle_linked_file_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
 
-                files.append(
-                    self._runtime.build_file_reference(mapping=blob_file_mapping)
-                )
-            elif message.type == ToolRuntimeMessage.MessageType.TEXT:
-                assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
-                text += message.message.text
-                yield StreamChunkEvent(
-                    selector=[node_id, "text"],
-                    chunk=message.message.text,
-                    is_final=False,
-                )
-            elif message.type == ToolRuntimeMessage.MessageType.JSON:
-                assert isinstance(message.message, ToolRuntimeMessage.JsonMessage)
-                # JSON message handling for tool node
-                if message.message.json_object:
-                    json.append(message.message.json_object)
-            elif message.type == ToolRuntimeMessage.MessageType.LINK:
-                assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
+        url = message.message.text
+        transfer_method = FileTransferMethod.TOOL_FILE
+        tool_file_id: str | None = None
+        if message.meta:
+            transfer_method = message.meta.get(
+                "transfer_method",
+                FileTransferMethod.TOOL_FILE,
+            )
+            tool_file_id = message.meta.get("tool_file_id")
+        if not isinstance(tool_file_id, str) or not tool_file_id:
+            msg = "tool message is missing tool_file_id metadata"
+            raise ToolFileError(msg)
 
-                # Check if this LINK message is a file link
-                file_obj = (message.meta or {}).get("file")
-                if isinstance(file_obj, File):
-                    files.append(file_obj)
-                    stream_text = f"File: {message.message.text}\n"
-                else:
-                    stream_text = f"Link: {message.message.text}\n"
+        tool_file = self._resolve_tool_file(
+            tool_file_id,
+            missing_message=f"tool file {tool_file_id} not found",
+        )
+        if tool_file.mime_type is None:
+            msg = f"tool file {tool_file_id} is missing mime type"
+            raise ToolFileError(msg)
 
-                text += stream_text
-                yield StreamChunkEvent(
-                    selector=[node_id, "text"],
-                    chunk=stream_text,
-                    is_final=False,
-                )
-            elif message.type == ToolRuntimeMessage.MessageType.VARIABLE:
-                assert isinstance(message.message, ToolRuntimeMessage.VariableMessage)
-                variable_name = message.message.variable_name
-                variable_value = message.message.variable_value
-                if message.message.stream:
-                    if not isinstance(variable_value, str):
-                        raise ToolNodeError(
-                            "When 'stream' is True, 'variable_value' must be a string."
-                        )
-                    if variable_name not in variables:
-                        variables[variable_name] = ""
-                    variables[variable_name] += variable_value
+        file_mapping: dict[str, Any] = {
+            "tool_file_id": tool_file_id,
+            "type": get_file_type_by_mime_type(tool_file.mime_type),
+            "transfer_method": transfer_method,
+            "url": url,
+        }
+        state.files.append(self._runtime.build_file_reference(mapping=file_mapping))
+        yield from ()
 
-                    yield StreamChunkEvent(
-                        selector=[node_id, variable_name],
-                        chunk=variable_value,
-                        is_final=False,
-                    )
-                else:
-                    variables[variable_name] = variable_value
-            elif message.type == ToolRuntimeMessage.MessageType.FILE:
-                assert message.meta is not None
-                assert isinstance(message.meta, dict)
-                # Validate that meta contains a 'file' key
-                if "file" not in message.meta:
-                    raise ToolNodeError("File message is missing 'file' key in meta")
+    def _handle_blob_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
+        assert message.meta
 
-                    # Validate that the file is an instance of File
-                    if not isinstance(message.meta["file"], File):
-                        raise ToolNodeError(
-                            "Expected File object but got "
-                            f"{type(message.meta['file']).__name__}"
-                        )
-                files.append(message.meta["file"])
-            elif message.type == ToolRuntimeMessage.MessageType.LOG:
-                assert isinstance(message.message, ToolRuntimeMessage.LogMessage)
-                if message.message.metadata:
-                    icon = tool_info.get("icon", "")
-                    dict_metadata = dict(message.message.metadata)
-                    if dict_metadata.get("provider"):
-                        icon, icon_dark = self._runtime.resolve_provider_icons(
-                            provider_name=dict_metadata["provider"],
-                            default_icon=icon,
-                        )
-                        dict_metadata["icon"] = icon
-                        dict_metadata["icon_dark"] = icon_dark
-                        message.message.metadata = dict_metadata
+        tool_file_id = message.meta.get("tool_file_id")
+        if not isinstance(tool_file_id, str) or not tool_file_id:
+            msg = "tool blob message is missing tool_file_id metadata"
+            raise ToolFileError(msg)
 
-        # Add agent_logs to outputs['json'] so frontend can access
-        # the thinking process.
-        json_output: list[dict[str, Any] | list[Any]] = []
+        self._resolve_tool_file(
+            tool_file_id,
+            missing_message=f"tool file {tool_file_id} not exists",
+        )
+        blob_file_mapping: dict[str, Any] = {
+            "tool_file_id": tool_file_id,
+            "transfer_method": FileTransferMethod.TOOL_FILE,
+        }
+        state.files.append(
+            self._runtime.build_file_reference(mapping=blob_file_mapping),
+        )
+        yield from ()
 
-        # Step 2: normalize JSON into {"data": [...]}.change json to list[dict]
-        if json:
-            json_output.extend(json)
+    def _handle_text_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        node_id: str,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
+        state.text += message.message.text
+        yield StreamChunkEvent(
+            selector=[node_id, "text"],
+            chunk=message.message.text,
+            is_final=False,
+        )
+
+    def _handle_json_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.JsonMessage)
+        if message.message.json_object:
+            state.json_values.append(message.message.json_object)
+        yield from ()
+
+    def _handle_link_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        node_id: str,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.TextMessage)
+
+        file_obj = (message.meta or {}).get("file")
+        if isinstance(file_obj, File):
+            state.files.append(file_obj)
+            stream_text = f"File: {message.message.text}\n"
         else:
-            json_output.append({"data": []})
+            stream_text = f"Link: {message.message.text}\n"
 
-        # Send final chunk events for all streamed outputs
-        # Final chunk for text stream
+        state.text += stream_text
+        yield StreamChunkEvent(
+            selector=[node_id, "text"],
+            chunk=stream_text,
+            is_final=False,
+        )
+
+    def _handle_variable_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        node_id: str,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.VariableMessage)
+        variable_name = message.message.variable_name
+        variable_value = message.message.variable_value
+
+        if not message.message.stream:
+            state.variables[variable_name] = variable_value
+            yield from ()
+            return
+
+        if not isinstance(variable_value, str):
+            msg = "When 'stream' is True, 'variable_value' must be a string."
+            raise ToolNodeError(msg)
+        if variable_name not in state.variables:
+            state.variables[variable_name] = ""
+        state.variables[variable_name] += variable_value
+        yield StreamChunkEvent(
+            selector=[node_id, variable_name],
+            chunk=variable_value,
+            is_final=False,
+        )
+
+    def _handle_file_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        state: _ToolMessageState,
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert message.meta is not None
+        assert isinstance(message.meta, dict)
+        if "file" not in message.meta:
+            msg = "File message is missing 'file' key in meta"
+            raise ToolNodeError(msg)
+
+        file_obj = message.meta["file"]
+        if not isinstance(file_obj, File):
+            msg = f"Expected File object but got {type(file_obj).__name__}"
+            raise ToolNodeError(msg)
+
+        state.files.append(file_obj)
+        yield from ()
+
+    def _handle_log_message(
+        self,
+        *,
+        message: ToolRuntimeMessage,
+        tool_info: Mapping[str, Any],
+        **_: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        assert isinstance(message.message, ToolRuntimeMessage.LogMessage)
+        if message.message.metadata:
+            icon = tool_info.get("icon", "")
+            dict_metadata = dict(message.message.metadata)
+            if dict_metadata.get("provider"):
+                icon, icon_dark = self._runtime.resolve_provider_icons(
+                    provider_name=dict_metadata["provider"],
+                    default_icon=icon,
+                )
+                dict_metadata["icon"] = icon
+                dict_metadata["icon_dark"] = icon_dark
+                message.message.metadata = dict_metadata
+        yield from ()
+
+    def _emit_final_stream_events(
+        self,
+        state: _ToolMessageState,
+    ) -> Generator[NodeEventBase, None, None]:
         yield StreamChunkEvent(
             selector=[self._node_id, "text"],
             chunk="",
             is_final=True,
         )
-
-        # Final chunks for any streamed variables
-        for var_name in variables:
+        for var_name in state.variables:
             yield StreamChunkEvent(
                 selector=[self._node_id, var_name],
                 chunk="",
                 is_final=True,
             )
 
-        usage = self._runtime.get_usage(tool_runtime=tool_runtime)
+    @staticmethod
+    def _normalize_json_output(
+        state: _ToolMessageState,
+    ) -> list[dict[str, Any] | list[Any]]:
+        if state.json_values:
+            return [*state.json_values]
+        return [{"data": []}]
 
+    @staticmethod
+    def _build_completion_metadata(
+        *,
+        tool_info: Mapping[str, Any],
+        usage: Any,
+    ) -> dict[WorkflowNodeExecutionMetadataKey, Any]:
         metadata: dict[WorkflowNodeExecutionMetadataKey, Any] = {
             WorkflowNodeExecutionMetadataKey.TOOL_INFO: tool_info,
         }
@@ -425,23 +532,7 @@ class ToolNode(Node[ToolNodeData]):
             metadata[WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS] = usage.total_tokens
             metadata[WorkflowNodeExecutionMetadataKey.TOTAL_PRICE] = usage.total_price
             metadata[WorkflowNodeExecutionMetadataKey.CURRENCY] = usage.currency
-
-        yield StreamCompletedEvent(
-            node_run_result=NodeRunResult(
-                status=WorkflowNodeExecutionStatus.SUCCEEDED,
-                outputs={
-                    "text": text,
-                    "files": ArrayFileSegment(value=files),
-                    "json": json_output,
-                    **variables,
-                },
-                metadata=metadata,
-                inputs=parameters_for_log,
-                llm_usage=usage,
-            )
-        )
-
-        return usage
+        return metadata
 
     @classmethod
     @override
@@ -452,35 +543,27 @@ class ToolNode(Node[ToolNodeData]):
         node_id: str,
         node_data: ToolNodeData,
     ) -> Mapping[str, Sequence[str]]:
-        """
-        Extract variable selector to variable mapping
-        :param graph_config: graph config
-        :param node_id: node id
-        :param node_data: node data
-        :return:
-        """
+        """Extract the variable-selector mapping referenced by tool parameters."""
         _ = graph_config  # Explicitly mark as unused
         typed_node_data = node_data
         result = {}
         for parameter_name in typed_node_data.tool_parameters:
-            input = typed_node_data.tool_parameters[parameter_name]
-            match input.type:
+            tool_input = typed_node_data.tool_parameters[parameter_name]
+            match tool_input.type:
                 case "mixed":
-                    assert isinstance(input.value, str)
+                    assert isinstance(tool_input.value, str)
                     selectors = VariableTemplateParser(
-                        input.value
+                        tool_input.value,
                     ).extract_variable_selectors()
                     for selector in selectors:
                         result[selector.variable] = selector.value_selector
                 case "variable":
-                    selector_key = ".".join(input.value)
-                    result[f"#{selector_key}#"] = input.value
+                    selector_key = ".".join(tool_input.value)
+                    result[f"#{selector_key}#"] = tool_input.value
                 case "constant":
                     pass
 
-        result = {node_id + "." + key: value for key, value in result.items()}
-
-        return result
+        return {node_id + "." + key: value for key, value in result.items()}
 
     @property
     def retry(self) -> bool:

--- a/src/graphon/nodes/tool_runtime_entities.py
+++ b/src/graphon/nodes/tool_runtime_entities.py
@@ -34,16 +34,24 @@ class ToolRuntimeMessage(_ToolRuntimeModel):
     """Graph-owned tool invocation message DTO."""
 
     class TextMessage(_ToolRuntimeModel):
+        """Plain-text tool message payload."""
+
         text: str
 
     class JsonMessage(_ToolRuntimeModel):
+        """Structured JSON tool message payload."""
+
         json_object: dict[str, Any] | list[Any]
         suppress_output: bool = Field(default=False)
 
     class BlobMessage(_ToolRuntimeModel):
+        """Binary blob tool message payload."""
+
         blob: bytes
 
     class BlobChunkMessage(_ToolRuntimeModel):
+        """Chunked binary payload emitted by a tool."""
+
         id: str
         sequence: int
         total_length: int
@@ -51,15 +59,23 @@ class ToolRuntimeMessage(_ToolRuntimeModel):
         end: bool
 
     class FileMessage(_ToolRuntimeModel):
+        """File-marker payload emitted by a tool."""
+
         file_marker: str = Field(default="file_marker")
 
     class VariableMessage(_ToolRuntimeModel):
+        """Payload used to assign a runtime variable from a tool."""
+
         variable_name: str
         variable_value: dict[str, Any] | list[Any] | str | int | float | bool | None
         stream: bool = Field(default=False)
 
     class LogMessage(_ToolRuntimeModel):
+        """Structured progress or status log emitted by a tool."""
+
         class LogStatus(StrEnum):
+            """Lifecycle states for a tool log message."""
+
             START = auto()
             ERROR = auto()
             SUCCESS = auto()
@@ -73,10 +89,14 @@ class ToolRuntimeMessage(_ToolRuntimeModel):
         metadata: dict[str, Any] = Field(default_factory=dict)
 
     class RetrieverResourceMessage(_ToolRuntimeModel):
+        """Retriever-resource payload emitted by a tool."""
+
         retriever_resources: list[dict[str, Any]]
         context: str
 
     class MessageType(StrEnum):
+        """Discriminator values for tool runtime messages."""
+
         TEXT = auto()
         IMAGE = auto()
         LINK = auto()

--- a/src/graphon/nodes/variable_aggregator/entities.py
+++ b/src/graphon/nodes/variable_aggregator/entities.py
@@ -6,16 +6,12 @@ from graphon.variables.types import SegmentType
 
 
 class AdvancedSettings(BaseModel):
-    """
-    Advanced setting.
-    """
+    """Advanced setting."""
 
     group_enabled: bool
 
     class Group(BaseModel):
-        """
-        Group.
-        """
+        """Group."""
 
         output_type: SegmentType
         variables: list[list[str]]
@@ -25,9 +21,7 @@ class AdvancedSettings(BaseModel):
 
 
 class VariableAggregatorNodeData(BaseNodeData):
-    """
-    Variable Aggregator Node Data.
-    """
+    """Variable Aggregator Node Data."""
 
     type: NodeType = BuiltinNodeTypes.VARIABLE_AGGREGATOR
     output_type: str

--- a/src/graphon/nodes/variable_aggregator/variable_aggregator_node.py
+++ b/src/graphon/nodes/variable_aggregator/variable_aggregator_node.py
@@ -44,5 +44,7 @@ class VariableAggregatorNode(Node[VariableAggregatorNodeData]):
                         break
 
         return NodeRunResult(
-            status=WorkflowNodeExecutionStatus.SUCCEEDED, outputs=outputs, inputs=inputs
+            status=WorkflowNodeExecutionStatus.SUCCEEDED,
+            outputs=outputs,
+            inputs=inputs,
         )

--- a/src/graphon/nodes/variable_assigner/common/helpers.py
+++ b/src/graphon/nodes/variable_assigner/common/helpers.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from graphon.nodes.variable_assigner.common.exc import VariableOperatorNodeError
 from graphon.variables.consts import SELECTORS_LENGTH
 from graphon.variables.segments import Segment
 from graphon.variables.types import SegmentType
@@ -20,10 +21,12 @@ class UpdatedVariable(BaseModel):
 
 
 def variable_to_processed_data(
-    selector: Sequence[str], seg: Segment
+    selector: Sequence[str],
+    seg: Segment,
 ) -> UpdatedVariable:
     if len(selector) < SELECTORS_LENGTH:
-        raise Exception("selector too short")
+        msg = "selector too short"
+        raise VariableOperatorNodeError(msg)
     _, var_name = selector[:2]
     return UpdatedVariable(
         name=var_name,
@@ -34,7 +37,8 @@ def variable_to_processed_data(
 
 
 def set_updated_variables[T: MutableMapping[str, Any]](
-    m: T, updates: Sequence[UpdatedVariable]
+    m: T,
+    updates: Sequence[UpdatedVariable],
 ) -> T:
     m[_UPDATED_VARIABLES_KEY] = updates
     return m
@@ -45,12 +49,13 @@ def get_updated_variables(m: Mapping[str, Any]) -> Sequence[UpdatedVariable] | N
     if updated_values is None:
         return None
     result = []
-    for items in updated_values:
-        if isinstance(items, UpdatedVariable):
-            result.append(items)
-        elif isinstance(items, dict):
-            items = UpdatedVariable.model_validate(items)
-            result.append(items)
+    for item in updated_values:
+        if isinstance(item, UpdatedVariable):
+            result.append(item)
+        elif isinstance(item, dict):
+            validated_item = UpdatedVariable.model_validate(item)
+            result.append(validated_item)
         else:
-            raise TypeError(f"Invalid updated variable: {items}, type={type(items)}")
+            msg = f"Invalid updated variable: {item}, type={type(item)}"
+            raise TypeError(msg)
     return result

--- a/src/graphon/nodes/variable_assigner/v1/node.py
+++ b/src/graphon/nodes/variable_assigner/v1/node.py
@@ -33,13 +33,13 @@ class VariableAssignerNode(Node[VariableAssignerData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
-    ):
+    ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -47,10 +47,13 @@ class VariableAssignerNode(Node[VariableAssignerData]):
 
     @override
     def blocks_variable_output(self, variable_selectors: set[tuple[str, ...]]) -> bool:
-        """
-        Check if this Variable Assigner node blocks the output of specific variables.
+        """Check if this Variable Assigner node blocks the output of specific variables.
 
         Returns True if this node updates any of the requested conversation variables.
+
+        Returns:
+            `True` when the assigned selector is among the requested selectors.
+
         """
         assigned_selector = tuple(self.node_data.assigned_variable_selector)
         return assigned_selector in variable_selectors
@@ -69,6 +72,7 @@ class VariableAssignerNode(Node[VariableAssignerData]):
         node_id: str,
         node_data: VariableAssignerData,
     ) -> Mapping[str, Sequence[str]]:
+        _ = graph_config
         mapping = {}
         selector_key = ".".join(node_data.assigned_variable_selector)
         key = f"{node_id}.#{selector_key}#"
@@ -84,43 +88,47 @@ class VariableAssignerNode(Node[VariableAssignerData]):
         assigned_variable_selector = self.node_data.assigned_variable_selector
         # Should be String, Number, Object, ArrayString, ArrayNumber, ArrayObject
         original_variable = self.graph_runtime_state.variable_pool.get(
-            assigned_variable_selector
+            assigned_variable_selector,
         )
         if not isinstance(original_variable, VariableBase):
-            raise VariableOperatorNodeError("assigned variable not found")
+            msg = "assigned variable not found"
+            raise VariableOperatorNodeError(msg)
 
         match self.node_data.write_mode:
             case WriteMode.OVER_WRITE:
                 income_value = self.graph_runtime_state.variable_pool.get(
-                    self.node_data.input_variable_selector
+                    self.node_data.input_variable_selector,
                 )
                 if not income_value:
-                    raise VariableOperatorNodeError("input value not found")
+                    msg = "input value not found"
+                    raise VariableOperatorNodeError(msg)
                 updated_variable = original_variable.model_copy(
-                    update={"value": income_value.value}
+                    update={"value": income_value.value},
                 )
 
             case WriteMode.APPEND:
                 income_value = self.graph_runtime_state.variable_pool.get(
-                    self.node_data.input_variable_selector
+                    self.node_data.input_variable_selector,
                 )
                 if not income_value:
-                    raise VariableOperatorNodeError("input value not found")
-                updated_value = original_variable.value + [income_value.value]
+                    msg = "input value not found"
+                    raise VariableOperatorNodeError(msg)
+                updated_value = [*original_variable.value, income_value.value]
                 updated_variable = original_variable.model_copy(
-                    update={"value": updated_value}
+                    update={"value": updated_value},
                 )
 
             case WriteMode.CLEAR:
                 income_value = SegmentType.get_zero_value(original_variable.value_type)
                 updated_variable = original_variable.model_copy(
-                    update={"value": income_value.to_object()}
+                    update={"value": income_value.to_object()},
                 )
 
         updated_variables = [
             common_helpers.variable_to_processed_data(
-                assigned_variable_selector, updated_variable
-            )
+                assigned_variable_selector,
+                updated_variable,
+            ),
         ]
         yield VariableUpdatedEvent(variable=cast("Variable", updated_variable))
         yield StreamCompletedEvent(
@@ -134,8 +142,9 @@ class VariableAssignerNode(Node[VariableAssignerData]):
                 # list to keep the output schema compatible with
                 # `v2.VariableAssignerNode`.
                 process_data=common_helpers.set_updated_variables(
-                    {}, updated_variables
+                    {},
+                    updated_variables,
                 ),
                 outputs={},
-            )
+            ),
         )

--- a/src/graphon/nodes/variable_assigner/v2/exc.py
+++ b/src/graphon/nodes/variable_assigner/v2/exc.py
@@ -7,34 +7,34 @@ from .enums import InputType, Operation
 
 
 class OperationNotSupportedError(VariableOperatorNodeError):
-    def __init__(self, *, operation: Operation, variable_type: str):
+    def __init__(self, *, operation: Operation, variable_type: str) -> None:
         super().__init__(
-            f"Operation {operation} is not supported for type {variable_type}"
+            f"Operation {operation} is not supported for type {variable_type}",
         )
 
 
 class InputTypeNotSupportedError(VariableOperatorNodeError):
-    def __init__(self, *, input_type: InputType, operation: Operation):
+    def __init__(self, *, input_type: InputType, operation: Operation) -> None:
         super().__init__(
-            f"Input type {input_type} is not supported for operation {operation}"
+            f"Input type {input_type} is not supported for operation {operation}",
         )
 
 
 class VariableNotFoundError(VariableOperatorNodeError):
-    def __init__(self, *, variable_selector: Sequence[str]):
+    def __init__(self, *, variable_selector: Sequence[str]) -> None:
         super().__init__(f"Variable {variable_selector} not found")
 
 
 class InvalidInputValueError(VariableOperatorNodeError):
-    def __init__(self, *, value: Any):
+    def __init__(self, *, value: Any) -> None:
         super().__init__(f"Invalid input value {value}")
 
 
 class ConversationIDNotFoundError(VariableOperatorNodeError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("conversation_id not found")
 
 
 class InvalidDataError(VariableOperatorNodeError):
-    def __init__(self, message: str):
+    def __init__(self, message: str) -> None:
         super().__init__(message)

--- a/src/graphon/nodes/variable_assigner/v2/helpers.py
+++ b/src/graphon/nodes/variable_assigner/v2/helpers.py
@@ -4,27 +4,55 @@ from graphon.variables.types import SegmentType
 
 from .enums import Operation
 
+_NO_VALUE_OPERATIONS = frozenset((
+    Operation.CLEAR,
+    Operation.REMOVE_FIRST,
+    Operation.REMOVE_LAST,
+))
+_LIST_VALUE_OPERATIONS = frozenset((Operation.EXTEND, Operation.OVER_WRITE))
+
+
+def _is_valid_list_input(
+    value: Any,
+    item_type: type[Any] | tuple[type[Any], ...],
+) -> bool:
+    match value:
+        case list() if all(isinstance(item, item_type) for item in value):
+            result = True
+        case _:
+            result = False
+    return result
+
+
+def _is_valid_numeric_input(*, operation: Operation, value: Any) -> bool:
+    match value:
+        case int() | float():
+            result = not (operation == Operation.DIVIDE and value == 0)
+        case _:
+            result = False
+    return result
+
 
 def is_operation_supported(*, variable_type: SegmentType, operation: Operation):
     match operation:
         case Operation.OVER_WRITE | Operation.CLEAR:
             return True
         case Operation.SET:
-            return variable_type in {
+            return variable_type in frozenset((
                 SegmentType.OBJECT,
                 SegmentType.STRING,
                 SegmentType.NUMBER,
                 SegmentType.INTEGER,
                 SegmentType.FLOAT,
                 SegmentType.BOOLEAN,
-            }
+            ))
         case Operation.ADD | Operation.SUBTRACT | Operation.MULTIPLY | Operation.DIVIDE:
             # Only number variable can be added, subtracted, multiplied or divided
-            return variable_type in {
+            return variable_type in frozenset((
                 SegmentType.NUMBER,
                 SegmentType.INTEGER,
                 SegmentType.FLOAT,
-            }
+            ))
         case (
             Operation.APPEND
             | Operation.EXTEND
@@ -37,100 +65,90 @@ def is_operation_supported(*, variable_type: SegmentType, operation: Operation):
 
 
 def is_variable_input_supported(*, operation: Operation):
-    return operation not in {
+    return operation not in frozenset((
         Operation.SET,
         Operation.ADD,
         Operation.SUBTRACT,
         Operation.MULTIPLY,
         Operation.DIVIDE,
-    }
+    ))
 
 
 def is_constant_input_supported(*, variable_type: SegmentType, operation: Operation):
     match variable_type:
         case SegmentType.STRING | SegmentType.OBJECT | SegmentType.BOOLEAN:
-            return operation in {Operation.OVER_WRITE, Operation.SET}
+            return operation in frozenset((Operation.OVER_WRITE, Operation.SET))
         case SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT:
-            return operation in {
+            return operation in frozenset((
                 Operation.OVER_WRITE,
                 Operation.SET,
                 Operation.ADD,
                 Operation.SUBTRACT,
                 Operation.MULTIPLY,
                 Operation.DIVIDE,
-            }
+            ))
         case _:
             return False
 
 
 def is_input_value_valid(
-    *, variable_type: SegmentType, operation: Operation, value: Any
+    *,
+    variable_type: SegmentType,
+    operation: Operation,
+    value: Any,
 ):
-    if operation in {Operation.CLEAR, Operation.REMOVE_FIRST, Operation.REMOVE_LAST}:
-        return True
-    match variable_type:
-        case SegmentType.STRING:
-            return isinstance(value, str)
-
-        case SegmentType.BOOLEAN:
-            return isinstance(value, bool)
-
-        case SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT:
-            if not isinstance(value, int | float):
-                return False
-            return not (operation == Operation.DIVIDE and value == 0)
-
-        case SegmentType.OBJECT:
-            return isinstance(value, dict)
-
-        # Array & Append
-        case SegmentType.ARRAY_ANY if operation == Operation.APPEND:
-            return isinstance(value, str | float | int | dict)
-        case SegmentType.ARRAY_STRING if operation == Operation.APPEND:
-            return isinstance(value, str)
-        case SegmentType.ARRAY_NUMBER if operation == Operation.APPEND:
-            return isinstance(value, int | float)
-        case SegmentType.ARRAY_OBJECT if operation == Operation.APPEND:
-            return isinstance(value, dict)
-        case SegmentType.ARRAY_BOOLEAN if operation == Operation.APPEND:
-            return isinstance(value, bool)
-
-        # Array & Extend / Overwrite
-        case SegmentType.ARRAY_ANY if operation in {
-            Operation.EXTEND,
-            Operation.OVER_WRITE,
-        }:
-            return isinstance(value, list) and all(
-                isinstance(item, str | float | int | dict) for item in value
-            )
-        case SegmentType.ARRAY_STRING if operation in {
-            Operation.EXTEND,
-            Operation.OVER_WRITE,
-        }:
-            return isinstance(value, list) and all(
-                isinstance(item, str) for item in value
-            )
-        case SegmentType.ARRAY_NUMBER if operation in {
-            Operation.EXTEND,
-            Operation.OVER_WRITE,
-        }:
-            return isinstance(value, list) and all(
-                isinstance(item, int | float) for item in value
-            )
-        case SegmentType.ARRAY_OBJECT if operation in {
-            Operation.EXTEND,
-            Operation.OVER_WRITE,
-        }:
-            return isinstance(value, list) and all(
-                isinstance(item, dict) for item in value
-            )
-        case SegmentType.ARRAY_BOOLEAN if operation in {
-            Operation.EXTEND,
-            Operation.OVER_WRITE,
-        }:
-            return isinstance(value, list) and all(
-                isinstance(item, bool) for item in value
-            )
-
-        case _:
-            return False
+    if operation in _NO_VALUE_OPERATIONS:
+        result = True
+    else:
+        match variable_type, operation, value:
+            case SegmentType.STRING, _, str():
+                result = True
+            case SegmentType.BOOLEAN, _, bool():
+                result = True
+            case (
+                SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT,
+                _,
+                _,
+            ):
+                result = _is_valid_numeric_input(operation=operation, value=value)
+            case SegmentType.OBJECT, _, dict():
+                result = True
+            case (
+                SegmentType.ARRAY_ANY,
+                Operation.APPEND,
+                str() | float() | int() | dict(),
+            ):
+                result = True
+            case SegmentType.ARRAY_STRING, Operation.APPEND, str():
+                result = True
+            case SegmentType.ARRAY_NUMBER, Operation.APPEND, int() | float():
+                result = True
+            case SegmentType.ARRAY_OBJECT, Operation.APPEND, dict():
+                result = True
+            case SegmentType.ARRAY_BOOLEAN, Operation.APPEND, bool():
+                result = True
+            case SegmentType.ARRAY_ANY, operation, _ if (
+                operation in _LIST_VALUE_OPERATIONS
+            ):
+                result = _is_valid_list_input(value, (str, float, int, dict))
+            case SegmentType.ARRAY_STRING, operation, _ if (
+                operation in _LIST_VALUE_OPERATIONS
+            ):
+                result = _is_valid_list_input(value, str)
+            case SegmentType.ARRAY_NUMBER, operation, _ if (
+                operation in _LIST_VALUE_OPERATIONS
+            ):
+                result = _is_valid_list_input(value, (int, float))
+            case SegmentType.ARRAY_OBJECT, operation, _ if (
+                operation in _LIST_VALUE_OPERATIONS
+            ):
+                result = _is_valid_list_input(value, dict)
+            case (
+                SegmentType.ARRAY_BOOLEAN,
+                operation,
+                _,
+            ) if operation in _LIST_VALUE_OPERATIONS:
+                result = _is_valid_list_input(value, bool)
+            case _:
+                result = False
+    return result

--- a/src/graphon/nodes/variable_assigner/v2/node.py
+++ b/src/graphon/nodes/variable_assigner/v2/node.py
@@ -42,7 +42,7 @@ def _target_mapping_from_item(
     mapping: MutableMapping[str, Sequence[str]],
     node_id: str,
     item: VariableOperationItem,
-):
+) -> None:
     selector_str = ".".join(item.variable_selector)
     key = f"{node_id}.#{selector_str}#"
     mapping[key] = item.variable_selector
@@ -52,18 +52,26 @@ def _source_mapping_from_item(
     mapping: MutableMapping[str, Sequence[str]],
     node_id: str,
     item: VariableOperationItem,
-):
+) -> None:
     # Keep this in sync with the logic in _run methods...
     if item.input_type != InputType.VARIABLE:
         return
     selector = item.value
     if not isinstance(selector, list):
-        raise InvalidDataError(f"selector is not a list, {node_id=}, {item=}")
+        msg = f"selector is not a list, {node_id=}, {item=}"
+        raise InvalidDataError(msg)
     if len(selector) < SELECTORS_LENGTH:
-        raise InvalidDataError(f"selector too short, {node_id=}, {item=}")
+        msg = f"selector too short, {node_id=}, {item=}"
+        raise InvalidDataError(msg)
     selector_str = ".".join(selector)
     key = f"{node_id}.#{selector_str}#"
     mapping[key] = selector
+
+
+def _trim_array_edge(*, value: Sequence[Any], remove_first: bool) -> Sequence[Any]:
+    if not value:
+        return value
+    return value[1:] if remove_first else value[:-1]
 
 
 class VariableAssignerNode(Node[VariableAssignerNodeData]):
@@ -72,13 +80,13 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
     @override
     def __init__(
         self,
-        id: str,
+        node_id: str,
         config: NodeConfigDict,
         graph_init_params: "GraphInitParams",
         graph_runtime_state: "GraphRuntimeState",
-    ):
+    ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -86,10 +94,13 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
 
     @override
     def blocks_variable_output(self, variable_selectors: set[tuple[str, ...]]) -> bool:
-        """
-        Check if this Variable Assigner node blocks the output of specific variables.
+        """Check if this Variable Assigner node blocks the output of specific variables.
 
         Returns True if this node updates any of the requested conversation variables.
+
+        Returns:
+            `True` when any assigned selector is among the requested selectors.
+
         """
         # Check each item in this Variable Assigner node
         for item in self.node_data.items:
@@ -116,6 +127,7 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
         node_id: str,
         node_data: VariableAssignerNodeData,
     ) -> Mapping[str, Sequence[str]]:
+        _ = graph_config
         var_mapping: dict[str, Sequence[str]] = {}
         for item in node_data.items:
             _target_mapping_from_item(var_mapping, node_id, item)
@@ -131,7 +143,7 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
         # Preserve intra-node read-after-write behavior without mutating the shared pool
         # until the engine processes the emitted VariableUpdatedEvent instances.
         working_variable_pool = self.graph_runtime_state.variable_pool.model_copy(
-            deep=True
+            deep=True,
         )
 
         try:
@@ -143,37 +155,42 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
                 # Check if variable exists
                 if not isinstance(variable, VariableBase):
                     raise VariableNotFoundError(
-                        variable_selector=item.variable_selector
+                        variable_selector=item.variable_selector,
                     )
 
                 # Check if operation is supported
                 if not helpers.is_operation_supported(
-                    variable_type=variable.value_type, operation=item.operation
+                    variable_type=variable.value_type,
+                    operation=item.operation,
                 ):
                     raise OperationNotSupportedError(
-                        operation=item.operation, variable_type=variable.value_type
+                        operation=item.operation,
+                        variable_type=variable.value_type,
                     )
 
                 # Check if variable input is supported
                 if (
                     item.input_type == InputType.VARIABLE
                     and not helpers.is_variable_input_supported(
-                        operation=item.operation
+                        operation=item.operation,
                     )
                 ):
                     raise InputTypeNotSupportedError(
-                        input_type=InputType.VARIABLE, operation=item.operation
+                        input_type=InputType.VARIABLE,
+                        operation=item.operation,
                     )
 
                 # Check if constant input is supported
                 if (
                     item.input_type == InputType.CONSTANT
                     and not helpers.is_constant_input_supported(
-                        variable_type=variable.value_type, operation=item.operation
+                        variable_type=variable.value_type,
+                        operation=item.operation,
                     )
                 ):
                     raise InputTypeNotSupportedError(
-                        input_type=InputType.CONSTANT, operation=item.operation
+                        input_type=InputType.CONSTANT,
+                        operation=item.operation,
                     )
 
                 # Get value from variable pool
@@ -181,11 +198,11 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
                 if (
                     item.input_type == InputType.VARIABLE
                     and item.operation
-                    not in {
+                    not in frozenset((
                         Operation.CLEAR,
                         Operation.REMOVE_FIRST,
                         Operation.REMOVE_LAST,
-                    }
+                    ))
                     and item.value is not None
                 ):
                     value = working_variable_pool.get(item.value)
@@ -205,8 +222,8 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
                 ):
                     try:
                         input_value = json.loads(input_value)
-                    except json.JSONDecodeError:
-                        raise InvalidInputValueError(value=input_value)
+                    except json.JSONDecodeError as error:
+                        raise InvalidInputValueError(value=input_value) from error
 
                 # Check if input value is valid
                 if not helpers.is_input_value_valid(
@@ -233,7 +250,7 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
                     inputs=inputs,
                     process_data=process_data,
                     error=str(e),
-                )
+                ),
             )
             return
 
@@ -241,7 +258,7 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
         # is not hashable.
         # remove duplicated items while preserving the first update order.
         updated_variable_selectors = list(
-            dict.fromkeys(map(tuple, updated_variable_selectors))
+            dict.fromkeys(map(tuple, updated_variable_selectors)),
         )
 
         for selector in updated_variable_selectors:
@@ -257,7 +274,8 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
         ]
 
         process_data = common_helpers.set_updated_variables(
-            process_data, updated_variables
+            process_data,
+            updated_variables,
         )
         for selector in updated_variable_selectors:
             variable = working_variable_pool.get(selector)
@@ -271,7 +289,7 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
                 inputs=inputs,
                 process_data=process_data,
                 outputs={},
-            )
+            ),
         )
 
     def _handle_item(
@@ -280,33 +298,28 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
         variable: VariableBase,
         operation: Operation,
         value: Any,
-    ):
+    ) -> Any:
         match operation:
             case Operation.OVER_WRITE:
-                return value
+                result = value
             case Operation.CLEAR:
-                return SegmentType.get_zero_value(variable.value_type).to_object()
+                result = SegmentType.get_zero_value(variable.value_type).to_object()
             case Operation.APPEND:
-                return variable.value + [value]
+                result = [*variable.value, value]
             case Operation.EXTEND:
-                return variable.value + value
+                result = variable.value + value
             case Operation.SET:
-                return value
+                result = value
             case Operation.ADD:
-                return variable.value + value
+                result = variable.value + value
             case Operation.SUBTRACT:
-                return variable.value - value
+                result = variable.value - value
             case Operation.MULTIPLY:
-                return variable.value * value
+                result = variable.value * value
             case Operation.DIVIDE:
-                return variable.value / value
+                result = variable.value / value
             case Operation.REMOVE_FIRST:
-                # If array is empty, do nothing
-                if not variable.value:
-                    return variable.value
-                return variable.value[1:]
+                result = _trim_array_edge(value=variable.value, remove_first=True)
             case Operation.REMOVE_LAST:
-                # If array is empty, do nothing
-                if not variable.value:
-                    return variable.value
-                return variable.value[:-1]
+                result = _trim_array_edge(value=variable.value, remove_first=False)
+        return result

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -29,7 +29,8 @@ class ReadyQueueProtocol(Protocol):
 
     def get(self, timeout: float | None = None) -> str:
         """Return the next node identifier,
-        blocking until available or timeout expires."""
+        blocking until available or timeout expires.
+        """
         ...
 
     def task_done(self) -> None:
@@ -130,7 +131,8 @@ class NodeProtocol(Protocol):
     node_type: ClassVar[NodeType]
 
     def blocks_variable_output(
-        self, variable_selectors: set[tuple[str, ...]]
+        self,
+        variable_selectors: set[tuple[str, ...]],
     ) -> bool: ...
 
 
@@ -144,7 +146,8 @@ class EdgeProtocol(Protocol):
 
 class GraphProtocol(Protocol):
     """Structural interface required from graph instances attached
-    to the runtime state."""
+    to the runtime state.
+    """
 
     nodes: Mapping[str, NodeProtocol]
     edges: Mapping[str, EdgeProtocol]
@@ -204,81 +207,14 @@ class _GraphRuntimeStateSnapshot:
     graph_edge_states: dict[str, NodeState]
 
 
-class GraphRuntimeState:
-    """Mutable runtime state shared across graph execution components.
+class _GraphRuntimeStateBindingMixin:
+    """Graph attachment and child-engine orchestration helpers."""
 
-    `GraphRuntimeState` encapsulates the runtime state of workflow execution,
-    including scheduling details, variable values, and timing information.
-
-    Values that are initialized prior to workflow execution and remain constant
-    throughout the execution should be part of `GraphInitParams` instead.
-    """
-
-    def __init__(
-        self,
-        *,
-        variable_pool: VariablePool,
-        start_at: float,
-        total_tokens: int = 0,
-        llm_usage: LLMUsage | None = None,
-        outputs: dict[str, object] | None = None,
-        node_run_steps: int = 0,
-        ready_queue: ReadyQueueProtocol | None = None,
-        graph_execution: GraphExecutionProtocol | None = None,
-        response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
-        graph: GraphProtocol | None = None,
-        execution_context: AbstractContextManager[object] | None = None,
-    ) -> None:
-        self._variable_pool = variable_pool
-        self._start_at = start_at
-
-        if total_tokens < 0:
-            raise ValueError("total_tokens must be non-negative")
-        self._total_tokens = total_tokens
-
-        self._llm_usage = (llm_usage or LLMUsage.empty_usage()).model_copy()
-        self._outputs = deepcopy(outputs) if outputs is not None else {}
-
-        if node_run_steps < 0:
-            raise ValueError("node_run_steps must be non-negative")
-        self._node_run_steps = node_run_steps
-
-        self._graph: GraphProtocol | None = None
-
-        self._ready_queue = ready_queue
-        self._graph_execution = graph_execution
-        self._response_coordinator = response_coordinator
-        # Application code injects this when worker threads must restore request
-        # or framework-local state. It is intentionally excluded from snapshots.
-        self._execution_context = (
-            execution_context if execution_context is not None else nullcontext(None)
-        )
-        self._pending_response_coordinator_dump: str | None = None
-        self._pending_graph_execution_workflow_id: str | None = None
-        self._paused_nodes: set[str] = set()
-        self._deferred_nodes: set[str] = set()
-        self._child_engine_builder: ChildGraphEngineBuilderProtocol | None = None
-
-        # Node and edges states needed to be restored into
-        # graph object.
-        #
-        # These two fields are non-None only when resuming from a snapshot.
-        # Once the graph is attached, these two fields will be set to None.
-        self._pending_graph_node_states: dict[str, NodeState] | None = None
-        self._pending_graph_edge_states: dict[str, NodeState] | None = None
-
-        if graph is not None:
-            self.attach_graph(graph)
-
-    # ------------------------------------------------------------------
-    # Context binding helpers
-    # ------------------------------------------------------------------
     def attach_graph(self, graph: GraphProtocol) -> None:
         """Attach the materialized graph to the runtime state."""
         if self._graph is not None and self._graph is not graph:
-            raise ValueError(
-                "GraphRuntimeState already attached to a different graph instance"
-            )
+            msg = "GraphRuntimeState already attached to a different graph instance"
+            raise ValueError(msg)
 
         self._graph = graph
 
@@ -305,7 +241,8 @@ class GraphRuntimeState:
             _ = self.response_coordinator
 
     def bind_child_engine_builder(
-        self, builder: ChildGraphEngineBuilderProtocol
+        self,
+        builder: ChildGraphEngineBuilderProtocol,
     ) -> None:
         self._child_engine_builder = builder
 
@@ -317,12 +254,10 @@ class GraphRuntimeState:
         root_node_id: str,
         variable_pool: VariablePool | None = None,
     ) -> Any:
-        """Create a child graph engine that derives its runtime state
-        from the parent."""
+        """Create a child graph engine whose runtime state derives from this parent."""
         if self._child_engine_builder is None:
-            raise ChildEngineBuilderNotConfiguredError(
-                "Child engine builder is not configured."
-            )
+            msg = "Child engine builder is not configured."
+            raise ChildEngineBuilderNotConfiguredError(msg)
 
         return self._child_engine_builder.build_child_engine(
             workflow_id=workflow_id,
@@ -332,9 +267,10 @@ class GraphRuntimeState:
             variable_pool=variable_pool,
         )
 
-    # ------------------------------------------------------------------
-    # Primary collaborators
-    # ------------------------------------------------------------------
+
+class _GraphRuntimeStateAccessorsMixin:
+    """Public scalar state and collaborator accessors."""
+
     @property
     def variable_pool(self) -> VariablePool:
         return self._variable_pool
@@ -355,9 +291,8 @@ class GraphRuntimeState:
     def response_coordinator(self) -> ResponseStreamCoordinatorProtocol:
         if self._response_coordinator is None:
             if self._graph is None:
-                raise ValueError(
-                    "Graph must be attached before accessing response coordinator"
-                )
+                msg = "Graph must be attached before accessing response coordinator"
+                raise ValueError(msg)
             self._response_coordinator = self._build_response_coordinator(self._graph)
         return self._response_coordinator
 
@@ -369,9 +304,6 @@ class GraphRuntimeState:
     def execution_context(self, value: AbstractContextManager[object] | None) -> None:
         self._execution_context = value if value is not None else nullcontext(None)
 
-    # ------------------------------------------------------------------
-    # Scalar state
-    # ------------------------------------------------------------------
     @property
     def start_at(self) -> float:
         return self._start_at
@@ -387,7 +319,8 @@ class GraphRuntimeState:
     @total_tokens.setter
     def total_tokens(self, value: int) -> None:
         if value < 0:
-            raise ValueError("total_tokens must be non-negative")
+            msg = "total_tokens must be non-negative"
+            raise ValueError(msg)
         self._total_tokens = value
 
     @property
@@ -423,7 +356,8 @@ class GraphRuntimeState:
     @node_run_steps.setter
     def node_run_steps(self, value: int) -> None:
         if value < 0:
-            raise ValueError("node_run_steps must be non-negative")
+            msg = "node_run_steps must be non-negative"
+            raise ValueError(msg)
         self._node_run_steps = value
 
     def increment_node_run_steps(self) -> None:
@@ -431,15 +365,16 @@ class GraphRuntimeState:
 
     def add_tokens(self, tokens: int) -> None:
         if tokens < 0:
-            raise ValueError("tokens must be non-negative")
+            msg = "tokens must be non-negative"
+            raise ValueError(msg)
         self._total_tokens += tokens
 
-    # ------------------------------------------------------------------
-    # Serialization
-    # ------------------------------------------------------------------
+
+class _GraphRuntimeStateSnapshotMixin:
+    """Snapshot serialization and suspension queue management."""
+
     def dumps(self) -> str:
         """Serialize runtime state into a JSON string."""
-
         snapshot: dict[str, Any] = {
             "version": "1.0",
             "start_at": self._start_at,
@@ -466,7 +401,6 @@ class GraphRuntimeState:
     @classmethod
     def from_snapshot(cls, data: str | Mapping[str, Any]) -> GraphRuntimeState:
         """Restore runtime state from a serialized snapshot."""
-
         snapshot = cls._parse_snapshot_payload(data)
 
         state = cls(
@@ -482,43 +416,109 @@ class GraphRuntimeState:
 
     def loads(self, data: str | Mapping[str, Any]) -> None:
         """Restore runtime state from a serialized snapshot (legacy API)."""
-
         snapshot = self._parse_snapshot_payload(data)
         self._apply_snapshot(snapshot)
 
     def register_paused_node(self, node_id: str) -> None:
         """Record a node that should resume when execution is continued."""
-
         self._paused_nodes.add(node_id)
 
     def get_paused_nodes(self) -> list[str]:
         """Retrieve the list of paused nodes without mutating internal state."""
-
         return list(self._paused_nodes)
 
     def consume_paused_nodes(self) -> list[str]:
         """Retrieve and clear the list of paused nodes awaiting resume."""
-
         nodes = list(self._paused_nodes)
         self._paused_nodes.clear()
         return nodes
 
     def register_deferred_node(self, node_id: str) -> None:
         """Record a node that became ready during pause and should resume later."""
-
         self._deferred_nodes.add(node_id)
 
     def get_deferred_nodes(self) -> list[str]:
         """Retrieve deferred nodes without mutating internal state."""
-
         return list(self._deferred_nodes)
 
     def consume_deferred_nodes(self) -> list[str]:
         """Retrieve and clear deferred nodes awaiting resume."""
-
         nodes = list(self._deferred_nodes)
         self._deferred_nodes.clear()
         return nodes
+
+
+class GraphRuntimeState(
+    _GraphRuntimeStateBindingMixin,
+    _GraphRuntimeStateAccessorsMixin,
+    _GraphRuntimeStateSnapshotMixin,
+):
+    """Mutable runtime state shared across graph execution components.
+
+    `GraphRuntimeState` encapsulates the runtime state of workflow execution,
+    including scheduling details, variable values, and timing information.
+
+    Values that are initialized prior to workflow execution and remain constant
+    throughout the execution should be part of `GraphInitParams` instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        variable_pool: VariablePool,
+        start_at: float,
+        total_tokens: int = 0,
+        llm_usage: LLMUsage | None = None,
+        outputs: dict[str, object] | None = None,
+        node_run_steps: int = 0,
+        ready_queue: ReadyQueueProtocol | None = None,
+        graph_execution: GraphExecutionProtocol | None = None,
+        response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
+        graph: GraphProtocol | None = None,
+        execution_context: AbstractContextManager[object] | None = None,
+    ) -> None:
+        self._variable_pool = variable_pool
+        self._start_at = start_at
+
+        if total_tokens < 0:
+            msg = "total_tokens must be non-negative"
+            raise ValueError(msg)
+        self._total_tokens = total_tokens
+
+        self._llm_usage = (llm_usage or LLMUsage.empty_usage()).model_copy()
+        self._outputs = deepcopy(outputs) if outputs is not None else {}
+
+        if node_run_steps < 0:
+            msg = "node_run_steps must be non-negative"
+            raise ValueError(msg)
+        self._node_run_steps = node_run_steps
+
+        self._graph: GraphProtocol | None = None
+
+        self._ready_queue = ready_queue
+        self._graph_execution = graph_execution
+        self._response_coordinator = response_coordinator
+        # Application code injects this when worker threads must restore request
+        # or framework-local state. It is intentionally excluded from snapshots.
+        self._execution_context = (
+            execution_context if execution_context is not None else nullcontext(None)
+        )
+        self._pending_response_coordinator_dump: str | None = None
+        self._pending_graph_execution_workflow_id: str | None = None
+        self._paused_nodes: set[str] = set()
+        self._deferred_nodes: set[str] = set()
+        self._child_engine_builder: ChildGraphEngineBuilderProtocol | None = None
+
+        # Node and edges states needed to be restored into
+        # graph object.
+        #
+        # These two fields are non-None only when resuming from a snapshot.
+        # Once the graph is attached, these two fields will be set to None.
+        self._pending_graph_node_states: dict[str, NodeState] | None = None
+        self._pending_graph_edge_states: dict[str, NodeState] | None = None
+
+        if graph is not None:
+            self.attach_graph(graph)
 
     # ------------------------------------------------------------------
     # Builders
@@ -539,7 +539,8 @@ class GraphRuntimeState:
         return graph_execution_cls(workflow_id=workflow_id)  # type: ignore[invalid-return-type]
 
     def _build_response_coordinator(
-        self, graph: GraphProtocol
+        self,
+        graph: GraphProtocol,
     ) -> ResponseStreamCoordinatorProtocol:
         # Lazily import to keep the runtime domain decoupled from graph_engine modules.
         module = importlib.import_module("graphon.graph_engine.response_coordinator")
@@ -551,29 +552,30 @@ class GraphRuntimeState:
     # ------------------------------------------------------------------
     @classmethod
     def _parse_snapshot_payload(
-        cls, data: str | Mapping[str, Any]
+        cls,
+        data: str | Mapping[str, Any],
     ) -> _GraphRuntimeStateSnapshot:
         payload: dict[str, Any]
         payload = json.loads(data) if isinstance(data, str) else dict(data)
 
         version = payload.get("version")
         if version != "1.0":
-            raise ValueError(
-                f"Unsupported GraphRuntimeState snapshot version: {version}"
-            )
+            msg = f"Unsupported GraphRuntimeState snapshot version: {version}"
+            raise ValueError(msg)
 
         start_at = float(payload.get("start_at", 0.0))
 
         total_tokens = int(payload.get("total_tokens", 0))
         if total_tokens < 0:
-            raise ValueError("total_tokens must be non-negative")
+            msg = "total_tokens must be non-negative"
+            raise ValueError(msg)
 
         node_run_steps = int(payload.get("node_run_steps", 0))
         if node_run_steps < 0:
-            raise ValueError("node_run_steps must be non-negative")
+            msg = "node_run_steps must be non-negative"
+            raise ValueError(msg)
 
-        llm_usage_payload = payload.get("llm_usage", {})
-        llm_usage = LLMUsage.model_validate(llm_usage_payload)
+        llm_usage = LLMUsage.model_validate(payload.get("llm_usage", {}))
 
         outputs_payload = deepcopy(payload.get("outputs", {}))
 
@@ -585,11 +587,6 @@ class GraphRuntimeState:
             else VariablePool()
         )
 
-        ready_queue_payload = payload.get("ready_queue")
-        graph_execution_payload = payload.get("graph_execution")
-        response_payload = payload.get("response_coordinator")
-        paused_nodes_payload = payload.get("paused_nodes", [])
-        deferred_nodes_payload = payload.get("deferred_nodes", [])
         graph_state_payload = payload.get("graph_state", {}) or {}
         graph_node_states = _coerce_graph_state_map(graph_state_payload, "nodes")
         graph_edge_states = _coerce_graph_state_map(graph_state_payload, "edges")
@@ -602,11 +599,11 @@ class GraphRuntimeState:
             outputs=outputs_payload,
             variable_pool=variable_pool,
             has_variable_pool=has_variable_pool,
-            ready_queue_dump=ready_queue_payload,
-            graph_execution_dump=graph_execution_payload,
-            response_coordinator_dump=response_payload,
-            paused_nodes=tuple(map(str, paused_nodes_payload)),
-            deferred_nodes=tuple(map(str, deferred_nodes_payload)),
+            ready_queue_dump=payload.get("ready_queue"),
+            graph_execution_dump=payload.get("graph_execution"),
+            response_coordinator_dump=payload.get("response_coordinator"),
+            paused_nodes=tuple(map(str, payload.get("paused_nodes", []))),
+            deferred_nodes=tuple(map(str, payload.get("deferred_nodes", []))),
             graph_node_states=graph_node_states,
             graph_edge_states=graph_edge_states,
         )
@@ -646,7 +643,7 @@ class GraphRuntimeState:
         try:
             execution_payload = json.loads(payload)
             self._pending_graph_execution_workflow_id = execution_payload.get(
-                "workflow_id"
+                "workflow_id",
             )
         except (json.JSONDecodeError, TypeError, AttributeError):
             self._pending_graph_execution_workflow_id = None

--- a/src/graphon/runtime/graph_runtime_state_protocol.py
+++ b/src/graphon/runtime/graph_runtime_state_protocol.py
@@ -22,8 +22,7 @@ class ReadOnlyVariablePool(Protocol):
 
 
 class ReadOnlyGraphRuntimeState(Protocol):
-    """
-    Read-only view of GraphRuntimeState for layers.
+    """Read-only view of GraphRuntimeState for layers.
 
     This protocol defines a read-only interface that prevents layers from
     modifying the graph runtime state while still allowing observation.

--- a/src/graphon/runtime/variable_pool.py
+++ b/src/graphon/runtime/variable_pool.py
@@ -23,7 +23,7 @@ from graphon.variables.variables import RAGPipelineVariableInput, Variable, Vari
 type VariableValue = str | int | float | dict[str, object] | list[object] | File
 
 VARIABLE_PATTERN = re.compile(
-    r"\{\{#([a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10})#\}\}"
+    r"\{\{#([a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10})#\}\}",
 )
 
 
@@ -43,38 +43,47 @@ class VariablePool(BaseModel):
     # Other elements of the selector are keys in the second-level dictionary.
     # To get the key, we hash the elements of the selector except the first one.
     variable_dictionary: defaultdict[
-        str, Annotated[dict[str, Variable], Field(default_factory=dict)]
+        str,
+        Annotated[dict[str, Variable], Field(default_factory=dict)],
     ] = Field(
         description="Variables mapping",
         default_factory=_default_variable_dictionary,
     )
     system_variables: Sequence[Variable] = Field(default_factory=tuple, exclude=True)
     environment_variables: Sequence[Variable] = Field(
-        default_factory=tuple, exclude=True
+        default_factory=tuple,
+        exclude=True,
     )
     conversation_variables: Sequence[Variable] = Field(
-        default_factory=tuple, exclude=True
+        default_factory=tuple,
+        exclude=True,
     )
     rag_pipeline_variables: Sequence[RAGPipelineVariableInput] = Field(
-        default_factory=tuple, exclude=True
+        default_factory=tuple,
+        exclude=True,
     )
     user_inputs: Mapping[str, Any] = Field(default_factory=dict, exclude=True)
 
     @model_validator(mode="after")
     def _load_legacy_bootstrap_inputs(self) -> VariablePool:
-        """
-        Accept legacy constructor kwargs that still appear throughout the workflow
+        """Accept legacy constructor kwargs that still appear throughout the workflow
         layer while keeping serialized state focused on `variable_dictionary`.
-        """
 
+        Returns:
+            The normalized `VariablePool` instance after ingesting legacy inputs.
+
+        """
         self._ingest_legacy_variables(
-            self.system_variables, node_id=self._SYSTEM_VARIABLE_NODE_ID
+            self.system_variables,
+            node_id=self._SYSTEM_VARIABLE_NODE_ID,
         )
         self._ingest_legacy_variables(
-            self.environment_variables, node_id=self._ENVIRONMENT_VARIABLE_NODE_ID
+            self.environment_variables,
+            node_id=self._ENVIRONMENT_VARIABLE_NODE_ID,
         )
         self._ingest_legacy_variables(
-            self.conversation_variables, node_id=self._CONVERSATION_VARIABLE_NODE_ID
+            self.conversation_variables,
+            node_id=self._CONVERSATION_VARIABLE_NODE_ID,
         )
         self._ingest_legacy_rag_variables(self.rag_pipeline_variables)
 
@@ -88,7 +97,10 @@ class VariablePool(BaseModel):
         return self
 
     def _ingest_legacy_variables(
-        self, variables: Sequence[Variable], *, node_id: str
+        self,
+        variables: Sequence[Variable],
+        *,
+        node_id: str,
     ) -> None:
         for variable in variables:
             selector = [node_id, variable.name]
@@ -98,7 +110,8 @@ class VariablePool(BaseModel):
             self.add(normalized_variable.selector, normalized_variable)
 
     def _ingest_legacy_rag_variables(
-        self, rag_pipeline_variables: Sequence[RAGPipelineVariableInput]
+        self,
+        rag_pipeline_variables: Sequence[RAGPipelineVariableInput],
     ) -> None:
         if not rag_pipeline_variables:
             return
@@ -113,8 +126,7 @@ class VariablePool(BaseModel):
             self.add((self._RAG_PIPELINE_VARIABLE_NODE_ID, node_id), value)
 
     def add(self, selector: Sequence[str], value: Any, /):
-        """
-        Add a variable to the variable pool.
+        """Add a variable to the variable pool.
 
         This method accepts a selector path and a value, converting the value
         to a Variable object if necessary before storing it in the pool.
@@ -132,20 +144,23 @@ class VariablePool(BaseModel):
         Note:
             While non-Segment values are currently accepted and automatically
             converted, it's recommended to pass Segment or Variable objects directly.
+
         """
         if len(selector) != SELECTORS_LENGTH:
-            raise ValueError(
+            msg = (
                 f"Invalid selector: expected {SELECTORS_LENGTH} elements "
                 f"(node_id, variable_name), got {len(selector)} elements"
             )
+            raise ValueError(msg)
 
-        if isinstance(value, VariableBase):
-            variable = value
-        elif isinstance(value, Segment):
-            variable = segment_to_variable(segment=value, selector=selector)
-        else:
-            segment = build_segment(value)
-            variable = segment_to_variable(segment=segment, selector=selector)
+        match value:
+            case VariableBase():
+                variable = value
+            case Segment():
+                variable = segment_to_variable(segment=value, selector=selector)
+            case _:
+                segment = build_segment(value)
+                variable = segment_to_variable(segment=segment, selector=selector)
 
         node_id, name = self._selector_to_keys(selector)
         # Based on the definition of `Variable`,
@@ -165,8 +180,7 @@ class VariablePool(BaseModel):
         )
 
     def get(self, selector: Sequence[str], /) -> Segment | None:
-        """
-        Retrieve a variable's value from the pool as a Segment.
+        """Retrieve a variable's value from the pool as a Segment.
 
         This method supports both simple selectors [node_id, variable_name] and
         extended selectors that include attribute access for FileSegment and
@@ -180,55 +194,78 @@ class VariablePool(BaseModel):
 
         Returns:
             The Segment associated with the selector, or None if not found.
-            Returns None if selector has fewer than 2 elements.
+            Returns None if selector has fewer than 2 elements or if an invalid
+            file attribute is requested.
 
-        Raises:
-            ValueError: If attempting to access an invalid FileAttribute.
         """
         if len(selector) < SELECTORS_LENGTH:
             return None
 
         node_id, name = self._selector_to_keys(selector)
         node_map = self.variable_dictionary.get(node_id)
-        if node_map is None:
-            return None
-
-        segment: Segment | None = node_map.get(name)
-
-        if segment is None:
-            return None
-
-        if len(selector) == 2:
+        segment = node_map.get(name) if node_map is not None else None
+        if segment is None or len(selector) == SELECTORS_LENGTH:
             return segment
 
-        if isinstance(segment, FileSegment):
-            attr = selector[2]
-            if attr not in FileAttribute:
-                return None
-            attr = FileAttribute(attr)
-            attr_value = file_manager.get_attr(file=segment.value, attr=attr)
-            return build_segment(attr_value)
+        match segment:
+            case FileSegment():
+                result = self._get_file_attribute_segment(
+                    segment=segment,
+                    attr=selector[2],
+                )
+            case _:
+                result = self._get_nested_segment(
+                    segment=segment,
+                    selector=selector[2:],
+                )
+        return result
 
-        # Navigate through nested attributes
+    def _get_file_attribute_segment(
+        self,
+        *,
+        segment: FileSegment,
+        attr: str,
+    ) -> Segment | None:
+        if attr not in FileAttribute:
+            return None
+        file_attr = FileAttribute(attr)
+        attr_value = file_manager.get_attr(file=segment.value, attr=file_attr)
+        return build_segment(attr_value)
+
+    def _get_nested_segment(
+        self,
+        *,
+        segment: Segment,
+        selector: Sequence[str],
+    ) -> Segment | None:
         result: Any = segment
-        for attr in selector[2:]:
+        for attr in selector:
             result = self._extract_value(result)
             result = self._get_nested_attribute(result, attr)
             if result is None:
                 return None
+        match result:
+            case Segment():
+                nested_segment = result
+            case _:
+                nested_segment = build_segment(result)
+        return nested_segment
 
-        # Return result as Segment
-        return result if isinstance(result, Segment) else build_segment(result)
-
-    def _extract_value(self, obj: Any):
+    def _extract_value(self, obj: Any) -> Any:
         """Extract the actual value from an ObjectSegment."""
-        return obj.value if isinstance(obj, ObjectSegment) else obj
+        match obj:
+            case ObjectSegment():
+                result = obj.value
+            case _:
+                result = obj
+        return result
 
     def _get_nested_attribute(
-        self, obj: Mapping[str, Any], attr: str
+        self,
+        obj: Mapping[str, Any],
+        attr: str,
     ) -> Segment | None:
-        """
-        Get a nested attribute from a dictionary-like object.
+        """Get a nested attribute from a dictionary-like object.
 
         Args:
             obj: The dictionary-like object to search.
@@ -238,20 +275,21 @@ class VariablePool(BaseModel):
             Segment | None:
                 The corresponding Segment built from the attribute value if the
                 key exists, otherwise None.
+
         """
-        if not isinstance(obj, dict) or attr not in obj:
-            return None
-        return build_segment(obj.get(attr))
+        match obj:
+            case dict() if attr in obj:
+                result = build_segment(obj.get(attr))
+            case _:
+                result = None
+        return result
 
     def remove(self, selector: Sequence[str], /):
-        """
-        Remove variables from the variable pool based on the given selector.
+        """Remove variables from the variable pool based on the given selector.
 
         Args:
             selector (Sequence[str]): A sequence of strings representing the selector.
 
-        Returns:
-            None
         """
         if not selector:
             return
@@ -273,13 +311,15 @@ class VariablePool(BaseModel):
 
     def get_file(self, selector: Sequence[str], /) -> FileSegment | None:
         segment = self.get(selector)
-        if isinstance(segment, FileSegment):
-            return segment
-        return None
+        match segment:
+            case FileSegment():
+                result = segment
+            case _:
+                result = None
+        return result
 
     def get_by_prefix(self, prefix: str, /) -> Mapping[str, object]:
         """Return a copy of all variables stored under the given node prefix."""
-
         nodes = self.variable_dictionary.get(prefix)
         if not nodes:
             return {}
@@ -293,7 +333,6 @@ class VariablePool(BaseModel):
 
     def flatten(self, *, unprefixed_node_id: str | None = None) -> Mapping[str, object]:
         """Return a selector-style snapshot of the entire variable pool."""
-
         result: dict[str, object] = {}
         for node_id, variables in self.variable_dictionary.items():
             for name, variable in variables.items():

--- a/src/graphon/utils/condition/processor.py
+++ b/src/graphon/utils/condition/processor.py
@@ -13,17 +13,26 @@ from graphon.variables.segments import (
 
 from .entities import Condition, SubCondition, SupportedComparisonOperator
 
+_FILE_SUB_CONDITION_OPERATORS = frozenset(("contains", "not contains", "all of"))
+_EXISTENCE_OPERATORS = frozenset(("exists", "not exists"))
+
 
 def _convert_to_bool(value: object) -> bool:
-    if isinstance(value, int):
-        return bool(value)
-
-    if isinstance(value, str):
-        loaded = json.loads(value)
-        if isinstance(loaded, (int, bool)):
-            return bool(loaded)
-
-    raise TypeError(f"unexpected value: type={type(value)}, value={value}")
+    match value:
+        case int():
+            result = bool(value)
+        case str():
+            loaded = json.loads(value)
+            match loaded:
+                case int() | bool():
+                    result = bool(loaded)
+                case _:
+                    msg = f"unexpected value: type={type(value)}, value={value}"
+                    raise TypeError(msg)
+        case _:
+            msg = f"unexpected value: type={type(value)}, value={value}"
+            raise TypeError(msg)
+    return result
 
 
 class ConditionCheckResult(NamedTuple):
@@ -46,50 +55,35 @@ class ConditionProcessor:
         for condition in conditions:
             variable = variable_pool.get(condition.variable_selector)
             if variable is None:
-                raise ValueError(f"Variable {condition.variable_selector} not found")
+                msg = f"Variable {condition.variable_selector} not found"
+                raise ValueError(msg)
 
-            if isinstance(
-                variable, ArrayFileSegment
-            ) and condition.comparison_operator in {
-                "contains",
-                "not contains",
-                "all of",
-            }:
+            if _should_process_file_sub_conditions(
+                variable=variable,
+                comparison_operator=condition.comparison_operator,
+            ):
                 # check sub conditions
                 if not condition.sub_variable_condition:
-                    raise ValueError("Sub variable is required")
+                    msg = "Sub variable is required"
+                    raise ValueError(msg)
                 result = _process_sub_conditions(
                     variable=variable,
                     sub_conditions=condition.sub_variable_condition.conditions,
                     operator=condition.sub_variable_condition.logical_operator,
                 )
-            elif condition.comparison_operator in {
-                "exists",
-                "not exists",
-            }:
+            elif condition.comparison_operator in _EXISTENCE_OPERATORS:
                 result = _evaluate_condition(
                     value=variable.value,
                     operator=condition.comparison_operator,
                     expected=None,
                 )
             else:
-                actual_value = variable.value if variable else None
-                expected_value: str | Sequence[str] | bool | list[bool] | None = (
-                    condition.value
+                actual_value = variable.value
+                expected_value = _prepare_expected_value(
+                    variable=variable,
+                    variable_pool=variable_pool,
+                    expected_value=condition.value,
                 )
-                if isinstance(expected_value, str):
-                    expected_value = variable_pool.convert_template(expected_value).text
-                # Here we need to explicit convet the input string to boolean.
-                if (
-                    isinstance(variable, (BooleanSegment, ArrayBooleanSegment))
-                    and expected_value is not None
-                ):
-                    # The following two lines are for compatibility
-                    # with existing workflows.
-                    if isinstance(expected_value, list):
-                        expected_value = [_convert_to_bool(i) for i in expected_value]
-                    else:
-                        expected_value = _convert_to_bool(expected_value)
                 input_conditions.append({
                     "actual_value": actual_value,
                     "expected_value": expected_value,
@@ -105,7 +99,9 @@ class ConditionProcessor:
             if (operator == "and" and not result) or (operator == "or" and result):
                 final_result = result
                 return ConditionCheckResult(
-                    input_conditions, group_results, final_result
+                    input_conditions,
+                    group_results,
+                    final_result,
                 )
 
         final_result = all(group_results) if operator == "and" else any(group_results)
@@ -120,144 +116,205 @@ def _evaluate_condition(
 ) -> bool:
     match operator:
         case "contains":
-            return _assert_contains(value=value, expected=expected)
+            result = _assert_contains(value=value, expected=expected)
         case "not contains":
-            return _assert_not_contains(value=value, expected=expected)
+            result = _assert_not_contains(value=value, expected=expected)
         case "start with":
-            return _assert_start_with(value=value, expected=expected)
+            result = _assert_start_with(value=value, expected=expected)
         case "end with":
-            return _assert_end_with(value=value, expected=expected)
+            result = _assert_end_with(value=value, expected=expected)
         case "is":
-            return _assert_is(value=value, expected=expected)
+            result = _assert_is(value=value, expected=expected)
         case "is not":
-            return _assert_is_not(value=value, expected=expected)
+            result = _assert_is_not(value=value, expected=expected)
         case "empty":
-            return _assert_empty(value=value)
+            result = _assert_empty(value=value)
         case "not empty":
-            return _assert_not_empty(value=value)
+            result = _assert_not_empty(value=value)
         case "=":
-            return _assert_equal(value=value, expected=expected)
+            result = _assert_equal(value=value, expected=expected)
         case "≠":
-            return _assert_not_equal(value=value, expected=expected)
+            result = _assert_not_equal(value=value, expected=expected)
         case ">":
-            return _assert_greater_than(value=value, expected=expected)
+            result = _assert_greater_than(value=value, expected=expected)
         case "<":
-            return _assert_less_than(value=value, expected=expected)
+            result = _assert_less_than(value=value, expected=expected)
         case "≥":
-            return _assert_greater_than_or_equal(value=value, expected=expected)
+            result = _assert_greater_than_or_equal(value=value, expected=expected)
         case "≤":
-            return _assert_less_than_or_equal(value=value, expected=expected)
+            result = _assert_less_than_or_equal(value=value, expected=expected)
         case "null":
-            return _assert_null(value=value)
+            result = _assert_null(value=value)
         case "not null":
-            return _assert_not_null(value=value)
+            result = _assert_not_null(value=value)
         case "in":
-            return _assert_in(value=value, expected=expected)
+            result = _assert_in(value=value, expected=expected)
         case "not in":
-            return _assert_not_in(value=value, expected=expected)
-        case "all of" if isinstance(expected, list):
-            # Type narrowing: expected is a list, either list[str] or list[bool].
-            if all(isinstance(item, str) for item in expected):
-                # Create a new typed list to satisfy type checker
-                str_list: list[str] = [
-                    item for item in expected if isinstance(item, str)
-                ]
-                return _assert_all_of(value=value, expected=str_list)
-            if all(isinstance(item, bool) for item in expected):
-                # Create a new typed list to satisfy type checker
-                bool_list: list[bool] = [
-                    item for item in expected if isinstance(item, bool)
-                ]
-                return _assert_all_of_bool(value=value, expected=bool_list)
-            raise ValueError(
-                "all of operator expects homogeneous list of strings or booleans"
-            )
+            result = _assert_not_in(value=value, expected=expected)
+        case "all of":
+            result = _evaluate_all_of_condition(value=value, expected=expected)
         case "exists":
-            return _assert_exists(value=value)
+            result = _assert_exists(value=value)
         case "not exists":
-            return _assert_not_exists(value=value)
+            result = _assert_not_exists(value=value)
         case _:
-            raise ValueError(f"Unsupported operator: {operator}")
+            msg = f"Unsupported operator: {operator}"
+            raise ValueError(msg)
+    return result
+
+
+def _should_process_file_sub_conditions(
+    *,
+    variable: object,
+    comparison_operator: SupportedComparisonOperator,
+) -> bool:
+    match variable:
+        case ArrayFileSegment():
+            result = comparison_operator in _FILE_SUB_CONDITION_OPERATORS
+        case _:
+            result = False
+    return result
+
+
+def _prepare_expected_value(
+    *,
+    variable: object,
+    variable_pool: VariablePool,
+    expected_value: str | Sequence[str] | bool | Sequence[bool] | None,
+) -> str | Sequence[str] | bool | list[bool] | None:
+    match expected_value:
+        case str():
+            normalized_expected_value = variable_pool.convert_template(
+                expected_value,
+            ).text
+        case _:
+            normalized_expected_value = expected_value
+
+    if normalized_expected_value is None:
+        return None
+
+    match variable, normalized_expected_value:
+        case ((BooleanSegment() | ArrayBooleanSegment()), list()):
+            result = [_convert_to_bool(item) for item in normalized_expected_value]
+        case ((BooleanSegment() | ArrayBooleanSegment()), _):
+            result = _convert_to_bool(normalized_expected_value)
+        case _:
+            result = normalized_expected_value
+    return result
+
+
+def _evaluate_all_of_condition(*, value: object, expected: object) -> bool:
+    match expected:
+        case list() if all(isinstance(item, str) for item in expected):
+            str_list: list[str] = [item for item in expected if isinstance(item, str)]
+            result = _assert_all_of(value=value, expected=str_list)
+        case list() if all(isinstance(item, bool) for item in expected):
+            bool_list: list[bool] = [
+                item for item in expected if isinstance(item, bool)
+            ]
+            result = _assert_all_of_bool(value=value, expected=bool_list)
+        case _:
+            msg = "all of operator expects homogeneous list of strings or booleans"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_contains(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    if not isinstance(value, (str, list)):
-        raise ValueError("Invalid actual value type: string or array")
-
-    # Type checking ensures value is str or list at this point
-    if isinstance(value, str):
-        if not isinstance(expected, str):
-            expected = str(expected)
-        if expected not in value:
-            return False
-    elif expected not in value:
-        return False
-    return True
+    match value:
+        case str():
+            match expected:
+                case str():
+                    normalized_expected = expected
+                case _:
+                    normalized_expected = str(expected)
+            result = normalized_expected in value
+        case list():
+            result = expected in value
+        case _:
+            msg = "Invalid actual value type: string or array"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_not_contains(*, value: object, expected: object) -> bool:
     if not value:
         return True
 
-    if not isinstance(value, (str, list)):
-        raise ValueError("Invalid actual value type: string or array")
-
-    # Type checking ensures value is str or list at this point
-    if isinstance(value, str):
-        if not isinstance(expected, str):
-            expected = str(expected)
-        if expected in value:
-            return False
-    elif expected in value:
-        return False
-    return True
+    match value:
+        case str():
+            match expected:
+                case str():
+                    normalized_expected = expected
+                case _:
+                    normalized_expected = str(expected)
+            result = normalized_expected not in value
+        case list():
+            result = expected not in value
+        case _:
+            msg = "Invalid actual value type: string or array"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_start_with(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    if not isinstance(value, str):
-        raise ValueError("Invalid actual value type: string")
-
-    if not isinstance(expected, str):
-        raise ValueError("Expected value must be a string for startswith")
-    return value.startswith(expected)
+    match value, expected:
+        case str(), str():
+            result = value.startswith(expected)
+        case str(), _:
+            msg = "Expected value must be a string for startswith"
+            raise ValueError(msg)
+        case _:
+            msg = "Invalid actual value type: string"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_end_with(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    if not isinstance(value, str):
-        raise ValueError("Invalid actual value type: string")
-
-    if not isinstance(expected, str):
-        raise ValueError("Expected value must be a string for endswith")
-    return value.endswith(expected)
+    match value, expected:
+        case str(), str():
+            result = value.endswith(expected)
+        case str(), _:
+            msg = "Expected value must be a string for endswith"
+            raise ValueError(msg)
+        case _:
+            msg = "Invalid actual value type: string"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_is(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (str, bool)):
-        raise ValueError("Invalid actual value type: string or boolean")
-
-    return value == expected
+    match value:
+        case str() | bool():
+            result = value == expected
+        case _:
+            msg = "Invalid actual value type: string or boolean"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_is_not(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (str, bool)):
-        raise ValueError("Invalid actual value type: string or boolean")
-
-    return value != expected
+    match value:
+        case str() | bool():
+            result = value != expected
+        case _:
+            msg = "Invalid actual value type: string or boolean"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_empty(*, value: object) -> bool:
@@ -269,10 +326,10 @@ def _assert_not_empty(*, value: object) -> bool:
 
 
 def _normalize_numeric_values(
-    value: float, expected: object
+    value: float,
+    expected: object,
 ) -> tuple[int | float, int | float]:
-    """
-    Normalize value and expected to compatible numeric types for comparison.
+    """Normalize value and expected to compatible numeric types for comparison.
 
     Args:
         value: The actual numeric value (int or float)
@@ -283,120 +340,154 @@ def _normalize_numeric_values(
 
     Raises:
         ValueError: If expected cannot be converted to a number
+
     """
-    if not isinstance(expected, (int, float, str)):
-        raise ValueError(f"Cannot convert {type(expected)} to number")
+    match expected:
+        case str():
+            try:
+                expected_float = float(expected)
+            except ValueError as e:
+                msg = f"Cannot convert '{expected}' to number"
+                raise ValueError(msg) from e
 
-    # Convert expected to appropriate numeric type
-    if isinstance(expected, str):
-        # Try to convert to float first to handle decimal strings
-        try:
-            expected_float = float(expected)
-        except ValueError as e:
-            raise ValueError(f"Cannot convert '{expected}' to number") from e
+            match value:
+                case int() if expected_float.is_integer():
+                    normalized_values = (value, int(expected_float))
+                case int():
+                    normalized_values = (float(value), expected_float)
+                case _:
+                    normalized_values = (value, expected_float)
+        case float():
+            match value:
+                case int():
+                    normalized_values = (float(value), expected)
+                case _:
+                    normalized_values = (value, expected)
+        case int():
+            normalized_values = (value, expected)
+        case _:
+            msg = f"Cannot convert {type(expected)} to number"
+            raise ValueError(msg)
+    return normalized_values
 
-        # If value is int and expected is a whole number, keep as int comparison
-        if isinstance(value, int) and expected_float.is_integer():
-            return value, int(expected_float)
-        # Otherwise convert value to float for comparison
-        return float(value) if isinstance(value, int) else value, expected_float
-    if isinstance(expected, float):
-        # If expected is already float, convert int value to float
-        return float(value) if isinstance(value, int) else value, expected
-    # expected is int
-    return value, expected
+
+def _normalize_numeric_equality_expected(*, value: object, expected: object) -> object:
+    match value:
+        case bool():
+            match expected:
+                case bool() | int() | str():
+                    normalized_expected = bool(expected)
+                case _:
+                    msg = f"Cannot convert {type(expected)} to bool"
+                    raise ValueError(msg)
+        case int():
+            match expected:
+                case int() | float() | str():
+                    normalized_expected = int(expected)
+                case _:
+                    msg = f"Cannot convert {type(expected)} to int"
+                    raise ValueError(msg)
+        case float():
+            match expected:
+                case int() | float() | str():
+                    normalized_expected = float(expected)
+                case _:
+                    msg = f"Cannot convert {type(expected)} to float"
+                    raise ValueError(msg)
+        case _:
+            msg = "Invalid actual value type: number or boolean"
+            raise ValueError(msg)
+    return normalized_expected
 
 
 def _assert_equal(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float, bool)):
-        raise ValueError("Invalid actual value type: number or boolean")
-
-    # Handle boolean comparison
-    if isinstance(value, bool):
-        if not isinstance(expected, (bool, int, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to bool")
-        expected = bool(expected)
-    elif isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    return value == expected
+    normalized_expected = _normalize_numeric_equality_expected(
+        value=value,
+        expected=expected,
+    )
+    return value == normalized_expected
 
 
 def _assert_not_equal(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float, bool)):
-        raise ValueError("Invalid actual value type: number or boolean")
-
-    # Handle boolean comparison
-    if isinstance(value, bool):
-        if not isinstance(expected, (bool, int, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to bool")
-        expected = bool(expected)
-    elif isinstance(value, int):
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to int")
-        expected = int(expected)
-    else:
-        if not isinstance(expected, (int, float, str)):
-            raise ValueError(f"Cannot convert {type(expected)} to float")
-        expected = float(expected)
-
-    return value != expected
+    normalized_expected = _normalize_numeric_equality_expected(
+        value=value,
+        expected=expected,
+    )
+    return value != normalized_expected
 
 
 def _assert_greater_than(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float)):
-        raise ValueError("Invalid actual value type: number")
-
-    value, expected = _normalize_numeric_values(value, expected)
-    return value > expected
+    match value:
+        case int() | float():
+            normalized_value, normalized_expected = _normalize_numeric_values(
+                value,
+                expected,
+            )
+            result = normalized_value > normalized_expected
+        case _:
+            msg = "Invalid actual value type: number"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_less_than(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float)):
-        raise ValueError("Invalid actual value type: number")
-
-    value, expected = _normalize_numeric_values(value, expected)
-    return value < expected
+    match value:
+        case int() | float():
+            normalized_value, normalized_expected = _normalize_numeric_values(
+                value,
+                expected,
+            )
+            result = normalized_value < normalized_expected
+        case _:
+            msg = "Invalid actual value type: number"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_greater_than_or_equal(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float)):
-        raise ValueError("Invalid actual value type: number")
-
-    value, expected = _normalize_numeric_values(value, expected)
-    return value >= expected
+    match value:
+        case int() | float():
+            normalized_value, normalized_expected = _normalize_numeric_values(
+                value,
+                expected,
+            )
+            result = normalized_value >= normalized_expected
+        case _:
+            msg = "Invalid actual value type: number"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_less_than_or_equal(*, value: object, expected: object) -> bool:
     if value is None:
         return False
 
-    if not isinstance(value, (int, float)):
-        raise ValueError("Invalid actual value type: number")
-
-    value, expected = _normalize_numeric_values(value, expected)
-    return value <= expected
+    match value:
+        case int() | float():
+            normalized_value, normalized_expected = _normalize_numeric_values(
+                value,
+                expected,
+            )
+            result = normalized_value <= normalized_expected
+        case _:
+            msg = "Invalid actual value type: number"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_null(*, value: object) -> bool:
@@ -411,40 +502,50 @@ def _assert_in(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    if not isinstance(expected, list):
-        raise ValueError("Invalid expected value type: array")
-    return value in expected
+    match expected:
+        case list():
+            result = value in expected
+        case _:
+            msg = "Invalid expected value type: array"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_not_in(*, value: object, expected: object) -> bool:
     if not value:
         return True
 
-    if not isinstance(expected, list):
-        raise ValueError("Invalid expected value type: array")
-    return value not in expected
+    match expected:
+        case list():
+            result = value not in expected
+        case _:
+            msg = "Invalid expected value type: array"
+            raise ValueError(msg)
+    return result
 
 
 def _assert_all_of(*, value: object, expected: Sequence[str]) -> bool:
     if not value:
         return False
 
-    # Ensure value is a container that supports 'in' operator
-    if not isinstance(value, (list, tuple, set, str)):
-        return False
-
-    return all(item in value for item in expected)
+    match value:
+        case list() | tuple() | set() | str():
+            result = all(item in value for item in expected)
+        case _:
+            result = False
+    return result
 
 
 def _assert_all_of_bool(*, value: object, expected: Sequence[bool]) -> bool:
     if not value:
         return False
 
-    # Ensure value is a container that supports 'in' operator
-    if not isinstance(value, (list, tuple, set)):
-        return False
-
-    return all(item in value for item in expected)
+    match value:
+        case list() | tuple() | set():
+            result = all(item in value for item in expected)
+        case _:
+            result = False
+    return result
 
 
 def _assert_exists(*, value: object) -> bool:
@@ -468,18 +569,21 @@ def _process_sub_conditions(
         expected_value = condition.value
         if key == FileAttribute.EXTENSION:
             if not isinstance(expected_value, str):
-                raise TypeError(
+                msg = (
                     "Expected value must be a string when key is "
                     "FileAttribute.EXTENSION"
                 )
+                raise TypeError(msg)
             if expected_value and not expected_value.startswith("."):
                 expected_value = "." + expected_value
 
             normalized_values: list[object] = []
             for value in values:
                 if value and isinstance(value, str) and not value.startswith("."):
-                    value = "." + value
-                normalized_values.append(value)
+                    normalized_value = "." + value
+                else:
+                    normalized_value = value
+                normalized_values.append(normalized_value)
             values = normalized_values
         sub_group_results: list[bool] = [
             _evaluate_condition(

--- a/src/graphon/utils/json_in_md_parser.py
+++ b/src/graphon/utils/json_in_md_parser.py
@@ -7,6 +7,10 @@ class OutputParserError(ValueError):
     """Raised when a markdown-wrapped JSON payload cannot be parsed or validated."""
 
 
+_JSON_START_CHARS = frozenset(("{", "["))
+_JSON_END_CHARS = frozenset(("}", "]"))
+
+
 def parse_json_markdown(json_string: str) -> dict | list:
     """Extract and parse the first JSON object or array embedded in markdown text."""
     json_string = json_string.strip()
@@ -18,7 +22,7 @@ def parse_json_markdown(json_string: str) -> dict | list:
     for start_marker in starts:
         start_index = json_string.find(start_marker)
         if start_index != -1:
-            if json_string[start_index] not in ("{", "["):
+            if json_string[start_index] not in _JSON_START_CHARS:
                 start_index += len(start_marker)
             break
 
@@ -26,12 +30,13 @@ def parse_json_markdown(json_string: str) -> dict | list:
         for end_marker in ends:
             end_index = json_string.rfind(end_marker, start_index)
             if end_index != -1:
-                if json_string[end_index] in ("}", "]"):
+                if json_string[end_index] in _JSON_END_CHARS:
                     end_index += 1
                 break
 
     if start_index == -1 or end_index == -1 or start_index >= end_index:
-        raise ValueError("could not find json block in the output.")
+        msg = "could not find json block in the output."
+        raise ValueError(msg)
 
     extracted_content = json_string[start_index:end_index].strip()
     return json.loads(extracted_content)
@@ -41,19 +46,22 @@ def parse_and_check_json_markdown(text: str, expected_keys: list[str]) -> dict:
     try:
         json_obj = parse_json_markdown(text)
     except json.JSONDecodeError as exc:
-        raise OutputParserError(f"got invalid json object. error: {exc}") from exc
+        msg = f"got invalid json object. error: {exc}"
+        raise OutputParserError(msg) from exc
 
     if isinstance(json_obj, list):
         if len(json_obj) == 1 and isinstance(json_obj[0], dict):
             json_obj = json_obj[0]
         else:
-            raise OutputParserError(f"got invalid return object. obj:{json_obj}")
+            msg = f"got invalid return object. obj:{json_obj}"
+            raise OutputParserError(msg)
 
     for key in expected_keys:
         if key not in json_obj:
-            raise OutputParserError(
+            msg = (
                 f"got invalid return object. expected key `{key}` to be present, "
                 f"but got {json_obj}"
             )
+            raise OutputParserError(msg)
 
     return json_obj

--- a/src/graphon/variable_loader.py
+++ b/src/graphon/variable_loader.py
@@ -42,6 +42,7 @@ class _DummyVariableLoader(VariableLoader):
     """
 
     def load_variables(self, selectors: list[list[str]]) -> list[VariableBase]:
+        _ = selectors
         return []
 
 
@@ -62,9 +63,8 @@ def load_into_variable_pool(
         # `WorkflowEntry.mapping_user_inputs_to_variable_pool`.
         node_variable_list = key.split(".")
         if len(node_variable_list) < 2:
-            raise ValueError(
-                f"Invalid variable key: {key}. It should have at least two elements."
-            )
+            msg = f"Invalid variable key: {key}. It should have at least two elements."
+            raise ValueError(msg)
         if key in user_inputs:
             continue
         node_variable_key = ".".join(node_variable_list[1:])

--- a/src/graphon/variables/factory.py
+++ b/src/graphon/variables/factory.py
@@ -6,7 +6,7 @@ containers can operate without importing application-layer packages.
 """
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 from graphon.file.models import File
@@ -72,55 +72,107 @@ SEGMENT_TO_VARIABLE_MAP: Mapping[type[Segment], type[Variable]] = {
     StringSegment: StringVariable,
 }
 
+_NUMERICAL_SEGMENT_TYPES = frozenset((
+    SegmentType.NUMBER,
+    SegmentType.INTEGER,
+    SegmentType.FLOAT,
+))
+_ARRAY_SEGMENT_FACTORY_BY_VALUE_TYPE: Mapping[SegmentType, type[Segment]] = {
+    SegmentType.STRING: ArrayStringSegment,
+    SegmentType.NUMBER: ArrayNumberSegment,
+    SegmentType.INTEGER: ArrayNumberSegment,
+    SegmentType.FLOAT: ArrayNumberSegment,
+    SegmentType.BOOLEAN: ArrayBooleanSegment,
+    SegmentType.OBJECT: ArrayObjectSegment,
+    SegmentType.FILE: ArrayFileSegment,
+    SegmentType.NONE: ArrayAnySegment,
+}
+_EMPTY_ARRAY_SEGMENT_FACTORY: Mapping[SegmentType, type[Segment]] = {
+    SegmentType.ARRAY_ANY: ArrayAnySegment,
+    SegmentType.ARRAY_STRING: ArrayStringSegment,
+    SegmentType.ARRAY_BOOLEAN: ArrayBooleanSegment,
+    SegmentType.ARRAY_NUMBER: ArrayNumberSegment,
+    SegmentType.ARRAY_OBJECT: ArrayObjectSegment,
+    SegmentType.ARRAY_FILE: ArrayFileSegment,
+}
+
+
+def _build_non_list_segment(value: Any) -> Segment | None:
+    match value:
+        case None:
+            segment = NoneSegment()
+        case Segment():
+            segment = value
+        case str():
+            segment = StringSegment(value=value)
+        case bool():
+            segment = BooleanSegment(value=value)
+        case int():
+            segment = IntegerSegment(value=value)
+        case float():
+            segment = FloatSegment(value=value)
+        case dict():
+            segment = ObjectSegment(value=value)
+        case File():
+            segment = FileSegment(value=value)
+        case _:
+            segment = None
+    return segment
+
+
+def _build_list_segment(value: list[Any]) -> Segment:
+    items = [build_segment(item) for item in value]
+    types = {item.value_type for item in items}
+
+    if all(isinstance(item, ArraySegment) for item in items):
+        return ArrayAnySegment(value=value)
+    if len(types) != 1:
+        return (
+            ArrayNumberSegment(value=value)
+            if types.issubset(_NUMERICAL_SEGMENT_TYPES)
+            else ArrayAnySegment(value=value)
+        )
+
+    segment_class = _ARRAY_SEGMENT_FACTORY_BY_VALUE_TYPE.get(types.pop())
+    if segment_class is None:
+        msg = f"not supported value {value}"
+        raise ValueError(msg)
+    return segment_class(value=value)
+
+
+def _build_empty_array_segment(
+    *,
+    segment_type: SegmentType,
+    value: list[Any],
+) -> Segment | None:
+    segment_class = _EMPTY_ARRAY_SEGMENT_FACTORY.get(segment_type)
+    return None if segment_class is None else segment_class(value=value)
+
+
+def _resolve_segment_class_for_type_match(
+    *,
+    segment_type: SegmentType,
+    inferred_type: SegmentType,
+) -> type[Segment] | None:
+    if inferred_type == segment_type:
+        return _SEGMENT_FACTORY[segment_type]
+    if segment_type == SegmentType.NUMBER and inferred_type in frozenset((
+        SegmentType.INTEGER,
+        SegmentType.FLOAT,
+    )):
+        return _SEGMENT_FACTORY[inferred_type]
+    return None
+
 
 def build_segment(value: Any, /) -> Segment:
     """Build a runtime segment from a Python value."""
-    if value is None:
-        return NoneSegment()
-    if isinstance(value, Segment):
-        return value
-    if isinstance(value, str):
-        return StringSegment(value=value)
-    if isinstance(value, bool):
-        return BooleanSegment(value=value)
-    if isinstance(value, int):
-        return IntegerSegment(value=value)
-    if isinstance(value, float):
-        return FloatSegment(value=value)
-    if isinstance(value, dict):
-        return ObjectSegment(value=value)
-    if isinstance(value, File):
-        return FileSegment(value=value)
+    segment = _build_non_list_segment(value)
+    if segment is not None:
+        return segment
     if isinstance(value, list):
-        items = [build_segment(item) for item in value]
-        types = {item.value_type for item in items}
-        if all(isinstance(item, ArraySegment) for item in items):
-            return ArrayAnySegment(value=value)
-        if len(types) != 1:
-            if types.issubset({
-                SegmentType.NUMBER,
-                SegmentType.INTEGER,
-                SegmentType.FLOAT,
-            }):
-                return ArrayNumberSegment(value=value)
-            return ArrayAnySegment(value=value)
-
-        match types.pop():
-            case SegmentType.STRING:
-                return ArrayStringSegment(value=value)
-            case SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT:
-                return ArrayNumberSegment(value=value)
-            case SegmentType.BOOLEAN:
-                return ArrayBooleanSegment(value=value)
-            case SegmentType.OBJECT:
-                return ArrayObjectSegment(value=value)
-            case SegmentType.FILE:
-                return ArrayFileSegment(value=value)
-            case SegmentType.NONE:
-                return ArrayAnySegment(value=value)
-            case _:
-                raise ValueError(f"not supported value {value}")
-    raise ValueError(f"not supported value {value}")
+        return _build_list_segment(value)
+    msg = f"not supported value {value}"
+    raise ValueError(msg)
 
 
 _SEGMENT_FACTORY: Mapping[SegmentType, type[Segment]] = {
@@ -145,51 +197,48 @@ def build_segment_with_type(segment_type: SegmentType, value: Any) -> Segment:
     if value is None:
         if segment_type == SegmentType.NONE:
             return NoneSegment()
-        raise TypeMismatchError(f"Type mismatch: expected {segment_type}, but got None")
+        msg = f"Type mismatch: expected {segment_type}, but got None"
+        raise TypeMismatchError(msg)
 
     if isinstance(value, list) and len(value) == 0:
-        if segment_type == SegmentType.ARRAY_ANY:
-            return ArrayAnySegment(value=value)
-        if segment_type == SegmentType.ARRAY_STRING:
-            return ArrayStringSegment(value=value)
-        if segment_type == SegmentType.ARRAY_BOOLEAN:
-            return ArrayBooleanSegment(value=value)
-        if segment_type == SegmentType.ARRAY_NUMBER:
-            return ArrayNumberSegment(value=value)
-        if segment_type == SegmentType.ARRAY_OBJECT:
-            return ArrayObjectSegment(value=value)
-        if segment_type == SegmentType.ARRAY_FILE:
-            return ArrayFileSegment(value=value)
-        raise TypeMismatchError(
-            f"Type mismatch: expected {segment_type}, but got empty list"
+        empty_segment = _build_empty_array_segment(
+            segment_type=segment_type,
+            value=value,
         )
+        if empty_segment is not None:
+            return empty_segment
+        msg = f"Type mismatch: expected {segment_type}, but got empty list"
+        raise TypeMismatchError(msg)
 
     inferred_type = SegmentType.infer_segment_type(value)
     if inferred_type is None:
-        raise TypeMismatchError(
+        msg = (
             f"Type mismatch: expected {segment_type}, but got python object, "
             f"type={type(value)}, value={value}"
         )
-    if inferred_type == segment_type:
-        segment_class = _SEGMENT_FACTORY[segment_type]
-        return segment_class(value_type=segment_type, value=value)
-    if segment_type == SegmentType.NUMBER and inferred_type in (
-        SegmentType.INTEGER,
-        SegmentType.FLOAT,
-    ):
-        segment_class = _SEGMENT_FACTORY[inferred_type]
-        return segment_class(value_type=inferred_type, value=value)
-    raise TypeMismatchError(
+        raise TypeMismatchError(msg)
+
+    segment_class = _resolve_segment_class_for_type_match(
+        segment_type=segment_type,
+        inferred_type=inferred_type,
+    )
+    if segment_class is not None:
+        value_type = (
+            inferred_type if segment_type == SegmentType.NUMBER else segment_type
+        )
+        return segment_class(value_type=value_type, value=value)
+    msg = (
         f"Type mismatch: expected {segment_type}, but got {inferred_type}, "
         f"value={value}"
     )
+    raise TypeMismatchError(msg)
 
 
 def segment_to_variable(
     *,
     segment: Segment,
     selector: Sequence[str],
-    id: str | None = None,
+    variable_id: str | None = None,
     name: str | None = None,
     description: str = "",
 ) -> VariableBase:
@@ -197,17 +246,21 @@ def segment_to_variable(
     if isinstance(segment, VariableBase):
         return segment
     name = name or selector[-1]
-    id = id or str(uuid4())
+    resolved_variable_id = variable_id or str(uuid4())
 
     segment_type = type(segment)
     if segment_type not in SEGMENT_TO_VARIABLE_MAP:
-        raise UnsupportedSegmentTypeError(f"not supported segment type {segment_type}")
+        msg = f"not supported segment type {segment_type}"
+        raise UnsupportedSegmentTypeError(msg)
 
     variable_class = SEGMENT_TO_VARIABLE_MAP[segment_type]
-    return variable_class(
-        id=id,
-        name=name,
-        description=description,
-        value=segment.value,
-        selector=list(selector),
+    return cast(
+        "VariableBase",
+        variable_class(
+            id=resolved_variable_id,
+            name=name,
+            description=description,
+            value=segment.value,
+            selector=list(selector),
+        ),
     )

--- a/src/graphon/variables/input_entities.py
+++ b/src/graphon/variables/input_entities.py
@@ -24,9 +24,7 @@ class VariableEntityType(StrEnum):
 
 
 class VariableEntity(BaseModel):
-    """
-    Shared variable entity used by workflow runtime and app configuration.
-    """
+    """Shared variable entity used by workflow runtime and app configuration."""
 
     # `variable` records the name of the variable in user inputs.
     variable: str
@@ -41,7 +39,7 @@ class VariableEntity(BaseModel):
     allowed_file_types: Sequence[FileType] | None = Field(default_factory=list)
     allowed_file_extensions: Sequence[str] | None = Field(default_factory=list)
     allowed_file_upload_methods: Sequence[FileTransferMethod] | None = Field(
-        default_factory=list
+        default_factory=list,
     )
     json_schema: dict[str, Any] | None = Field(default=None)
 
@@ -58,12 +56,14 @@ class VariableEntity(BaseModel):
     @field_validator("json_schema")
     @classmethod
     def validate_json_schema(
-        cls, schema: dict[str, Any] | None
+        cls,
+        schema: dict[str, Any] | None,
     ) -> dict[str, Any] | None:
         if schema is None:
             return None
         try:
             Draft7Validator.check_schema(schema)
         except SchemaError as error:
-            raise ValueError(f"Invalid JSON schema: {error.message}")
+            msg = f"Invalid JSON schema: {error.message}"
+            raise ValueError(msg) from error
         return schema

--- a/src/graphon/variables/segments.py
+++ b/src/graphon/variables/segments.py
@@ -23,14 +23,21 @@ class Segment(BaseModel):
 
     @field_validator("value_type")
     @classmethod
-    def validate_value_type(cls, value):
-        """
-        This validator checks if the provided value is equal to the default value
+    def validate_value_type(cls, value: SegmentType) -> SegmentType:
+        """Validate that the provided value is equal to the default value
         of the `'value_type'` field. If the value is different, a ValueError is
         raised.
+
+        Returns:
+            The validated `value_type` when it matches the segment class default.
+
+        Raises:
+            ValueError: If `value` differs from the segment class default `value_type`.
+
         """
         if value != cls.model_fields["value_type"].default:
-            raise ValueError("Cannot modify 'value_type'")
+            msg = "Cannot modify 'value_type'"
+            raise ValueError(msg)
         return value
 
     @property
@@ -47,9 +54,7 @@ class Segment(BaseModel):
 
     @property
     def size(self) -> int:
-        """
-        Return the size of the value in bytes.
-        """
+        """Return the size of the value in bytes."""
         return sys.getsizeof(self.value)
 
     def to_object(self):

--- a/src/graphon/variables/types.py
+++ b/src/graphon/variables/types.py
@@ -10,12 +10,47 @@ if TYPE_CHECKING:
     from graphon.variables.segments import Segment
 
 
+def _infer_scalar_segment_type(value: Any) -> SegmentType | None:
+    match value:
+        case None:
+            inferred_type = SegmentType.NONE
+        case bool():
+            inferred_type = SegmentType.BOOLEAN
+        case int():
+            inferred_type = SegmentType.INTEGER
+        case float():
+            inferred_type = SegmentType.FLOAT
+        case str():
+            inferred_type = SegmentType.STRING
+        case dict():
+            inferred_type = SegmentType.OBJECT
+        case File():
+            inferred_type = SegmentType.FILE
+        case _:
+            inferred_type = None
+    return inferred_type
+
+
+def _is_group_value_valid(value: Any) -> bool:
+    from .segment_group import SegmentGroup  # noqa: PLC0415
+    from .segments import Segment  # noqa: PLC0415
+
+    match value:
+        case SegmentGroup():
+            return all(isinstance(item, Segment) for item in value.value)
+        case list():
+            return all(isinstance(item, Segment) for item in value)
+        case _:
+            return False
+
+
 class ArrayValidation(StrEnum):
     """Strategy for validating array elements.
 
     Note:
         The `NONE` and `FIRST` strategies are primarily for compatibility purposes.
         Avoid using them in new code whenever possible.
+
     """
 
     # Skip element validation (only check array container)
@@ -55,63 +90,45 @@ class SegmentType(StrEnum):
 
     @classmethod
     def infer_segment_type(cls, value: Any) -> SegmentType | None:
-        """
-        Attempt to infer the `SegmentType` based on the Python type of the
+        """Attempt to infer the `SegmentType` based on the Python type of the
         `value` parameter.
 
         Returns `None` if no appropriate `SegmentType` can be determined for
         the given `value`. For example, this may occur if the input is a
         generic Python object of type `object`.
-        """
 
+        Returns:
+            The inferred `SegmentType`, or `None` when no runtime type matches.
+
+        Raises:
+            ValueError: If an unsupported homogeneous list element type reaches the
+                internal exhaustive match.
+
+        """
         if isinstance(value, list):
             elem_types: set[SegmentType] = set()
-            for i in value:
-                segment_type = cls.infer_segment_type(i)
+            for item in value:
+                segment_type = cls.infer_segment_type(item)
                 if segment_type is None:
                     return None
-
                 elem_types.add(segment_type)
 
             if len(elem_types) != 1:
-                if elem_types.issubset(_NUMERICAL_TYPES):
-                    return SegmentType.ARRAY_NUMBER
+                return (
+                    SegmentType.ARRAY_NUMBER
+                    if elem_types.issubset(_NUMERICAL_TYPES)
+                    else SegmentType.ARRAY_ANY
+                )
+            if all(item.is_array_type() for item in elem_types):
                 return SegmentType.ARRAY_ANY
-            if all(i.is_array_type() for i in elem_types):
-                return SegmentType.ARRAY_ANY
-            match elem_types.pop():
-                case SegmentType.STRING:
-                    return SegmentType.ARRAY_STRING
-                case SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT:
-                    return SegmentType.ARRAY_NUMBER
-                case SegmentType.OBJECT:
-                    return SegmentType.ARRAY_OBJECT
-                case SegmentType.FILE:
-                    return SegmentType.ARRAY_FILE
-                case SegmentType.NONE:
-                    return SegmentType.ARRAY_ANY
-                case SegmentType.BOOLEAN:
-                    return SegmentType.ARRAY_BOOLEAN
-                case _:
-                    # This should be unreachable.
-                    raise ValueError(f"not supported value {value}")
-        if value is None:
-            return SegmentType.NONE
-        # Important: The check for `bool` must precede the check for `int`,
-        # as `bool` is a subclass of `int` in Python's type hierarchy.
-        if isinstance(value, bool):
-            return SegmentType.BOOLEAN
-        if isinstance(value, int):
-            return SegmentType.INTEGER
-        if isinstance(value, float):
-            return SegmentType.FLOAT
-        if isinstance(value, str):
-            return SegmentType.STRING
-        if isinstance(value, dict):
-            return SegmentType.OBJECT
-        if isinstance(value, File):
-            return SegmentType.FILE
-        return None
+
+            inferred_type = _ARRAY_SEGMENT_TYPE_BY_ELEMENT_TYPE.get(elem_types.pop())
+            if inferred_type is None:
+                msg = f"not supported value {value}"
+                raise ValueError(msg)
+            return inferred_type
+
+        return _infer_scalar_segment_type(value)
 
     def _validate_array(self, value: Any, array_validation: ArrayValidation) -> bool:
         if not isinstance(value, list):
@@ -133,10 +150,11 @@ class SegmentType(StrEnum):
         )
 
     def is_valid(
-        self, value: Any, array_validation: ArrayValidation = ArrayValidation.ALL
+        self,
+        value: Any,
+        array_validation: ArrayValidation = ArrayValidation.ALL,
     ) -> bool:
-        """
-        Check if a value matches the segment type.
+        """Check if a value matches the segment type.
         Users of `SegmentType` should call this method, instead of using
         `isinstance` manually.
 
@@ -147,37 +165,33 @@ class SegmentType(StrEnum):
 
         Returns:
             True if the value matches the type under the given validation strategy
+
+        Raises:
+            AssertionError: If an unsupported `SegmentType` reaches this method.
+
         """
         if self.is_array_type():
-            return self._validate_array(value, array_validation)
-        # Important: The check for `bool` must precede the check for `int`,
-        # as `bool` is a subclass of `int` in Python's type hierarchy.
-        if self == SegmentType.BOOLEAN:
-            return isinstance(value, bool)
-        if self in [SegmentType.INTEGER, SegmentType.FLOAT, SegmentType.NUMBER]:
-            return isinstance(value, (int, float))
-        if self == SegmentType.STRING:
-            return isinstance(value, str)
-        if self == SegmentType.OBJECT:
-            return isinstance(value, dict)
-        if self == SegmentType.SECRET:
-            return isinstance(value, str)
-        if self == SegmentType.FILE:
-            return isinstance(value, File)
-        if self == SegmentType.NONE:
-            return value is None
-        if self == SegmentType.GROUP:
-            from .segment_group import SegmentGroup
-            from .segments import Segment
-
-            if isinstance(value, SegmentGroup):
-                return all(isinstance(item, Segment) for item in value.value)
-
-            if isinstance(value, list):
-                return all(isinstance(item, Segment) for item in value)
-
-            return False
-        raise AssertionError("this statement should be unreachable.")
+            result = self._validate_array(value, array_validation)
+        else:
+            match self:
+                case SegmentType.GROUP:
+                    result = _is_group_value_valid(value)
+                case SegmentType.BOOLEAN:
+                    result = isinstance(value, bool)
+                case SegmentType.NUMBER | SegmentType.INTEGER | SegmentType.FLOAT:
+                    result = isinstance(value, (int, float))
+                case SegmentType.STRING | SegmentType.SECRET:
+                    result = isinstance(value, str)
+                case SegmentType.OBJECT:
+                    result = isinstance(value, dict)
+                case SegmentType.FILE:
+                    result = isinstance(value, File)
+                case SegmentType.NONE:
+                    result = value is None
+                case _:
+                    msg = "this statement should be unreachable."
+                    raise AssertionError(msg)
+        return result
 
     @staticmethod
     def cast_value(value: Any, type_: SegmentType):
@@ -191,10 +205,7 @@ class SegmentType(StrEnum):
         # It should not be used to compromise the integrity of the runtime type system.
         # No additional casting rules should be introduced to this function.
 
-        if type_ in (
-            SegmentType.INTEGER,
-            SegmentType.NUMBER,
-        ) and isinstance(value, bool):
+        if type_ in _BOOL_CASTABLE_TYPES and isinstance(value, bool):
             return int(value)
         if type_ == SegmentType.ARRAY_NUMBER and all(
             isinstance(i, bool) for i in value
@@ -207,14 +218,21 @@ class SegmentType(StrEnum):
 
         The frontend treats `INTEGER` and `FLOAT` as `NUMBER`,
         so these are returned as `NUMBER` here.
+
+        Returns:
+            The frontend-facing type for this runtime segment type.
+
         """
-        if self in (SegmentType.INTEGER, SegmentType.FLOAT):
+        if self in _EXPOSED_NUMBER_TYPES:
             return SegmentType.NUMBER
         return self
 
     def element_type(self) -> SegmentType | None:
         """Return the element type of the current segment type, or `None` if the
         element type is undefined.
+
+        Returns:
+            The array element `SegmentType`, or `None` when the array is untyped.
 
         Raises:
             ValueError: If the current segment type is not an array type.
@@ -223,42 +241,57 @@ class SegmentType(StrEnum):
             For certain array types, such as `SegmentType.ARRAY_ANY`, their
             element types are not defined
             by the runtime system. In such cases, this method will return `None`.
+
         """
         if not self.is_array_type():
-            raise ValueError(
-                f"element_type is only supported by array type, got {self}"
-            )
+            msg = f"element_type is only supported by array type, got {self}"
+            raise ValueError(msg)
         return _ARRAY_ELEMENT_TYPES_MAPPING.get(self)
 
     @staticmethod
     def get_zero_value(t: SegmentType) -> Segment:
         # Lazy import to avoid circular dependency between segment types
         # and factory helpers.
-        from graphon.variables.factory import build_segment, build_segment_with_type
+        from .factory import build_segment, build_segment_with_type  # noqa: PLC0415
 
-        match t:
-            case (
-                SegmentType.ARRAY_OBJECT
-                | SegmentType.ARRAY_ANY
-                | SegmentType.ARRAY_STRING
-                | SegmentType.ARRAY_NUMBER
-                | SegmentType.ARRAY_BOOLEAN
-            ):
-                return build_segment_with_type(t, [])
-            case SegmentType.OBJECT:
-                return build_segment({})
-            case SegmentType.STRING:
-                return build_segment("")
-            case SegmentType.INTEGER:
-                return build_segment(0)
-            case SegmentType.FLOAT:
-                return build_segment(0.0)
-            case SegmentType.NUMBER:
-                return build_segment(0)
-            case SegmentType.BOOLEAN:
-                return build_segment(False)
-            case _:
-                raise ValueError(f"unsupported variable type: {t}")
+        if t in _EMPTY_ARRAY_ZERO_VALUE_TYPES:
+            return build_segment_with_type(t, [])
+
+        zero_value = _SCALAR_ZERO_VALUES_BY_SEGMENT_TYPE.get(t)
+        if zero_value is None:
+            msg = f"unsupported variable type: {t}"
+            raise ValueError(msg)
+        return build_segment(zero_value)
+
+
+_ARRAY_SEGMENT_TYPE_BY_ELEMENT_TYPE: Mapping[SegmentType, SegmentType] = {
+    SegmentType.STRING: SegmentType.ARRAY_STRING,
+    SegmentType.NUMBER: SegmentType.ARRAY_NUMBER,
+    SegmentType.INTEGER: SegmentType.ARRAY_NUMBER,
+    SegmentType.FLOAT: SegmentType.ARRAY_NUMBER,
+    SegmentType.OBJECT: SegmentType.ARRAY_OBJECT,
+    SegmentType.FILE: SegmentType.ARRAY_FILE,
+    SegmentType.NONE: SegmentType.ARRAY_ANY,
+    SegmentType.BOOLEAN: SegmentType.ARRAY_BOOLEAN,
+}
+_EMPTY_ARRAY_ZERO_VALUE_TYPES = frozenset((
+    SegmentType.ARRAY_OBJECT,
+    SegmentType.ARRAY_ANY,
+    SegmentType.ARRAY_STRING,
+    SegmentType.ARRAY_NUMBER,
+    SegmentType.ARRAY_BOOLEAN,
+))
+_SCALAR_ZERO_VALUES_BY_SEGMENT_TYPE: Mapping[
+    SegmentType,
+    dict[Any, Any] | str | int | float | bool,
+] = {
+    SegmentType.OBJECT: {},
+    SegmentType.STRING: "",
+    SegmentType.INTEGER: 0,
+    SegmentType.FLOAT: 0.0,
+    SegmentType.NUMBER: 0,
+    SegmentType.BOOLEAN: False,
+}
 
 
 _ARRAY_ELEMENT_TYPES_MAPPING: Mapping[SegmentType, SegmentType] = {
@@ -270,15 +303,23 @@ _ARRAY_ELEMENT_TYPES_MAPPING: Mapping[SegmentType, SegmentType] = {
     SegmentType.ARRAY_BOOLEAN: SegmentType.BOOLEAN,
 }
 
-_ARRAY_TYPES = frozenset(
-    list(_ARRAY_ELEMENT_TYPES_MAPPING.keys())
-    + [
-        SegmentType.ARRAY_ANY,
-    ]
-)
+_ARRAY_TYPES = frozenset([
+    *_ARRAY_ELEMENT_TYPES_MAPPING.keys(),
+    SegmentType.ARRAY_ANY,
+])
 
 _NUMERICAL_TYPES = frozenset([
     SegmentType.NUMBER,
+    SegmentType.INTEGER,
+    SegmentType.FLOAT,
+])
+
+_BOOL_CASTABLE_TYPES = frozenset([
+    SegmentType.INTEGER,
+    SegmentType.NUMBER,
+])
+
+_EXPOSED_NUMBER_TYPES = frozenset([
     SegmentType.INTEGER,
     SegmentType.FLOAT,
 ])

--- a/src/graphon/variables/utils.py
+++ b/src/graphon/variables/utils.py
@@ -16,20 +16,25 @@ def to_selector(node_id: str, name: str, paths: Iterable[str] = ()) -> Sequence[
 
 def segment_orjson_default(o: Any):
     """Default function for orjson serialization of Segment types"""
-    if isinstance(o, ArrayFileSegment):
-        return [v.model_dump() for v in o.value]
-    if isinstance(o, FileSegment):
-        return o.value.model_dump()
-    if isinstance(o, SegmentGroup):
-        return [segment_orjson_default(seg) for seg in o.value]
-    if isinstance(o, Segment):
-        return o.value
-    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+    result: object
+    match o:
+        case ArrayFileSegment():
+            result = [v.model_dump() for v in o.value]
+        case FileSegment():
+            result = o.value.model_dump()
+        case SegmentGroup():
+            result = [segment_orjson_default(seg) for seg in o.value]
+        case Segment():
+            result = o.value
+        case _:
+            msg = f"Object of type {type(o).__name__} is not JSON serializable"
+            raise TypeError(msg)
+    return result
 
 
-def dumps_with_segments(obj: Any, ensure_ascii: bool = False) -> str:
+def dumps_with_segments(obj: Any) -> str:
     """JSON dumps with segment support using orjson"""
     option = orjson.OPT_NON_STR_KEYS
     return orjson.dumps(obj, default=segment_orjson_default, option=option).decode(
-        "utf-8"
+        "utf-8",
     )

--- a/src/graphon/variables/variables.py
+++ b/src/graphon/variables/variables.py
@@ -34,8 +34,7 @@ def _obfuscated_token(token: str) -> str:
 
 
 class VariableBase(Segment):
-    """
-    A variable is a segment that has a name.
+    """A variable is a segment that has a name.
 
     It is mainly used to store segments and their selector in VariablePool.
 
@@ -118,12 +117,12 @@ class ArrayBooleanVariable(ArrayBooleanSegment, ArrayVariable):
 
 class RAGPipelineVariable(BaseModel):
     belong_to_node_id: str = Field(
-        description="belong to which node id, shared means public"
+        description="belong to which node id, shared means public",
     )
     type: str = Field(
         description=(
             "variable type, text-input, paragraph, select, number, file, file-list"
-        )
+        ),
     )
     label: str = Field(description="label")
     description: str | None = Field(description="description", default="")
@@ -137,13 +136,16 @@ class RAGPipelineVariable(BaseModel):
     unit: str | None = Field(description="unit, applicable to Number", default="")
     tooltips: str | None = Field(description="helpful text", default="")
     allowed_file_types: list[str] | None = Field(
-        description="image, document, audio, video, custom.", default_factory=list
+        description="image, document, audio, video, custom.",
+        default_factory=list,
     )
     allowed_file_extensions: list[str] | None = Field(
-        description="e.g. ['.jpg', '.mp3']", default_factory=list
+        description="e.g. ['.jpg', '.mp3']",
+        default_factory=list,
     )
     allowed_file_upload_methods: list[str] | None = Field(
-        description="remote_url, local_file, tool_file.", default_factory=list
+        description="remote_url, local_file, tool_file.",
+        default_factory=list,
     )
     required: bool = Field(description="optional, default false", default=False)
     options: list[str] | None = Field(default_factory=list)

--- a/src/graphon/workflow_type_encoder.py
+++ b/src/graphon/workflow_type_encoder.py
@@ -15,34 +15,36 @@ class WorkflowRuntimeTypeConverter:
     def to_json_encodable(self, value: None) -> None: ...
 
     def to_json_encodable(
-        self, value: Mapping[str, Any] | None
+        self,
+        value: Mapping[str, Any] | None,
     ) -> Mapping[str, Any] | None:
         """Convert runtime values to JSON-serializable structures."""
-
         result = self.value_to_json_encodable_recursive(value)
         if isinstance(result, Mapping) or result is None:
             return result
         return {}
 
     def value_to_json_encodable_recursive(self, value: Any):
-        if value is None:
-            return value
-        if isinstance(value, (bool, int, str, float)):
-            return value
-        if isinstance(value, Decimal):
-            # Convert Decimal to float for JSON serialization
-            return float(value)
-        if isinstance(value, Segment):
-            return self.value_to_json_encodable_recursive(value.value)
-        if isinstance(value, File):
-            return value.to_dict()
-        if isinstance(value, BaseModel):
-            return value.model_dump(mode="json")
-        if isinstance(value, dict):
-            res = {}
-            for k, v in value.items():
-                res[k] = self.value_to_json_encodable_recursive(v)
-            return res
-        if isinstance(value, list):
-            return [self.value_to_json_encodable_recursive(item) for item in value]
-        return value
+        result = value
+        match value:
+            case None | bool() | int() | str() | float():
+                result = value
+            case Decimal():
+                # Convert Decimal to float for JSON serialization
+                result = float(value)
+            case Segment():
+                result = self.value_to_json_encodable_recursive(value.value)
+            case File():
+                result = value.to_dict()
+            case BaseModel():
+                result = value.model_dump(mode="json")
+            case dict():
+                encoded_mapping = {}
+                for key, item in value.items():
+                    encoded_mapping[key] = self.value_to_json_encodable_recursive(item)
+                result = encoded_mapping
+            case list():
+                result = [
+                    self.value_to_json_encodable_recursive(item) for item in value
+                ]
+        return result

--- a/tests/entities/test_pause_reason.py
+++ b/tests/entities/test_pause_reason.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
@@ -39,14 +41,14 @@ class TestPauseReasonDiscriminator:
                     "reason": {
                         "TYPE": "scheduled_pause",
                         "message": "Hold on",
-                    }
+                    },
                 },
                 SchedulingPause(message="Hold on"),
                 id="SchedulingPause",
             ),
         ],
     )
-    def test_model_validate(self, dict_value, expected):
+    def test_model_validate(self, dict_value: dict[str, Any], expected: PauseReason):
         holder = _Holder.model_validate(dict_value)
 
         assert type(holder.reason) is type(expected)
@@ -65,7 +67,7 @@ class TestPauseReasonDiscriminator:
         ],
         ids=lambda x: type(x).__name__,
     )
-    def test_model_construct(self, reason):
+    def test_model_construct(self, reason: PauseReason):
         holder = _Holder(reason=reason)
         assert holder.reason == reason
 

--- a/tests/entities/test_workflow_execution_status.py
+++ b/tests/entities/test_workflow_execution_status.py
@@ -23,9 +23,9 @@ class TestWorkflowExecutionStatus:
             assert not status.is_ended(), f"{status} should not be considered ended"
 
     def test_ended_values(self):
-        assert set(WorkflowExecutionStatus.ended_values()) == {
+        assert set(WorkflowExecutionStatus.ended_values()) == frozenset((
             WorkflowExecutionStatus.SUCCEEDED.value,
             WorkflowExecutionStatus.FAILED.value,
             WorkflowExecutionStatus.PARTIAL_SUCCEEDED.value,
             WorkflowExecutionStatus.STOPPED.value,
-        }
+        ))

--- a/tests/entities/test_workflow_node_execution.py
+++ b/tests/entities/test_workflow_node_execution.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -21,7 +21,7 @@ class TestWorkflowNodeExecutionProcessDataTruncation:
             node_type=BuiltinNodeTypes.LLM,
             title="Test Node",
             process_data=process_data,
-            created_at=datetime.now(),
+            created_at=datetime.now(UTC).replace(tzinfo=None),
         )
 
     def test_initial_process_data_truncated_state(self):
@@ -105,7 +105,10 @@ class TestWorkflowNodeExecutionProcessDataTruncation:
             {},
         ],
     )
-    def test_truncated_process_data_with_various_data_types(self, test_data):
+    def test_truncated_process_data_with_various_data_types(
+        self,
+        test_data: dict[str, Any],
+    ) -> None:
         execution = self.create_workflow_node_execution()
 
         execution.set_truncated_process_data(test_data)
@@ -190,7 +193,7 @@ class TestWorkflowNodeExecutionProcessDataScenarios:
             node_type=BuiltinNodeTypes.LLM,
             title="Test Node",
             process_data=scenario.original_data,
-            created_at=datetime.now(),
+            created_at=datetime.now(UTC).replace(tzinfo=None),
         )
 
         if scenario.truncated_data is not None:

--- a/tests/examples/test_graphon_openai_slim.py
+++ b/tests/examples/test_graphon_openai_slim.py
@@ -15,7 +15,10 @@ from graphon.enums import BuiltinNodeTypes
 from graphon.graph_events.node import NodeRunStreamChunkEvent
 
 
-def test_load_env_file_sets_missing_values(monkeypatch, tmp_path: Path) -> None:
+def test_load_env_file_sets_missing_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     env_file = tmp_path / ".env"
     env_file.write_text(
         "OPENAI_API_KEY=secret\n"
@@ -34,13 +37,13 @@ def test_load_env_file_sets_missing_values(monkeypatch, tmp_path: Path) -> None:
         assert env_file.is_file()
         assert os.environ["OPENAI_API_KEY"] == "secret"
         assert os.environ["SLIM_BINARY_PATH"] == str(
-            (tmp_path / ".." / "bin" / "dify-plugin-daemon-slim").resolve()
+            (tmp_path / ".." / "bin" / "dify-plugin-daemon-slim").resolve(),
         )
         assert os.environ["SLIM_PROVIDER"] == "openai"
 
 
 def test_load_env_file_does_not_override_existing_values(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     env_file = tmp_path / ".env"
@@ -99,7 +102,7 @@ def test_env_example_leaves_slim_binary_path_empty() -> None:
         for key, value in [line.removeprefix("export ").split("=", 1)]
     }
 
-    assert values["SLIM_BINARY_PATH"] == ""
+    assert not values["SLIM_BINARY_PATH"]
 
 
 def test_write_stream_chunk_writes_llm_text_chunks() -> None:
@@ -129,4 +132,4 @@ def test_write_stream_chunk_ignores_non_llm_text_chunks() -> None:
     )
 
     assert write_stream_chunk(event, stream_output=output) is False
-    assert output.getvalue() == ""
+    assert not output.getvalue()

--- a/tests/file/test_file_manager.py
+++ b/tests/file/test_file_manager.py
@@ -1,4 +1,5 @@
 import base64
+from collections.abc import Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -30,8 +31,8 @@ def _build_file(
     mime_type: str = "image/png",
 ) -> File:
     return File(
-        id="file-id",
-        type=file_type,
+        file_id="file-id",
+        file_type=file_type,
         transfer_method=transfer_method,
         reference=reference,
         remote_url=remote_url,
@@ -43,7 +44,7 @@ def _build_file(
 
 
 @pytest.fixture
-def workflow_file_runtime():
+def workflow_file_runtime() -> Generator[MagicMock, None, None]:
     previous_runtime = get_workflow_file_runtime()
     runtime = MagicMock()
     set_workflow_file_runtime(runtime)
@@ -62,13 +63,15 @@ def workflow_file_runtime():
     ],
 )
 def test_download_delegates_storage_backed_files_to_runtime_loader(
-    workflow_file_runtime, transfer_method
+    workflow_file_runtime: MagicMock,
+    transfer_method: FileTransferMethod,
 ) -> None:
     workflow_file_runtime.load_file_bytes.return_value = b"payload"
     file = _build_file(
         transfer_method=transfer_method,
         reference=build_file_reference(
-            record_id="file-id", storage_key="files/payload.bin"
+            record_id="file-id",
+            storage_key="files/payload.bin",
         ),
     )
 
@@ -76,7 +79,9 @@ def test_download_delegates_storage_backed_files_to_runtime_loader(
     workflow_file_runtime.load_file_bytes.assert_called_once_with(file=file)
 
 
-def test_download_remote_url_uses_runtime_http_get(workflow_file_runtime) -> None:
+def test_download_remote_url_uses_runtime_http_get(
+    workflow_file_runtime: MagicMock,
+) -> None:
     response = MagicMock()
     response.content = b"remote-payload"
     workflow_file_runtime.http_get.return_value = response
@@ -87,13 +92,14 @@ def test_download_remote_url_uses_runtime_http_get(workflow_file_runtime) -> Non
 
     assert download(file) == b"remote-payload"
     workflow_file_runtime.http_get.assert_called_once_with(
-        "https://example.com/image.png", follow_redirects=True
+        "https://example.com/image.png",
+        follow_redirects=True,
     )
     response.raise_for_status.assert_called_once_with()
 
 
 def test_to_prompt_message_content_uses_runtime_url_resolution_for_images(
-    workflow_file_runtime,
+    workflow_file_runtime: MagicMock,
 ) -> None:
     workflow_file_runtime.multimodal_send_format = "url"
     workflow_file_runtime.resolve_file_url.return_value = (
@@ -102,22 +108,24 @@ def test_to_prompt_message_content_uses_runtime_url_resolution_for_images(
     file = _build_file(
         transfer_method=FileTransferMethod.LOCAL_FILE,
         reference=build_file_reference(
-            record_id="upload-file-id", storage_key="files/image.png"
+            record_id="upload-file-id",
+            storage_key="files/image.png",
         ),
     )
 
     content = to_prompt_message_content(
-        file, image_detail_config=ImagePromptMessageContent.DETAIL.HIGH
+        file,
+        image_detail_config=ImagePromptMessageContent.DETAIL.HIGH,
     )
 
     assert isinstance(content, ImagePromptMessageContent)
     assert content.url == "https://cdn.example.com/image.png"
-    assert content.base64_data == ""
+    assert not content.base64_data
     assert content.detail == ImagePromptMessageContent.DETAIL.HIGH
 
 
 def test_to_prompt_message_content_uses_runtime_file_loader_for_base64_documents(
-    workflow_file_runtime,
+    workflow_file_runtime: MagicMock,
 ) -> None:
     workflow_file_runtime.multimodal_send_format = "base64"
     workflow_file_runtime.load_file_bytes.return_value = b"document-bytes"
@@ -125,7 +133,8 @@ def test_to_prompt_message_content_uses_runtime_file_loader_for_base64_documents
         transfer_method=FileTransferMethod.TOOL_FILE,
         file_type=FileType.DOCUMENT,
         reference=build_file_reference(
-            record_id="tool-file-id", storage_key="docs/report.pdf"
+            record_id="tool-file-id",
+            storage_key="docs/report.pdf",
         ),
         filename="report.pdf",
         extension=".pdf",
@@ -136,7 +145,7 @@ def test_to_prompt_message_content_uses_runtime_file_loader_for_base64_documents
 
     assert isinstance(content, DocumentPromptMessageContent)
     assert content.base64_data == base64.b64encode(b"document-bytes").decode("utf-8")
-    assert content.url == ""
+    assert not content.url
     workflow_file_runtime.load_file_bytes.assert_called_once_with(file=file)
 
 

--- a/tests/file/test_models.py
+++ b/tests/file/test_models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from graphon.file import helpers
 from graphon.file.enums import (
     FileTransferMethod,
@@ -10,8 +12,8 @@ from ..helpers import build_file_reference
 
 def _build_local_file(*, reference: str, storage_key: str | None = None) -> File:
     return File(
-        id="file-id",
-        type=FileType.DOCUMENT,
+        file_id="file-id",
+        file_type=FileType.DOCUMENT,
         transfer_method=FileTransferMethod.LOCAL_FILE,
         reference=reference,
         filename="report.pdf",
@@ -24,7 +26,8 @@ def _build_local_file(*, reference: str, storage_key: str | None = None) -> File
 
 def test_file_exposes_legacy_aliases_from_opaque_reference() -> None:
     reference = build_file_reference(
-        record_id="upload-file-id", storage_key="files/report.pdf"
+        record_id="upload-file-id",
+        storage_key="files/report.pdf",
     )
 
     file = _build_local_file(reference=reference)
@@ -36,22 +39,31 @@ def test_file_exposes_legacy_aliases_from_opaque_reference() -> None:
 
 def test_file_falls_back_to_raw_reference_when_opaque_reference_is_invalid() -> None:
     file = _build_local_file(
-        reference="dify-file-ref:not-base64", storage_key="fallback-key"
+        reference="dify-file-ref:not-base64",
+        storage_key="fallback-key",
     )
 
     assert file.related_id == "dify-file-ref:not-base64"
     assert file.storage_key == "fallback-key"
 
 
-def test_file_to_dict_keeps_reference_and_legacy_related_id(monkeypatch) -> None:
+def test_file_to_dict_keeps_reference_and_legacy_related_id(
+    monkeypatch: Any,
+) -> None:
     reference = build_file_reference(
-        record_id="upload-file-id", storage_key="files/report.pdf"
+        record_id="upload-file-id",
+        storage_key="files/report.pdf",
     )
     file = _build_local_file(reference=reference)
+
+    def fake_resolve_file_url(_file: Any, *, for_external: bool = True) -> str:
+        _ = for_external
+        return "https://example.com/report.pdf"
+
     monkeypatch.setattr(
         helpers,
         "resolve_file_url",
-        lambda _file, for_external=True: "https://example.com/report.pdf",
+        fake_resolve_file_url,
     )
 
     serialized = file.to_dict()

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -41,7 +41,10 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="child1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="child1",
+                source_handle="source",
             ),
         }
 
@@ -64,10 +67,16 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="child1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="child1",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="root2", head="child2", source_handle="source"
+                id="edge2",
+                tail="root2",
+                head="child2",
+                source_handle="source",
             ),
         }
 
@@ -94,16 +103,28 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="child1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="child1",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="root2", head="child2", source_handle="source"
+                id="edge2",
+                tail="root2",
+                head="child2",
+                source_handle="source",
             ),
             "edge3": Edge(
-                id="edge3", tail="child1", head="shared", source_handle="source"
+                id="edge3",
+                tail="child1",
+                head="shared",
+                source_handle="source",
             ),
             "edge4": Edge(
-                id="edge4", tail="child2", head="shared", source_handle="source"
+                id="edge4",
+                tail="child2",
+                head="shared",
+                source_handle="source",
             ),
         }
 
@@ -144,19 +165,34 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="level1_a", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="level1_a",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="root2", head="level1_b", source_handle="source"
+                id="edge2",
+                tail="root2",
+                head="level1_b",
+                source_handle="source",
             ),
             "edge3": Edge(
-                id="edge3", tail="level1_a", head="level2_a", source_handle="source"
+                id="edge3",
+                tail="level1_a",
+                head="level2_a",
+                source_handle="source",
             ),
             "edge4": Edge(
-                id="edge4", tail="level1_b", head="level2_b", source_handle="source"
+                id="edge4",
+                tail="level1_b",
+                head="level2_b",
+                source_handle="source",
             ),
             "edge5": Edge(
-                id="edge5", tail="level2_b", head="level3", source_handle="source"
+                id="edge5",
+                tail="level2_b",
+                head="level3",
+                source_handle="source",
             ),
         }
 
@@ -200,10 +236,16 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="child1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="child1",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="non_root", head="child2", source_handle="source"
+                id="edge2",
+                tail="non_root",
+                head="child2",
+                source_handle="source",
             ),
         }
 
@@ -234,13 +276,22 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="child1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="child1",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="root2", head="child2", source_handle="source"
+                id="edge2",
+                tail="root2",
+                head="child2",
+                source_handle="source",
             ),
             "edge3": Edge(
-                id="edge3", tail="root3", head="child3", source_handle="source"
+                id="edge3",
+                tail="root3",
+                head="child3",
+                source_handle="source",
             ),
         }
 
@@ -279,19 +330,34 @@ class TestMarkInactiveRootBranches:
 
         edges = {
             "edge1": Edge(
-                id="edge1", tail="root1", head="mid1", source_handle="source"
+                id="edge1",
+                tail="root1",
+                head="mid1",
+                source_handle="source",
             ),
             "edge2": Edge(
-                id="edge2", tail="root2", head="mid2", source_handle="source"
+                id="edge2",
+                tail="root2",
+                head="mid2",
+                source_handle="source",
             ),
             "edge3": Edge(
-                id="edge3", tail="root3", head="convergent", source_handle="source"
+                id="edge3",
+                tail="root3",
+                head="convergent",
+                source_handle="source",
             ),
             "edge4": Edge(
-                id="edge4", tail="mid1", head="convergent", source_handle="source"
+                id="edge4",
+                tail="mid1",
+                head="convergent",
+                source_handle="source",
             ),
             "edge5": Edge(
-                id="edge5", tail="mid2", head="convergent", source_handle="source"
+                id="edge5",
+                tail="mid2",
+                head="convergent",
+                source_handle="source",
             ),
         }
 

--- a/tests/graph/test_graph_validation.py
+++ b/tests/graph/test_graph_validation.py
@@ -34,13 +34,13 @@ class _TestNode(Node[_TestNodeData]):
     def __init__(
         self,
         *,
-        id: str,
+        node_id: str,
         config: Mapping[str, object],
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
         super().__init__(
-            id=id,
+            node_id=node_id,
             config=config,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
@@ -50,7 +50,7 @@ class _TestNode(Node[_TestNodeData]):
         if isinstance(node_type_value, str):
             self.node_type = node_type_value
 
-    def _run(self):
+    def _run(self) -> None:
         raise NotImplementedError
 
     def post_init(self) -> None:
@@ -76,7 +76,7 @@ class _SimpleNodeFactory:
     def create_node(self, node_config: Mapping[str, object]) -> _TestNode:
         node_id = str(node_config["id"])
         return _TestNode(
-            id=node_id,
+            node_id=node_id,
             config=node_config,
             graph_init_params=self.graph_init_params,
             graph_runtime_state=self.graph_runtime_state,
@@ -91,10 +91,12 @@ def graph_init_dependencies() -> tuple[_SimpleNodeFactory, dict[str, object]]:
         graph_config=graph_config,
     )
     runtime_state = GraphRuntimeState(
-        variable_pool=VariablePool(), start_at=time.perf_counter()
+        variable_pool=VariablePool(),
+        start_at=time.perf_counter(),
     )
     factory = _SimpleNodeFactory(
-        graph_init_params=init_params, graph_runtime_state=runtime_state
+        graph_init_params=init_params,
+        graph_runtime_state=runtime_state,
     )
     return factory, graph_config
 
@@ -119,7 +121,9 @@ def test_graph_initialization_runs_default_validators(
     ]
 
     graph = Graph.init(
-        graph_config=graph_config, node_factory=node_factory, root_node_id="start"
+        graph_config=graph_config,
+        node_factory=node_factory,
+        root_node_id="start",
     )
 
     assert graph.root_node.id == "start"
@@ -146,7 +150,9 @@ def test_graph_validation_fails_for_unknown_edge_targets(
 
     with pytest.raises(GraphValidationError) as exc:
         Graph.init(
-            graph_config=graph_config, node_factory=node_factory, root_node_id="start"
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
         )
 
     assert any(issue.code == "MISSING_NODE" for issue in exc.value.issues)
@@ -179,7 +185,9 @@ def test_graph_promotes_fail_branch_nodes_to_branch_execution_type(
     ]
 
     graph = Graph.init(
-        graph_config=graph_config, node_factory=node_factory, root_node_id="start"
+        graph_config=graph_config,
+        node_factory=node_factory,
+        root_node_id="start",
     )
 
     assert graph.nodes["branch"].execution_type == NodeExecutionType.BRANCH
@@ -216,7 +224,9 @@ def test_graph_init_ignores_custom_note_nodes_before_node_data_validation(
     ]
 
     graph = Graph.init(
-        graph_config=graph_config, node_factory=node_factory, root_node_id="start"
+        graph_config=graph_config,
+        node_factory=node_factory,
+        root_node_id="start",
     )
 
     assert graph.root_node.id == "start"
@@ -242,5 +252,7 @@ def test_graph_init_fails_for_unknown_root_node_id(
 
     with pytest.raises(ValueError, match="Root node id missing not found in the graph"):
         Graph.init(
-            graph_config=graph_config, node_factory=node_factory, root_node_id="missing"
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="missing",
         )

--- a/tests/graph_engine/graph_traversal/test_skip_propagator.py
+++ b/tests/graph_engine/graph_traversal/test_skip_propagator.py
@@ -152,7 +152,7 @@ class TestSkipPropagator:
 
         mock_graph.edges = {"edge_1": edge1, "edge_3": edge3}
 
-        def get_incoming_edges_side_effect(node_id):
+        def get_incoming_edges_side_effect(node_id: str) -> list[Edge]:
             if node_id == "node_2":
                 return [edge1]
             if node_id == "node_4":
@@ -161,7 +161,7 @@ class TestSkipPropagator:
 
         mock_graph.get_incoming_edges.side_effect = get_incoming_edges_side_effect
 
-        def get_outgoing_edges_side_effect(node_id):
+        def get_outgoing_edges_side_effect(node_id: str) -> list[Edge]:
             if node_id == "node_2":
                 return [edge3]
             if node_id == "node_4":

--- a/tests/graph_engine/test_dispatch_patterns.py
+++ b/tests/graph_engine/test_dispatch_patterns.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime
+from time import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.enums import BuiltinNodeTypes
+from graphon.graph_engine.command_channels.redis_channel import RedisChannel
+from graphon.graph_engine.entities.commands import (
+    AbortCommand,
+    CommandType,
+    PauseCommand,
+    UpdateVariablesCommand,
+)
+from graphon.graph_engine.layers.execution_limits import (
+    ExecutionLimitsLayer,
+    LimitType,
+)
+from graphon.graph_engine.ready_queue.factory import create_ready_queue_from_state
+from graphon.graph_engine.ready_queue.protocol import ReadyQueueState
+from graphon.graph_events.node import NodeRunStartedEvent
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_command_type"),
+    [
+        (
+            {"command_type": CommandType.ABORT.value, "reason": "stop"},
+            AbortCommand,
+        ),
+        (
+            {"command_type": CommandType.PAUSE.value, "reason": "wait"},
+            PauseCommand,
+        ),
+        (
+            {"command_type": CommandType.UPDATE_VARIABLES.value, "updates": []},
+            UpdateVariablesCommand,
+        ),
+    ],
+)
+def test_redis_channel_deserializes_command_with_model_map(
+    payload: dict[str, object],
+    expected_command_type: type,
+) -> None:
+    channel = RedisChannel(redis_client=MagicMock(), channel_key="test-channel")
+
+    command = channel._deserialize_command(payload)
+
+    assert isinstance(command, expected_command_type)
+
+
+def test_create_ready_queue_from_state_restores_queue_items() -> None:
+    queue = create_ready_queue_from_state(
+        ReadyQueueState(type="InMemoryReadyQueue", version="1.0", items=["a", "b"]),
+    )
+
+    assert queue.get(timeout=0.01) == "a"
+    assert queue.get(timeout=0.01) == "b"
+
+
+@pytest.mark.parametrize(
+    ("limit_type", "expected_reason"),
+    [
+        (LimitType.STEP_LIMIT, "Maximum execution steps exceeded: 4 > 3"),
+        (LimitType.TIME_LIMIT, "Maximum execution time exceeded:"),
+    ],
+)
+def test_execution_limits_layer_builds_abort_reason_with_match_case(
+    limit_type: LimitType,
+    expected_reason: str,
+) -> None:
+    layer = ExecutionLimitsLayer(max_steps=3, max_time=10)
+    layer.command_channel = MagicMock()
+    layer._execution_started = True
+    layer.step_count = 4
+    layer.start_time = time() - 20
+
+    layer._send_abort_command(limit_type)
+
+    abort_command = layer.command_channel.send_command.call_args.args[0]
+    assert isinstance(abort_command, AbortCommand)
+    assert abort_command.reason is not None
+    assert abort_command.reason.startswith(expected_reason)
+
+
+def test_execution_limits_layer_matches_subclassed_node_start_event() -> None:
+    class CustomNodeRunStartedEvent(NodeRunStartedEvent):
+        pass
+
+    layer = ExecutionLimitsLayer(max_steps=3, max_time=10)
+    layer.on_graph_start()
+
+    layer.on_event(
+        CustomNodeRunStartedEvent(
+            id="node-run-1",
+            node_id="node-1",
+            node_type=BuiltinNodeTypes.CODE,
+            node_title="Code",
+            start_at=datetime.now(UTC).replace(tzinfo=None),
+        ),
+    )
+
+    assert layer.step_count == 1

--- a/tests/helpers/builders.py
+++ b/tests/helpers/builders.py
@@ -18,7 +18,7 @@ def build_file_reference(*, record_id: str, storage_key: str | None = None) -> s
         payload["storage_key"] = storage_key
 
     encoded_payload = base64.urlsafe_b64encode(
-        json.dumps(payload, separators=(",", ":")).encode()
+        json.dumps(payload, separators=(",", ":")).encode(),
     ).decode()
     return f"{_FILE_REFERENCE_PREFIX}{encoded_payload}"
 

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pytest_mock import MockerFixture
 
 from graphon.http import (
     HttpClientMaxRetriesExceededError,
@@ -56,7 +57,9 @@ def _build_runtime_state() -> GraphRuntimeState:
     )
 
 
-def test_httpx_http_client_normalizes_request_kwargs(mocker):
+def test_httpx_http_client_normalizes_request_kwargs(
+    mocker: MockerFixture,
+) -> None:
     request = httpx.Request("POST", "https://example.com")
     response = httpx.Response(200, request=request)
     request_mock = mocker.patch(
@@ -84,7 +87,7 @@ def test_httpx_http_client_normalizes_request_kwargs(mocker):
     assert kwargs["timeout"].write == 3
 
 
-def test_httpx_http_client_retries_until_success(mocker):
+def test_httpx_http_client_retries_until_success(mocker: MockerFixture) -> None:
     request = httpx.Request("GET", "https://example.com")
     request_mock = mocker.patch(
         "graphon.http.client.httpx.request",
@@ -108,7 +111,9 @@ def test_http_response_raise_for_status_uses_library_error():
         response.raise_for_status()
 
 
-def test_httpx_http_client_raises_max_retries_exceeded_after_last_retry(mocker):
+def test_httpx_http_client_raises_max_retries_exceeded_after_last_retry(
+    mocker: MockerFixture,
+) -> None:
     request = httpx.Request("GET", "https://example.com")
     request_mock = mocker.patch(
         "graphon.http.client.httpx.request",
@@ -124,7 +129,9 @@ def test_httpx_http_client_raises_max_retries_exceeded_after_last_retry(mocker):
     assert request_mock.call_count == 2
 
 
-def test_httpx_http_client_raises_request_error_without_retry_wrapping(mocker):
+def test_httpx_http_client_raises_request_error_without_retry_wrapping(
+    mocker: MockerFixture,
+) -> None:
     request = httpx.Request("GET", "https://example.com")
     mocker.patch(
         "graphon.http.client.httpx.request",
@@ -137,7 +144,7 @@ def test_httpx_http_client_raises_request_error_without_retry_wrapping(mocker):
 
 def test_http_request_node_uses_default_http_client_when_not_injected():
     node = HttpRequestNode(
-        id="http",
+        node_id="http",
         config={
             "id": "http",
             "data": {
@@ -152,7 +159,7 @@ def test_http_request_node_uses_default_http_client_when_not_injected():
             },
         },
         graph_init_params=build_graph_init_params(
-            graph_config={"nodes": [], "edges": []}
+            graph_config={"nodes": [], "edges": []},
         ),
         graph_runtime_state=_build_runtime_state(),
         http_request_config=build_http_request_config(),
@@ -166,7 +173,7 @@ def test_http_request_node_uses_default_http_client_when_not_injected():
 
 def test_document_extractor_node_uses_default_http_client_when_not_injected():
     node = DocumentExtractorNode(
-        id="extractor",
+        node_id="extractor",
         config={
             "id": "extractor",
             "data": {
@@ -176,7 +183,7 @@ def test_document_extractor_node_uses_default_http_client_when_not_injected():
             },
         },
         graph_init_params=build_graph_init_params(
-            graph_config={"nodes": [], "edges": []}
+            graph_config={"nodes": [], "edges": []},
         ),
         graph_runtime_state=_build_runtime_state(),
     )
@@ -203,7 +210,10 @@ def test_file_saver_impl_uses_default_http_client_when_not_injected():
         (QuestionClassifierNode.__init__, "http_client"),
     ],
 )
-def test_http_client_injection_is_optional(callable_obj, parameter_name):
+def test_http_client_injection_is_optional(
+    callable_obj: Any,
+    parameter_name: str,
+) -> None:
     parameter = inspect.signature(callable_obj).parameters[parameter_name]
 
     assert parameter.default is None

--- a/tests/model_runtime/slim/test_runtime.py
+++ b/tests/model_runtime/slim/test_runtime.py
@@ -23,7 +23,7 @@ from graphon.model_runtime.slim import (
 
 
 @pytest.fixture(autouse=True)
-def clear_slim_binary_path_env(monkeypatch) -> None:
+def clear_slim_binary_path_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SLIM_BINARY_PATH", raising=False)
 
 
@@ -38,7 +38,7 @@ def _write_fake_plugin(plugin_root: Path) -> None:
             plugins:
               models:
                 - provider/provider.yaml
-            """
+            """,
         ).strip()
         + "\n",
         encoding="utf-8",
@@ -78,7 +78,7 @@ def _write_fake_plugin(plugin_root: Path) -> None:
               llm:
                 predefined:
                   - models/llm/*.yaml
-            """
+            """,
         ).strip()
         + "\n",
         encoding="utf-8",
@@ -97,7 +97,7 @@ def _write_fake_plugin(plugin_root: Path) -> None:
             parameter_rules:
               - name: temperature
                 use_template: temperature
-            """
+            """,
         ).strip()
         + "\n",
         encoding="utf-8",
@@ -120,7 +120,7 @@ def _write_multi_provider_plugin(plugin_root: Path) -> None:
               models:
                 - provider/first.yaml
                 - provider/second.yaml
-            """
+            """,
         ).strip()
         + "\n",
         encoding="utf-8",
@@ -181,7 +181,7 @@ def _write_multi_provider_plugin(plugin_root: Path) -> None:
                   llm:
                     predefined:
                       - {model_file}
-                """
+                """,
             ).strip()
             + "\n",
             encoding="utf-8",
@@ -200,7 +200,7 @@ def _write_multi_provider_plugin(plugin_root: Path) -> None:
                 parameter_rules:
                   - name: temperature
                     use_template: temperature
-                """
+                """,
             ).strip()
             + "\n",
             encoding="utf-8",
@@ -372,7 +372,7 @@ def _write_fake_slim(binary_path: Path) -> None:
             else:
                 emit("error", {"code": "UNKNOWN_ACTION", "message": action})
                 sys.exit(1)
-            """
+            """,
         ),
         encoding="utf-8",
     )
@@ -389,18 +389,17 @@ def _build_runtime(tmp_path: Path) -> SlimRuntime:
         "graphon.model_runtime.slim.runtime.shutil.which",
         return_value=str(binary_path),
     ):
-        runtime = SlimRuntime(
+        return SlimRuntime(
             SlimConfig(
                 bindings=[
                     SlimProviderBinding(
                         plugin_id="author/fake:0.0.1@test",
                         plugin_root=plugin_root,
-                    )
+                    ),
                 ],
                 local=SlimLocalSettings(folder=tmp_path / "plugins"),
-            )
+            ),
         )
-    return runtime
 
 
 def test_slim_runtime_loads_provider_schema_and_icon(tmp_path: Path) -> None:
@@ -411,7 +410,7 @@ def test_slim_runtime_loads_provider_schema_and_icon(tmp_path: Path) -> None:
     assert len(providers) == 1
     provider = providers[0]
     assert provider.provider == "fake-provider"
-    assert provider.label.en_US == "Fake Provider"
+    assert provider.label.en_us == "Fake Provider"
     assert provider.models[0].model == "fake-chat"
 
     icon_bytes, extension = runtime.get_provider_icon(
@@ -477,10 +476,10 @@ def test_slim_package_loader_selects_requested_provider(tmp_path: Path) -> None:
                         plugin_id="author/fake:0.0.1@test",
                         provider="other-provider",
                         plugin_root=plugin_root,
-                    )
+                    ),
                 ],
                 local=SlimLocalSettings(folder=tmp_path / "plugins"),
-            )
+            ),
         )
 
     providers = runtime.fetch_model_providers()
@@ -500,7 +499,7 @@ def test_slim_runtime_invokes_tts_without_tenant_context(tmp_path: Path) -> None
             credentials={"api_key": "secret"},
             content_text="Hello",
             voice="nova",
-        )
+        ),
     )
 
     assert result == b"hi"
@@ -520,7 +519,7 @@ def test_slim_runtime_merges_non_stream_tool_call_deltas(tmp_path: Path) -> None
                 name="extract",
                 description="Extract fields",
                 parameters={},
-            )
+            ),
         ],
         stop=None,
         stream=False,
@@ -554,7 +553,7 @@ def test_slim_runtime_keeps_blocking_structured_output(tmp_path: Path) -> None:
 
 
 def test_slim_config_auto_discovers_uv_and_python(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
@@ -573,23 +572,28 @@ def test_slim_config_auto_discovers_uv_and_python(
 
 
 def test_slim_runtime_panics_when_binary_is_missing(
-    caplog,
+    caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
 ) -> None:
-    with patch("graphon.model_runtime.slim.runtime.shutil.which", return_value=None):
-        with pytest.raises(
+    with (
+        patch(
+            "graphon.model_runtime.slim.runtime.shutil.which",
+            return_value=None,
+        ),
+        pytest.raises(
             RuntimeError,
             match=(
                 r"dify-plugin-daemon-slim is not available in PATH\. "
                 r"Set SLIM_BINARY_PATH to override it\."
             ),
-        ):
-            SlimRuntime(
-                SlimConfig(
-                    bindings=[SlimProviderBinding(plugin_id="author/fake:0.0.1@test")],
-                    local=SlimLocalSettings(folder=tmp_path / "plugins"),
-                )
-            )
+        ),
+    ):
+        SlimRuntime(
+            SlimConfig(
+                bindings=[SlimProviderBinding(plugin_id="author/fake:0.0.1@test")],
+                local=SlimLocalSettings(folder=tmp_path / "plugins"),
+            ),
+        )
 
     assert (
         "dify-plugin-daemon-slim is not available in PATH. "
@@ -598,7 +602,7 @@ def test_slim_runtime_panics_when_binary_is_missing(
 
 
 def test_slim_runtime_uses_slim_binary_path_env(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     custom_binary = tmp_path / "custom-slim"
@@ -612,14 +616,14 @@ def test_slim_runtime_uses_slim_binary_path_env(
             SlimConfig(
                 bindings=[SlimProviderBinding(plugin_id="author/fake:0.0.1@test")],
                 local=SlimLocalSettings(folder=tmp_path / "plugins"),
-            )
+            ),
         )
 
     assert runtime._binary_path == str(custom_binary)  # pyright: ignore[reportPrivateUsage]
 
 
 def test_slim_runtime_rejects_invalid_slim_binary_path_env(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     missing_binary = tmp_path / "missing-slim"
@@ -633,5 +637,5 @@ def test_slim_runtime_rejects_invalid_slim_binary_path_env(
             SlimConfig(
                 bindings=[SlimProviderBinding(plugin_id="author/fake:0.0.1@test")],
                 local=SlimLocalSettings(folder=tmp_path / "plugins"),
-            )
+            ),
         )

--- a/tests/model_runtime/test_common_entities.py
+++ b/tests/model_runtime/test_common_entities.py
@@ -1,0 +1,16 @@
+from graphon.model_runtime.entities.common_entities import I18nObject
+from graphon.model_runtime.utils.encoders import jsonable_encoder
+
+
+def test_i18n_object_accepts_alias_keys_and_fills_missing_zh_hans():
+    i18n = I18nObject.model_validate({"en_US": "Temperature"})
+
+    assert i18n.en_us == "Temperature"
+    assert i18n.zh_hans == "Temperature"
+
+
+def test_i18n_object_serializes_with_locale_aliases():
+    i18n = I18nObject(en_us="Temperature", zh_hans="温度")
+
+    assert i18n.model_dump() == {"zh_Hans": "温度", "en_US": "Temperature"}
+    assert jsonable_encoder(i18n) == {"zh_Hans": "温度", "en_US": "Temperature"}

--- a/tests/model_runtime/test_encoders.py
+++ b/tests/model_runtime/test_encoders.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 from collections import deque
+from collections.abc import Iterator
 from decimal import Decimal
 from enum import Enum
 from ipaddress import (
@@ -12,7 +13,7 @@ from ipaddress import (
     IPv6Network,
 )
 from pathlib import Path, PurePath
-from re import compile
+from re import compile as re_compile
 from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -25,11 +26,11 @@ from pydantic_core import Url
 from pydantic_extra_types.color import Color
 
 from graphon.model_runtime.utils.encoders import (
-    _model_dump,
     decimal_encoder,
     generate_encoders_by_class_tuples,
     isoformat,
     jsonable_encoder,
+    model_dump,
 )
 
 
@@ -51,15 +52,15 @@ class MockDataclass:
 
 
 class MockWithDict:
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]) -> None:
         self.data = data
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         return iter(self.data.items())
 
 
 class MockWithVars:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -67,7 +68,7 @@ class MockWithVars:
 class TestEncoders:
     def test_model_dump(self):
         model = MockPydanticModel(name="test", age=20)
-        result = _model_dump(model)
+        result = model_dump(model)
         assert result == {"name": "test", "age": 20}
 
     def test_isoformat(self):
@@ -77,9 +78,9 @@ class TestEncoders:
         assert isoformat(t) == "12:00:00"
 
     def test_decimal_encoder(self):
-        assert decimal_encoder(Decimal("1.0")) == 1.0
+        assert decimal_encoder(Decimal("1.0")) == pytest.approx(1.0)
         assert decimal_encoder(Decimal(1)) == 1
-        assert decimal_encoder(Decimal("1.5")) == 1.5
+        assert decimal_encoder(Decimal("1.5")) == pytest.approx(1.5)
         assert decimal_encoder(Decimal(0)) == 0
         assert decimal_encoder(Decimal(-1)) == -1
 
@@ -92,7 +93,7 @@ class TestEncoders:
     def test_jsonable_encoder_basic_types(self):
         assert jsonable_encoder("string") == "string"
         assert jsonable_encoder(123) == 123
-        assert jsonable_encoder(1.23) == 1.23
+        assert jsonable_encoder(1.23) == pytest.approx(1.23)
         assert jsonable_encoder(None) is None
 
     def test_jsonable_encoder_pydantic(self):
@@ -107,7 +108,7 @@ class TestEncoders:
     def test_jsonable_encoder_dataclass(self):
         obj = MockDataclass(name="test", value=1)
         assert jsonable_encoder(obj) == {"name": "test", "value": 1}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="__dict__ attribute"):
             jsonable_encoder(MockDataclass)
 
     def test_jsonable_encoder_enum(self):
@@ -140,7 +141,7 @@ class TestEncoders:
         assert jsonable_encoder(frozenset([1, 2])) == [1, 2]
         assert jsonable_encoder(deque([1, 2])) == [1, 2]
 
-        def gen():
+        def gen() -> Iterator[int]:
             yield 1
             yield 2
 
@@ -159,7 +160,7 @@ class TestEncoders:
         assert jsonable_encoder(b"bytes") == "bytes"
         assert jsonable_encoder(Color("red")) == "red"
 
-        dt = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        dt = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
         assert jsonable_encoder(dt) == dt.isoformat()
 
         date = datetime.date(2023, 1, 1)
@@ -169,7 +170,7 @@ class TestEncoders:
         assert jsonable_encoder(time) == time.isoformat()
 
         td = datetime.timedelta(seconds=60)
-        assert jsonable_encoder(td) == 60.0
+        assert jsonable_encoder(td) == pytest.approx(60.0)
 
         assert jsonable_encoder(IPv4Address("127.0.0.1")) == "127.0.0.1"
         assert jsonable_encoder(IPv4Interface("127.0.0.1/24")) == "127.0.0.1/24"
@@ -183,7 +184,7 @@ class TestEncoders:
             == "test <test@example.com>"
         )
 
-        assert jsonable_encoder(compile(r"abc")) == "abc"
+        assert jsonable_encoder(re_compile(r"abc")) == "abc"
 
         res_bytes = jsonable_encoder(SecretBytes(b"secret"))
         assert "**********" in res_bytes
@@ -210,10 +211,11 @@ class TestEncoders:
         class ReallyUnserializable:
             __slots__ = ["__weakref__"]
 
-            def __iter__(self):
-                raise TypeError("not iterable")
+            def __iter__(self) -> Iterator[Any]:
+                msg = "not iterable"
+                raise TypeError(msg)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="not iterable") as exc:
             jsonable_encoder(ReallyUnserializable())
         assert "not iterable" in str(exc.value)
 

--- a/tests/model_runtime/test_large_language_model_non_stream_result.py
+++ b/tests/model_runtime/test_large_language_model_non_stream_result.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 from graphon.model_runtime.entities.llm_entities import (
     LLMResult,
     LLMResultChunk,
@@ -9,8 +11,8 @@ from graphon.model_runtime.entities.message_entities import (
     TextPromptMessageContent,
     UserPromptMessage,
 )
-from graphon.model_runtime.model_providers.__base.large_language_model import (
-    _normalize_non_stream_runtime_result,
+from graphon.model_runtime.model_providers.base.large_language_model import (
+    normalize_non_stream_runtime_result,
 )
 
 
@@ -25,7 +27,9 @@ def _make_chunk(
     message = AssistantPromptMessage(content=content, tool_calls=tool_calls or [])
     delta = LLMResultChunkDelta(index=0, message=message, usage=usage)
     return LLMResultChunk(
-        model=model, delta=delta, system_fingerprint=system_fingerprint
+        model=model,
+        delta=delta,
+        system_fingerprint=system_fingerprint,
     )
 
 
@@ -37,34 +41,42 @@ def test_non_stream_result_merges_first_chunk_content_and_tool_calls():
             id="1",
             type="function",
             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                name="func_foo", arguments=""
+                name="func_foo",
+                arguments="",
             ),
         ),
         AssistantPromptMessage.ToolCall(
             id="",
             type="function",
             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                name="", arguments='{"arg1": '
+                name="",
+                arguments='{"arg1": ',
             ),
         ),
         AssistantPromptMessage.ToolCall(
             id="",
             type="function",
             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                name="", arguments='"value"}'
+                name="",
+                arguments='"value"}',
             ),
         ),
     ]
 
     usage = LLMUsage.empty_usage().model_copy(
-        update={"prompt_tokens": 1, "total_tokens": 1}
+        update={"prompt_tokens": 1, "total_tokens": 1},
     )
     chunk = _make_chunk(
-        content="hello", tool_calls=tool_calls, usage=usage, system_fingerprint="fp-1"
+        content="hello",
+        tool_calls=tool_calls,
+        usage=usage,
+        system_fingerprint="fp-1",
     )
 
-    result = _normalize_non_stream_runtime_result(
-        model="test-model", prompt_messages=prompt_messages, result=iter([chunk])
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=iter([chunk]),
     )
 
     assert result.model == "test-model"
@@ -77,9 +89,10 @@ def test_non_stream_result_merges_first_chunk_content_and_tool_calls():
             id="1",
             type="function",
             function=AssistantPromptMessage.ToolCall.ToolCallFunction(
-                name="func_foo", arguments='{"arg1": "value"}'
+                name="func_foo",
+                arguments='{"arg1": "value"}',
             ),
-        )
+        ),
     ]
 
 
@@ -92,8 +105,10 @@ def test__normalize_non_stream_runtime_result__from_first_chunk_list_content():
     ]
     chunk = _make_chunk(content=content_list, usage=LLMUsage.empty_usage())
 
-    result = _normalize_non_stream_runtime_result(
-        model="test-model", prompt_messages=prompt_messages, result=iter([chunk])
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=iter([chunk]),
     )
 
     assert result.message.content == content_list
@@ -109,8 +124,10 @@ def test__normalize_non_stream_runtime_result__passthrough_llm_result():
     )
 
     assert (
-        _normalize_non_stream_runtime_result(
-            model="test-model", prompt_messages=prompt_messages, result=llm_result
+        normalize_non_stream_runtime_result(
+            model="test-model",
+            prompt_messages=prompt_messages,
+            result=llm_result,
         )
         == llm_result
     )
@@ -119,8 +136,10 @@ def test__normalize_non_stream_runtime_result__passthrough_llm_result():
 def test__normalize_non_stream_runtime_result__empty_iterator_defaults():
     prompt_messages = [UserPromptMessage(content="hi")]
 
-    result = _normalize_non_stream_runtime_result(
-        model="test-model", prompt_messages=prompt_messages, result=iter([])
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=iter([]),
     )
 
     assert result.model == "test-model"
@@ -136,14 +155,14 @@ def test__normalize_non_stream_runtime_result__accumulates_all_chunks():
 
     closed: list[bool] = []
 
-    def _chunk_iter():
+    def _chunk_iter() -> Iterator[LLMResultChunk]:
         try:
             yield _make_chunk(content="hello", usage=LLMUsage.empty_usage())
             yield _make_chunk(content=" world", usage=LLMUsage.empty_usage())
         finally:
             closed.append(True)
 
-    result = _normalize_non_stream_runtime_result(
+    result = normalize_non_stream_runtime_result(
         model="test-model",
         prompt_messages=prompt_messages,
         result=_chunk_iter(),

--- a/tests/model_runtime/test_large_language_model_tool_calls.py
+++ b/tests/model_runtime/test_large_language_model_tool_calls.py
@@ -1,10 +1,11 @@
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from graphon.model_runtime.entities.message_entities import AssistantPromptMessage
-from graphon.model_runtime.model_providers.__base.large_language_model import (
-    _increase_tool_call,
+from graphon.model_runtime.model_providers.base.large_language_model import (
+    merge_tool_call_deltas,
 )
 
 ToolCall = AssistantPromptMessage.ToolCall
@@ -31,7 +32,8 @@ EXPECTED_CASE_1 = [
         id="1",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_foo", arguments='{"arg1": "value"}'
+            name="func_foo",
+            arguments='{"arg1": "value"}',
         ),
     ),
 ]
@@ -73,14 +75,16 @@ EXPECTED_CASE_2 = [
         id="1",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_foo", arguments='{"arg1": "value"}'
+            name="func_foo",
+            arguments='{"arg1": "value"}',
         ),
     ),
     ToolCall(
         id="2",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_bar", arguments='{"arg2": "value"}'
+            name="func_bar",
+            arguments='{"arg2": "value"}',
         ),
     ),
 ]
@@ -122,14 +126,16 @@ EXPECTED_CASE_3 = [
         id="1",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_foo", arguments='{"arg1": "value"}'
+            name="func_foo",
+            arguments='{"arg1": "value"}',
         ),
     ),
     ToolCall(
         id="2",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_bar", arguments='{"arg2": "value"}'
+            name="func_bar",
+            arguments='{"arg2": "value"}',
         ),
     ),
 ]
@@ -171,40 +177,45 @@ EXPECTED_CASE_4 = [
         id="RANDOM_ID_1",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_foo", arguments='{"arg1": "value"}'
+            name="func_foo",
+            arguments='{"arg1": "value"}',
         ),
     ),
     ToolCall(
         id="RANDOM_ID_2",
         type="function",
         function=ToolCall.ToolCallFunction(
-            name="func_bar", arguments='{"arg2": "value"}'
+            name="func_bar",
+            arguments='{"arg2": "value"}',
         ),
     ),
 ]
 
 
-def _run_case(inputs: list[ToolCall], expected: list[ToolCall]):
+def _run_case(
+    inputs: list[ToolCall],
+    expected: list[ToolCall],
+    *,
+    id_generator: Any = None,
+) -> None:
     actual = []
-    _increase_tool_call(inputs, actual)
+    merge_tool_call_deltas(inputs, actual, id_generator=id_generator)
     assert actual == expected
 
 
-def test__increase_tool_call():
+def test__merge_tool_call_deltas():
     _run_case(INPUTS_CASE_1, EXPECTED_CASE_1)
     _run_case(INPUTS_CASE_2, EXPECTED_CASE_2)
     _run_case(INPUTS_CASE_3, EXPECTED_CASE_3)
 
     mock_id_generator = MagicMock()
-    mock_id_generator.side_effect = [_exp_case.id for _exp_case in EXPECTED_CASE_4]
-    with patch(
-        "graphon.model_runtime.model_providers.__base.large_language_model._gen_tool_call_id",
-        mock_id_generator,
-    ):
-        _run_case(INPUTS_CASE_4, EXPECTED_CASE_4)
+    mock_id_generator.side_effect = [
+        expected_case.id for expected_case in EXPECTED_CASE_4
+    ]
+    _run_case(INPUTS_CASE_4, EXPECTED_CASE_4, id_generator=mock_id_generator)
 
 
-def test__increase_tool_call__no_id_no_name_first_delta_should_raise():
+def test__merge_tool_call_deltas__no_id_no_name_first_delta_should_raise():
     inputs = [
         ToolCall(
             id="",
@@ -218,9 +229,8 @@ def test__increase_tool_call__no_id_no_name_first_delta_should_raise():
         ),
     ]
     actual: list[ToolCall] = []
-    with patch(
-        "graphon.model_runtime.model_providers.__base.large_language_model._gen_tool_call_id",
-        MagicMock(),
+    with pytest.raises(
+        ValueError,
+        match=r"no existing tool call is available to apply the delta",
     ):
-        with pytest.raises(ValueError):
-            _increase_tool_call(inputs, actual)
+        merge_tool_call_deltas(inputs, actual, id_generator=MagicMock())

--- a/tests/model_runtime/test_message_entities.py
+++ b/tests/model_runtime/test_message_entities.py
@@ -1,0 +1,33 @@
+from graphon.model_runtime.entities.message_entities import (
+    ImagePromptMessageContent,
+    TextPromptMessageContent,
+    UserPromptMessage,
+)
+
+
+def test_user_prompt_message_get_text_content_keeps_only_text_items() -> None:
+    message = UserPromptMessage(
+        content=[
+            TextPromptMessageContent(data="hello"),
+            ImagePromptMessageContent(
+                format="png",
+                mime_type="image/png",
+                url="https://example.com/image.png",
+            ),
+            TextPromptMessageContent(data=" world"),
+        ],
+    )
+
+    assert message.get_text_content() == "hello world"
+
+
+def test_prompt_message_normalizes_dict_content_items_for_serialization() -> None:
+    message = UserPromptMessage(
+        content=[{"type": "text", "data": "hello"}],
+    )
+
+    assert isinstance(message.content, list)
+    assert isinstance(message.content[0], TextPromptMessageContent)
+    assert message.model_dump(mode="json")["content"] == [
+        {"type": "text", "data": "hello"},
+    ]

--- a/tests/model_runtime/test_model_dispatch.py
+++ b/tests/model_runtime/test_model_dispatch.py
@@ -1,0 +1,94 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.model_runtime.entities.common_entities import I18nObject
+from graphon.model_runtime.entities.model_entities import ModelType
+from graphon.model_runtime.entities.provider_entities import ProviderEntity
+from graphon.model_runtime.model_providers.base.large_language_model import (
+    LargeLanguageModel,
+)
+from graphon.model_runtime.model_providers.base.moderation_model import (
+    ModerationModel,
+)
+from graphon.model_runtime.model_providers.base.rerank_model import RerankModel
+from graphon.model_runtime.model_providers.base.speech2text_model import (
+    Speech2TextModel,
+)
+from graphon.model_runtime.model_providers.base.text_embedding_model import (
+    TextEmbeddingModel,
+)
+from graphon.model_runtime.model_providers.base.tts_model import TTSModel
+from graphon.model_runtime.model_providers.model_provider_factory import (
+    ModelProviderFactory,
+)
+
+
+@pytest.mark.parametrize(
+    ("origin_model_type", "expected_model_type"),
+    [
+        ("text-generation", ModelType.LLM),
+        (ModelType.LLM.value, ModelType.LLM),
+        ("embeddings", ModelType.TEXT_EMBEDDING),
+        (ModelType.TEXT_EMBEDDING.value, ModelType.TEXT_EMBEDDING),
+        ("reranking", ModelType.RERANK),
+        ("speech2text", ModelType.SPEECH2TEXT),
+        ("moderation", ModelType.MODERATION),
+        ("tts", ModelType.TTS),
+    ],
+)
+def test_model_type_value_of_uses_model_map(
+    origin_model_type: str,
+    expected_model_type: ModelType,
+) -> None:
+    assert ModelType.value_of(origin_model_type) == expected_model_type
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_origin_model_type"),
+    [
+        (ModelType.LLM, "text-generation"),
+        (ModelType.TEXT_EMBEDDING, "embeddings"),
+        (ModelType.RERANK, "reranking"),
+        (ModelType.SPEECH2TEXT, "speech2text"),
+        (ModelType.MODERATION, "moderation"),
+        (ModelType.TTS, "tts"),
+    ],
+)
+def test_model_type_to_origin_model_type_uses_model_map(
+    model_type: ModelType,
+    expected_origin_model_type: str,
+) -> None:
+    assert model_type.to_origin_model_type() == expected_origin_model_type
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_model_class"),
+    [
+        (ModelType.LLM, LargeLanguageModel),
+        (ModelType.TEXT_EMBEDDING, TextEmbeddingModel),
+        (ModelType.RERANK, RerankModel),
+        (ModelType.SPEECH2TEXT, Speech2TextModel),
+        (ModelType.MODERATION, ModerationModel),
+        (ModelType.TTS, TTSModel),
+    ],
+)
+def test_model_provider_factory_uses_model_class_map(
+    model_type: ModelType,
+    expected_model_class: type,
+) -> None:
+    provider = ProviderEntity(
+        provider="test-provider",
+        label=I18nObject(en_us="Test Provider"),
+        supported_model_types=[model_type],
+        configurate_methods=[],
+    )
+    runtime = MagicMock()
+    runtime.fetch_model_providers.return_value = [provider]
+    factory = ModelProviderFactory(model_runtime=runtime)
+
+    model = factory.get_model_type_instance("test-provider", model_type)
+
+    assert isinstance(model, expected_model_class)
+    assert model.provider_schema is provider
+    assert model.model_runtime is runtime

--- a/tests/model_runtime/test_text_embedding_model.py
+++ b/tests/model_runtime/test_text_embedding_model.py
@@ -1,0 +1,17 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.model_runtime.model_providers.base.text_embedding_model import (
+    TextEmbeddingModel,
+)
+
+
+def test_text_embedding_model_invoke_requires_texts_or_documents() -> None:
+    model = TextEmbeddingModel(
+        provider_schema=MagicMock(provider="provider"),
+        model_runtime=MagicMock(),
+    )
+
+    with pytest.raises(ValueError, match="No texts or files provided"):
+        model.invoke(model="embedding-model", credentials={})

--- a/tests/node_events/test_node_event_aliases.py
+++ b/tests/node_events/test_node_event_aliases.py
@@ -13,7 +13,7 @@ def test_variable_alias_still_validates_in_event_models() -> None:
             "value": "hello",
             "name": "greeting",
             "selector": ["start", "greeting"],
-        }
+        },
     }
 
     node_event = VariableUpdatedEvent.model_validate(payload)

--- a/tests/node_events/test_node_run_result.py
+++ b/tests/node_events/test_node_run_result.py
@@ -9,7 +9,7 @@ def test_node_run_result_accepts_trigger_info_metadata() -> None:
             WorkflowNodeExecutionMetadataKey.TRIGGER_INFO: {
                 "provider_id": "provider-id",
                 "event_name": "event-name",
-            }
+            },
         },
     )
 

--- a/tests/nodes/base/test_variable_template_parser.py
+++ b/tests/nodes/base/test_variable_template_parser.py
@@ -17,7 +17,8 @@ def test_extract_selectors_from_template():
             value_selector=["node_id", "custom_query"],
         ),
         VariableSelector(
-            variable="#env.secret_key#", value_selector=["env", "secret_key"]
+            variable="#env.secret_key#",
+            value_selector=["env", "secret_key"],
         ),
     ]
 
@@ -37,7 +38,7 @@ def test_invalid_references():
     for idx, case in enumerate(cases, 1):
         fail_msg = f"Test case {case.name} failed, index={idx}"
         selectors = variable_template_parser.extract_selectors_from_template(
-            case.template
+            case.template,
         )
         assert selectors == [], fail_msg
         parser = variable_template_parser.VariableTemplateParser(case.template)

--- a/tests/nodes/document_extractor/test_docx_extraction.py
+++ b/tests/nodes/document_extractor/test_docx_extraction.py
@@ -1,0 +1,39 @@
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from docx import Document
+
+from graphon.file.enums import FileTransferMethod, FileType
+from graphon.nodes.document_extractor import node as document_extractor_node
+from graphon.nodes.document_extractor.exc import FileDownloadError
+
+
+def test_extract_text_from_docx_keeps_paragraph_and_table_order() -> None:
+    document = Document()
+    document.add_paragraph("Intro")
+    table = document.add_table(rows=2, cols=2)
+    table.rows[0].cells[0].text = "Name"
+    table.rows[0].cells[1].text = "Value"
+    table.rows[1].cells[0].text = "Color"
+    table.rows[1].cells[1].text = "Blue"
+    document.add_paragraph("Outro")
+
+    buffer = io.BytesIO()
+    document.save(buffer)
+
+    extracted = document_extractor_node._extract_text_from_docx(buffer.getvalue())
+
+    assert extracted == (
+        "Intro\n| Name | Value |\n| --- | --- |\n| Color | Blue |\n\nOutro"
+    )
+
+
+def test_download_file_content_requires_remote_url() -> None:
+    file = MagicMock()
+    file.transfer_method = FileTransferMethod.REMOTE_URL
+    file.remote_url = None
+    file.type = FileType.DOCUMENT
+
+    with pytest.raises(FileDownloadError, match="Missing URL for remote file"):
+        document_extractor_node._download_file_content(MagicMock(), file)

--- a/tests/nodes/http_request/test_dispatch.py
+++ b/tests/nodes/http_request/test_dispatch.py
@@ -1,0 +1,219 @@
+from unittest.mock import MagicMock
+
+from graphon.nodes.http_request.entities import (
+    HttpRequestNodeConfig,
+    HttpRequestNodeData,
+    HttpRequestNodeTimeout,
+)
+from graphon.nodes.http_request.executor import Executor
+from graphon.nodes.http_request.node import HttpRequestNode
+from tests.helpers.builders import build_variable_pool
+
+
+def _build_http_request_config() -> HttpRequestNodeConfig:
+    return HttpRequestNodeConfig(
+        max_connect_timeout=10,
+        max_read_timeout=10,
+        max_write_timeout=10,
+        max_binary_size=1024 * 1024,
+        max_text_size=1024 * 1024,
+        ssl_verify=True,
+        ssrf_default_max_retries=0,
+    )
+
+
+def test_http_request_node_extracts_variable_selectors_from_form_data() -> None:
+    node_data = HttpRequestNodeData(
+        method="post",
+        url="https://example.com/{{#start.id#}}",
+        authorization={"type": "no-auth"},
+        headers="X-Trace: {{#sys.trace#}}",
+        params="q: {{#input.query#}}",
+        body={
+            "type": "form-data",
+            "data": [
+                {
+                    "key": "name",
+                    "type": "text",
+                    "value": "{{#input.name#}}",
+                },
+                {
+                    "key": "file",
+                    "type": "file",
+                    "file": ["input", "file"],
+                },
+            ],
+        },
+    )
+
+    mapping = HttpRequestNode._extract_variable_selector_to_variable_mapping(
+        graph_config={},
+        node_id="node-1",
+        node_data=node_data,
+    )
+
+    assert mapping == {
+        "node-1.#start.id#": ["start", "id"],
+        "node-1.#sys.trace#": ["sys", "trace"],
+        "node-1.#input.query#": ["input", "query"],
+        "node-1.#input.name#": ["input", "name"],
+        "node-1.#input.file#": ["input", "file"],
+    }
+
+
+def test_executor_initializes_json_body_with_body_handler_map() -> None:
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            method="post",
+            url="https://example.com",
+            authorization={"type": "no-auth"},
+            headers="",
+            params="",
+            body={
+                "type": "json",
+                "data": [
+                    {
+                        "type": "text",
+                        "value": '{"answer": 1}',
+                    },
+                ],
+            },
+        ),
+        timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
+        variable_pool=build_variable_pool(),
+        http_request_config=_build_http_request_config(),
+        http_client=MagicMock(),
+        file_manager=MagicMock(),
+    )
+
+    assert executor.json == {"answer": 1}
+
+
+def test_executor_initializes_form_data_placeholder_when_no_files_resolve() -> None:
+    file_manager = MagicMock()
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            method="post",
+            url="https://example.com",
+            authorization={"type": "no-auth"},
+            headers="",
+            params="",
+            body={
+                "type": "form-data",
+                "data": [
+                    {"key": "note", "type": "text", "value": "hello"},
+                    {
+                        "key": "upload",
+                        "type": "file",
+                        "file": ["missing", "file"],
+                    },
+                ],
+            },
+        ),
+        timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
+        variable_pool=build_variable_pool(),
+        http_request_config=_build_http_request_config(),
+        http_client=MagicMock(),
+        file_manager=file_manager,
+    )
+
+    assert executor.data == {"note": "hello"}
+    assert executor.files == [
+        ("__multipart_placeholder__", ("", b"", "application/octet-stream")),
+    ]
+    file_manager.download.assert_not_called()
+
+
+def test_executor_assembling_headers_applies_bearer_auth_and_content_type() -> None:
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            method="post",
+            url="https://example.com",
+            authorization={
+                "type": "api-key",
+                "config": {
+                    "type": "bearer",
+                    "api_key": "secret-token",
+                },
+            },
+            headers="X-Test: 1",
+            params="",
+            body={
+                "type": "raw-text",
+                "data": [{"type": "text", "value": "payload"}],
+            },
+        ),
+        timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
+        variable_pool=build_variable_pool(),
+        http_request_config=_build_http_request_config(),
+        http_client=MagicMock(),
+        file_manager=MagicMock(),
+    )
+
+    headers = executor._assembling_headers()
+
+    assert headers["Authorization"] == "Bearer secret-token"
+    assert headers["Content-Type"] == "text/plain"
+    assert headers["X-Test"] == "1"
+
+
+def test_executor_to_log_masks_authorization_and_logs_raw_text_body() -> None:
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            method="post",
+            url="https://example.com/api?debug=1",
+            authorization={
+                "type": "api-key",
+                "config": {
+                    "type": "bearer",
+                    "api_key": "secret-token",
+                },
+            },
+            headers="X-Test: 1",
+            params="",
+            body={
+                "type": "raw-text",
+                "data": [{"type": "text", "value": "payload"}],
+            },
+        ),
+        timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
+        variable_pool=build_variable_pool(),
+        http_request_config=_build_http_request_config(),
+        http_client=MagicMock(),
+        file_manager=MagicMock(),
+    )
+
+    raw = executor.to_log()
+
+    assert raw.startswith("POST /api?debug=1 HTTP/1.1\r\n")
+    assert "Authorization: *******************" in raw
+    assert "X-Test: 1" in raw
+    assert raw.endswith("\r\npayload")
+
+
+def test_executor_to_log_renders_file_entries_for_multipart_body() -> None:
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            method="post",
+            url="https://example.com/upload",
+            authorization={"type": "no-auth"},
+            headers="",
+            params="",
+            body={
+                "type": "form-data",
+                "data": [{"key": "note", "type": "text", "value": "hello"}],
+            },
+        ),
+        timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
+        variable_pool=build_variable_pool(),
+        http_request_config=_build_http_request_config(),
+        http_client=MagicMock(),
+        file_manager=MagicMock(),
+    )
+    executor.files = [("upload", ("photo.png", b"abc", "image/png"))]
+
+    raw = executor.to_log()
+
+    assert "Content-Type: multipart/form-data; boundary=" in raw
+    assert 'Content-Disposition: form-data; name="upload"' in raw
+    assert "<file_content_binary: 'photo.png', type='image/png', size=3 bytes>" in raw

--- a/tests/nodes/parameter_extractor/test_entities.py
+++ b/tests/nodes/parameter_extractor/test_entities.py
@@ -1,0 +1,151 @@
+from graphon.model_runtime.entities.llm_entities import LLMMode
+from graphon.nodes.parameter_extractor.entities import (
+    ParameterConfig,
+    ParameterExtractorNodeData,
+)
+from graphon.nodes.parameter_extractor.parameter_extractor_node import (
+    ParameterExtractorNode,
+)
+from graphon.variables.types import SegmentType
+
+
+def test_parameter_config_maps_legacy_types() -> None:
+    assert (
+        ParameterConfig(
+            name="flag",
+            type="bool",
+            description="legacy bool",
+            required=True,
+        ).type
+        == SegmentType.BOOLEAN
+    )
+    assert (
+        ParameterConfig(
+            name="choice",
+            type="select",
+            description="legacy select",
+            required=False,
+        ).type
+        == SegmentType.STRING
+    )
+
+
+def test_parameter_extractor_node_data_builds_parameter_json_schema() -> None:
+    node_data = ParameterExtractorNodeData(
+        model={"provider": "test", "name": "model", "mode": LLMMode.CHAT},
+        query=["start", "query"],
+        parameters=[
+            {
+                "name": "location",
+                "type": "string",
+                "description": "Target location",
+                "required": True,
+            },
+            {
+                "name": "tags",
+                "type": "array[string]",
+                "description": "Selected tags",
+                "required": False,
+                "options": ["a", "b"],
+            },
+        ],
+        reasoning_mode="function_call",
+    )
+
+    assert node_data.get_parameter_json_schema() == {
+        "type": "object",
+        "properties": {
+            "location": {
+                "description": "Target location",
+                "type": "string",
+            },
+            "tags": {
+                "description": "Selected tags",
+                "type": "array",
+                "items": {"type": "string"},
+                "enum": ["a", "b"],
+            },
+        },
+        "required": ["location"],
+    }
+
+
+def test_parameter_extractor_transform_result_uses_type_dispatch() -> None:
+    node = ParameterExtractorNode.__new__(ParameterExtractorNode)
+    node_data = ParameterExtractorNodeData(
+        model={"provider": "test", "name": "model", "mode": LLMMode.CHAT},
+        query=["start", "query"],
+        parameters=[
+            {
+                "name": "age",
+                "type": "number",
+                "description": "Age",
+                "required": True,
+            },
+            {
+                "name": "enabled",
+                "type": "boolean",
+                "description": "Enabled",
+                "required": False,
+            },
+            {
+                "name": "name",
+                "type": "string",
+                "description": "Name",
+                "required": False,
+            },
+            {
+                "name": "scores",
+                "type": "array[number]",
+                "description": "Scores",
+                "required": False,
+            },
+            {
+                "name": "tags",
+                "type": "array[string]",
+                "description": "Tags",
+                "required": False,
+            },
+            {
+                "name": "payloads",
+                "type": "array[object]",
+                "description": "Payloads",
+                "required": False,
+            },
+            {
+                "name": "flags",
+                "type": "array[boolean]",
+                "description": "Flags",
+                "required": False,
+            },
+            {
+                "name": "missing_text",
+                "type": "string",
+                "description": "Missing text",
+                "required": False,
+            },
+        ],
+        reasoning_mode="function_call",
+    )
+
+    transformed = node._transform_result(
+        node_data,
+        {
+            "age": "3",
+            "enabled": 1,
+            "name": "Alice",
+            "scores": ["1", "x", 2.5],
+            "tags": ["a", 2, "b"],
+            "payloads": [{"ok": True}, "skip"],
+            "flags": [True, 1, False],
+        },
+    )
+
+    assert transformed["age"] == 3
+    assert transformed["enabled"] is True
+    assert transformed["name"] == "Alice"
+    assert transformed["scores"].value == [1, 2.5]
+    assert transformed["tags"].value == ["a", "b"]
+    assert transformed["payloads"].value == [{"ok": True}]
+    assert transformed["flags"].value == [True, False]
+    assert not transformed["missing_text"]

--- a/tests/nodes/parameter_extractor/test_prompts.py
+++ b/tests/nodes/parameter_extractor/test_prompts.py
@@ -23,11 +23,12 @@ from ...helpers import build_graph_init_params, build_variable_pool
 def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, object]:
     variable_pool = build_variable_pool(variables=[(("start", "rule"), "strictly")])
     runtime_state = GraphRuntimeState(
-        variable_pool=variable_pool, start_at=time.perf_counter()
+        variable_pool=variable_pool,
+        start_at=time.perf_counter(),
     )
     init_params = build_graph_init_params(graph_config={"nodes": [], "edges": []})
     node = ParameterExtractorNode(
-        id="extractor",
+        node_id="extractor",
         config={
             "id": "extractor",
             "data": {
@@ -45,7 +46,7 @@ def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, object]:
                         "type": "string",
                         "description": "The target location",
                         "required": True,
-                    }
+                    },
                 ],
                 "instruction": "Follow {{#start.rule#}} instructions.",
                 "reasoning_mode": "function_call",
@@ -66,7 +67,7 @@ def test_function_calling_system_prompt_formats_without_missing_placeholders():
     )
 
     assert FUNCTION_CALLING_EXTRACTOR_NAME in rendered
-    assert "{FUNCTION_CALLING_EXTRACTOR_NAME}" not in rendered
+    assert "{FUNCTION_CALLING_EXTRACTOR_NAME}" not in rendered  # noqa: RUF027
     assert "`extract_parameter`" not in rendered
     assert "previous messages" in rendered
     assert "Follow the schema." in rendered
@@ -80,14 +81,18 @@ def test_parameter_extractor_runtime_prompts_format_with_expected_arguments():
 
     rendered_prompts = [
         FUNCTION_CALLING_EXTRACTOR_USER_TEMPLATE.format(
-            content=input_text, structure=structure
+            content=input_text,
+            structure=structure,
         ),
         CHAT_GENERATE_JSON_USER_MESSAGE_TEMPLATE.format(
-            structure=structure, text=input_text
+            structure=structure,
+            text=input_text,
         ),
         CHAT_GENERATE_JSON_PROMPT.format(histories=histories, instruction=instruction),
         COMPLETION_GENERATE_JSON_PROMPT.format(
-            histories=histories, text=input_text, instruction=instruction
+            histories=histories,
+            text=input_text,
+            instruction=instruction,
         ),
     ]
 
@@ -116,7 +121,7 @@ def test_function_calling_prompt_template_renders_system_message():
     assert len(prompt_messages) == 2
     assert prompt_messages[0].role == PromptMessageRole.SYSTEM
     assert FUNCTION_CALLING_EXTRACTOR_NAME in prompt_messages[0].text
-    assert "{FUNCTION_CALLING_EXTRACTOR_NAME}" not in prompt_messages[0].text
+    assert "{FUNCTION_CALLING_EXTRACTOR_NAME}" not in prompt_messages[0].text  # noqa: RUF027
     assert "`extract_parameter`" not in prompt_messages[0].text
     assert "Follow strictly instructions." in prompt_messages[0].text
     assert prompt_messages[1].role == PromptMessageRole.USER

--- a/tests/nodes/test_code_node.py
+++ b/tests/nodes/test_code_node.py
@@ -1,0 +1,35 @@
+import pytest
+
+from graphon.nodes.code.code_node import CodeNode
+from graphon.nodes.code.entities import CodeNodeData
+from graphon.nodes.code.exc import OutputValidationError
+from graphon.nodes.code.limits import CodeNodeLimits
+from graphon.variables.types import SegmentType
+
+
+def _build_code_node() -> CodeNode:
+    node = object.__new__(CodeNode)
+    node._limits = CodeNodeLimits(
+        max_string_length=100,
+        max_number=100,
+        min_number=-100,
+        max_precision=4,
+        max_depth=5,
+        max_number_array_length=10,
+        max_string_array_length=10,
+        max_object_array_length=10,
+    )
+    return node
+
+
+def test_transform_result_reports_nested_missing_field_without_leading_dot() -> None:
+    node = _build_code_node()
+    output_schema = {
+        "root": CodeNodeData.Output(
+            type=SegmentType.OBJECT,
+            children={"child": CodeNodeData.Output(type=SegmentType.STRING)},
+        ),
+    }
+
+    with pytest.raises(OutputValidationError, match=r"Output root\.child is missing\."):
+        node._transform_result(result={"root": {}}, output_schema=output_schema)

--- a/tests/nodes/test_container_dispatch.py
+++ b/tests/nodes/test_container_dispatch.py
@@ -1,0 +1,90 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionMetadataKey
+from graphon.graph_events.graph import GraphRunSucceededEvent
+from graphon.graph_events.node import NodeRunStartedEvent, NodeRunSucceededEvent
+from graphon.nodes.iteration.entities import ErrorHandleMode
+from graphon.nodes.iteration.iteration_node import IterationNode
+from graphon.nodes.loop.loop_node import LoopNode
+from graphon.variables.segments import StringSegment
+from graphon.variables.variables import IntegerVariable
+
+
+def test_iteration_node_single_iter_keeps_iteration_event_dispatch() -> None:
+    node = IterationNode.__new__(IterationNode)
+    node._node_id = "iteration-node"
+    node._node_data = SimpleNamespace(
+        output_selector=["iteration-node", "answer"],
+        error_handle_mode=ErrorHandleMode.TERMINATED,
+    )
+
+    variable_pool = MagicMock()
+    variable_pool.get.side_effect = lambda selector: {
+        ("iteration-node", "index"): IntegerVariable(
+            name="index",
+            selector=["iteration-node", "index"],
+            value=2,
+        ),
+        ("iteration-node", "answer"): StringSegment(value="done"),
+    }.get(tuple(selector))
+
+    child_event = NodeRunStartedEvent(
+        id="child-run-1",
+        node_id="child-node",
+        node_type=BuiltinNodeTypes.CODE,
+        node_title="Code",
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    graph_engine = SimpleNamespace(
+        run=lambda: iter([child_event, GraphRunSucceededEvent()]),
+    )
+    outputs: list[object] = []
+
+    yielded_events = list(
+        node._run_single_iter(
+            variable_pool=variable_pool,
+            outputs=outputs,
+            graph_engine=graph_engine,
+        ),
+    )
+
+    assert yielded_events == [child_event]
+    assert child_event.in_iteration_id == "iteration-node"
+    assert (
+        child_event.node_run_result.metadata[
+            WorkflowNodeExecutionMetadataKey.ITERATION_INDEX
+        ]
+        == 2
+    )
+    assert outputs == ["done"]
+
+
+def test_loop_node_single_loop_keeps_loop_end_dispatch() -> None:
+    node = LoopNode.__new__(LoopNode)
+    node._node_id = "loop-node"
+    node._node_data = SimpleNamespace(loop_variables=None, outputs={})
+    node.graph_runtime_state = SimpleNamespace(variable_pool=MagicMock())
+
+    loop_end_event = NodeRunSucceededEvent(
+        id="loop-end-1",
+        node_id="loop-end-node",
+        node_type=BuiltinNodeTypes.LOOP_END,
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    graph_engine = SimpleNamespace(run=lambda: iter([loop_end_event]))
+    loop_state: dict[str, bool] = {}
+
+    yielded_events = list(
+        node._run_single_loop(
+            graph_engine=graph_engine,
+            current_index=1,
+            loop_state=loop_state,
+        ),
+    )
+
+    assert yielded_events == [loop_end_event]
+    assert loop_end_event.in_loop_id == "loop-node"
+    assert loop_state["reach_break_node"] is True
+    assert node.node_data.outputs["loop_round"] == 2

--- a/tests/nodes/tool/test_entities.py
+++ b/tests/nodes/tool/test_entities.py
@@ -1,0 +1,48 @@
+import pytest
+
+from graphon.nodes.tool.entities import ToolEntity, ToolNodeData
+
+
+def test_tool_input_accepts_variable_selector_list() -> None:
+    tool_input = ToolNodeData.ToolInput(type="variable", value=["node", "text"])
+
+    assert tool_input.type == "variable"
+    assert tool_input.value == ["node", "text"]
+
+
+def test_tool_input_rejects_non_string_mixed_value() -> None:
+    with pytest.raises(ValueError, match="value must be a string"):
+        ToolNodeData.ToolInput(type="mixed", value=1)
+
+
+def test_tool_entity_rejects_non_scalar_configuration_value() -> None:
+    with pytest.raises(
+        ValueError,
+        match="timeout must be one of: str, int, float, bool",
+    ):
+        ToolEntity(
+            provider_id="provider-1",
+            provider_type="builtin",
+            provider_name="Built-in",
+            tool_name="tool",
+            tool_label="Tool",
+            tool_configurations={"timeout": ["10"]},
+        )
+
+
+def test_tool_node_filters_none_and_empty_tool_inputs() -> None:
+    node_data = ToolNodeData(
+        provider_id="provider-1",
+        provider_type="builtin",
+        provider_name="Built-in",
+        tool_name="tool",
+        tool_label="Tool",
+        tool_configurations={"timeout": 10},
+        tool_parameters={
+            "answer": {"type": "mixed", "value": "ok"},
+            "ignored_none": None,
+            "ignored_empty": {"type": "mixed", "value": None},
+        },
+    )
+
+    assert set(node_data.tool_parameters) == {"answer"}

--- a/tests/nodes/tool/test_tool_node.py
+++ b/tests/nodes/tool/test_tool_node.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.file.enums import FileTransferMethod, FileType
+from graphon.file.models import File
+from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.node_events.node import StreamChunkEvent, StreamCompletedEvent
+from graphon.nodes.tool.exc import ToolNodeError
+from graphon.nodes.tool.tool_node import ToolNode
+from graphon.nodes.tool_runtime_entities import ToolRuntimeHandle, ToolRuntimeMessage
+
+
+def _build_tool_node() -> ToolNode:
+    node = ToolNode.__new__(ToolNode)
+    node._node_id = "node-1"
+    node._runtime = MagicMock()
+    node._runtime.get_usage.return_value = LLMUsage.empty_usage()
+    node._tool_file_manager_factory = MagicMock()
+    return node
+
+
+def test_transform_message_dispatches_text_variable_and_file_messages() -> None:
+    node = _build_tool_node()
+    file_obj = File(
+        file_type=FileType.DOCUMENT,
+        transfer_method=FileTransferMethod.LOCAL_FILE,
+        reference="file-ref",
+        filename="doc.txt",
+    )
+    messages = iter([
+        ToolRuntimeMessage(
+            type=ToolRuntimeMessage.MessageType.TEXT,
+            message=ToolRuntimeMessage.TextMessage(text="hello"),
+        ),
+        ToolRuntimeMessage(
+            type=ToolRuntimeMessage.MessageType.VARIABLE,
+            message=ToolRuntimeMessage.VariableMessage(
+                variable_name="answer",
+                variable_value="A",
+                stream=True,
+            ),
+        ),
+        ToolRuntimeMessage(
+            type=ToolRuntimeMessage.MessageType.FILE,
+            message=ToolRuntimeMessage.FileMessage(),
+            meta={"file": file_obj},
+        ),
+    ])
+
+    events = list(
+        node._transform_message(
+            messages=messages,
+            tool_info={},
+            parameters_for_log={},
+            node_id="node-1",
+            tool_runtime=ToolRuntimeHandle(raw=object()),
+        ),
+    )
+
+    assert isinstance(events[0], StreamChunkEvent)
+    assert events[0].selector == ["node-1", "text"]
+    assert events[0].chunk == "hello"
+    assert isinstance(events[1], StreamChunkEvent)
+    assert events[1].selector == ["node-1", "answer"]
+    assert events[1].chunk == "A"
+    assert isinstance(events[2], StreamChunkEvent)
+    assert events[2].selector == ["node-1", "text"]
+    assert events[2].is_final is True
+    assert isinstance(events[3], StreamChunkEvent)
+    assert events[3].selector == ["node-1", "answer"]
+    assert events[3].is_final is True
+
+    completed_event = events[4]
+    assert isinstance(completed_event, StreamCompletedEvent)
+    assert completed_event.node_run_result.outputs["text"] == "hello"
+    assert completed_event.node_run_result.outputs["answer"] == "A"
+    assert completed_event.node_run_result.outputs["files"].value == [file_obj]
+    assert completed_event.node_run_result.outputs["json"] == [{"data": []}]
+
+
+def test_transform_message_dispatches_image_link_with_handler_map() -> None:
+    node = _build_tool_node()
+    tool_file = File(
+        file_type=FileType.IMAGE,
+        transfer_method=FileTransferMethod.TOOL_FILE,
+        reference="tool-file-1",
+        mime_type="image/png",
+    )
+    built_file = File(
+        file_type=FileType.IMAGE,
+        transfer_method=FileTransferMethod.TOOL_FILE,
+        reference="tool-file-1",
+    )
+    node._tool_file_manager_factory.get_file_generator_by_tool_file_id.return_value = (
+        None,
+        tool_file,
+    )
+    node._runtime.build_file_reference.return_value = built_file
+
+    events = list(
+        node._transform_message(
+            messages=iter([
+                ToolRuntimeMessage(
+                    type=ToolRuntimeMessage.MessageType.IMAGE_LINK,
+                    message=ToolRuntimeMessage.TextMessage(
+                        text="https://example.com/image.png",
+                    ),
+                    meta={"tool_file_id": "tool-file-1"},
+                ),
+            ]),
+            tool_info={},
+            parameters_for_log={},
+            node_id="node-1",
+            tool_runtime=ToolRuntimeHandle(raw=object()),
+        ),
+    )
+
+    completed_event = events[-1]
+    assert isinstance(completed_event, StreamCompletedEvent)
+    assert completed_event.node_run_result.outputs["files"].value == [built_file]
+    node._runtime.build_file_reference.assert_called_once_with(
+        mapping={
+            "tool_file_id": "tool-file-1",
+            "type": FileType.IMAGE,
+            "transfer_method": FileTransferMethod.TOOL_FILE,
+            "url": "https://example.com/image.png",
+        },
+    )
+
+
+def test_transform_message_rejects_non_file_payload_in_file_message() -> None:
+    node = _build_tool_node()
+
+    with pytest.raises(ToolNodeError, match="Expected File object"):
+        list(
+            node._transform_message(
+                messages=iter([
+                    ToolRuntimeMessage(
+                        type=ToolRuntimeMessage.MessageType.FILE,
+                        message=ToolRuntimeMessage.FileMessage(),
+                        meta={"file": "not-a-file"},
+                    ),
+                ]),
+                tool_info={},
+                parameters_for_log={},
+                node_id="node-1",
+                tool_runtime=ToolRuntimeHandle(raw=object()),
+            ),
+        )

--- a/tests/nodes/variable_assigner/test_v1_node.py
+++ b/tests/nodes/variable_assigner/test_v1_node.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 
 from graphon.graph_events.node import NodeRunSucceededEvent, NodeRunVariableUpdatedEvent
 from graphon.nodes.variable_assigner.common import helpers as common_helpers
@@ -13,15 +14,22 @@ from graphon.variables.variables import (
 from ...helpers import build_graph_init_params, build_variable_pool
 
 
-def _build_node(*, variable_pool, assigned_selector, write_mode, input_selector):
+def _build_node(
+    *,
+    variable_pool: Any,
+    assigned_selector: Any,
+    write_mode: WriteMode,
+    input_selector: Any,
+) -> VariableAssignerNode:
     graph_config = {"nodes": [], "edges": []}
     init_params = build_graph_init_params(graph_config=graph_config)
     runtime_state = GraphRuntimeState(
-        variable_pool=variable_pool, start_at=time.perf_counter()
+        variable_pool=variable_pool,
+        start_at=time.perf_counter(),
     )
 
     return VariableAssignerNode(
-        id="assigner",
+        node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
         config={
@@ -38,10 +46,12 @@ def _build_node(*, variable_pool, assigned_selector, write_mode, input_selector)
 
 def test_overwrite_string_variable():
     conversation_variable = StringVariable(
-        name="test_conversation_variable", value="the first value"
+        name="test_conversation_variable",
+        value="the first value",
     )
     input_variable = StringVariable(
-        name="test_string_variable", value="the second value"
+        name="test_string_variable",
+        value="the second value",
     )
 
     variable_pool = build_variable_pool(
@@ -63,7 +73,7 @@ def test_overwrite_string_variable():
         event for event in events if isinstance(event, NodeRunSucceededEvent)
     )
     updated_variables = common_helpers.get_updated_variables(
-        succeeded_event.node_run_result.process_data
+        succeeded_event.node_run_result.process_data,
     )
 
     assert updated_variables is not None
@@ -79,10 +89,12 @@ def test_overwrite_string_variable():
 
 def test_append_variable_to_array():
     conversation_variable = ArrayStringVariable(
-        name="test_conversation_variable", value=["the first value"]
+        name="test_conversation_variable",
+        value=["the first value"],
     )
     input_variable = StringVariable(
-        name="test_string_variable", value="the second value"
+        name="test_string_variable",
+        value="the second value",
     )
 
     variable_pool = build_variable_pool(
@@ -104,7 +116,7 @@ def test_append_variable_to_array():
         event for event in events if isinstance(event, NodeRunSucceededEvent)
     )
     updated_variables = common_helpers.get_updated_variables(
-        succeeded_event.node_run_result.process_data
+        succeeded_event.node_run_result.process_data,
     )
 
     assert updated_variables is not None
@@ -115,7 +127,8 @@ def test_append_variable_to_array():
 
 def test_clear_array():
     conversation_variable = ArrayStringVariable(
-        name="test_conversation_variable", value=["the first value"]
+        name="test_conversation_variable",
+        value=["the first value"],
     )
 
     variable_pool = build_variable_pool(conversation_variables=[conversation_variable])
@@ -134,7 +147,7 @@ def test_clear_array():
         event for event in events if isinstance(event, NodeRunSucceededEvent)
     )
     updated_variables = common_helpers.get_updated_variables(
-        succeeded_event.node_run_result.process_data
+        succeeded_event.node_run_result.process_data,
     )
 
     assert updated_variables is not None

--- a/tests/nodes/variable_assigner/test_v2_helpers.py
+++ b/tests/nodes/variable_assigner/test_v2_helpers.py
@@ -10,7 +10,9 @@ def test_is_input_value_valid_overwrite_array_string():
         value=["hello", "world"],
     )
     assert is_input_value_valid(
-        variable_type=SegmentType.ARRAY_STRING, operation=Operation.OVER_WRITE, value=[]
+        variable_type=SegmentType.ARRAY_STRING,
+        operation=Operation.OVER_WRITE,
+        value=[],
     )
 
     assert not is_input_value_valid(
@@ -43,4 +45,12 @@ def test_is_input_value_valid_accepts_clear_without_input():
         variable_type=SegmentType.ARRAY_OBJECT,
         operation=Operation.CLEAR,
         value=None,
+    )
+
+
+def test_is_input_value_valid_accepts_array_any_append_string() -> None:
+    assert is_input_value_valid(
+        variable_type=SegmentType.ARRAY_ANY,
+        operation=Operation.APPEND,
+        value="hello",
     )

--- a/tests/nodes/variable_assigner/test_v2_node.py
+++ b/tests/nodes/variable_assigner/test_v2_node.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any
 
 from graphon.enums import WorkflowNodeExecutionStatus
 from graphon.graph_events.node import (
@@ -17,15 +18,20 @@ from graphon.variables.variables import (
 from ...helpers import build_graph_init_params, build_variable_pool
 
 
-def _build_node(*, variable_pool, items):
+def _build_node(
+    *,
+    variable_pool: Any,
+    items: Any,
+) -> VariableAssignerNode:
     graph_config = {"nodes": [], "edges": []}
     init_params = build_graph_init_params(graph_config=graph_config)
     runtime_state = GraphRuntimeState(
-        variable_pool=variable_pool, start_at=time.perf_counter()
+        variable_pool=variable_pool,
+        start_at=time.perf_counter(),
     )
 
     return VariableAssignerNode(
-        id="assigner",
+        node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
         config={
@@ -55,7 +61,7 @@ def test_remove_first_from_array():
                 "input_type": InputType.VARIABLE,
                 "operation": Operation.REMOVE_FIRST,
                 "value": None,
-            }
+            },
         ],
     )
 
@@ -83,7 +89,7 @@ def test_remove_last_from_array():
                 "input_type": InputType.VARIABLE,
                 "operation": Operation.REMOVE_LAST,
                 "value": None,
-            }
+            },
         ],
     )
 
@@ -161,7 +167,7 @@ def test_invalid_constant_input_returns_failed_event():
                 "input_type": InputType.CONSTANT,
                 "operation": Operation.OVER_WRITE,
                 "value": 123,
-            }
+            },
         ],
     )
 

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from graphon.graph_engine.domain.graph_execution import GraphExecution
+from graphon.graph_engine.ready_queue.in_memory import InMemoryReadyQueue
 from graphon.model_runtime.entities.llm_entities import LLMUsage
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.runtime.read_only_wrappers import ReadOnlyGraphRuntimeStateWrapper
@@ -87,10 +89,10 @@ class TestGraphRuntimeState:
     def test_type_validation(self):
         state = GraphRuntimeState(variable_pool=VariablePool(), start_at=time())
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="total_tokens must be non-negative"):
             state.total_tokens = -1
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="node_run_steps must be non-negative"):
             state.node_run_steps = -1
 
     def test_helper_methods(self):
@@ -104,15 +106,13 @@ class TestGraphRuntimeState:
         state.add_tokens(50)
         assert state.total_tokens == initial_tokens + 50
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="tokens must be non-negative"):
             state.add_tokens(-1)
 
     def test_ready_queue_default_instantiation(self):
         state = GraphRuntimeState(variable_pool=VariablePool(), start_at=time())
 
         queue = state.ready_queue
-
-        from graphon.graph_engine.ready_queue.in_memory import InMemoryReadyQueue
 
         assert isinstance(queue, InMemoryReadyQueue)
 
@@ -121,17 +121,18 @@ class TestGraphRuntimeState:
 
         execution = state.graph_execution
 
-        from graphon.graph_engine.domain.graph_execution import GraphExecution
-
         assert isinstance(execution, GraphExecution)
-        assert execution.workflow_id == ""
+        assert not execution.workflow_id
         assert state.graph_execution is execution
 
     def test_response_coordinator_configuration(self):
         variable_pool = VariablePool()
         state = GraphRuntimeState(variable_pool=variable_pool, start_at=time())
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="Graph must be attached before accessing response coordinator",
+        ):
             _ = state.response_coordinator
 
         mock_graph = MagicMock()
@@ -144,13 +145,17 @@ class TestGraphRuntimeState:
 
             assert state.response_coordinator is coordinator_instance
             coordinator_cls.assert_called_once_with(
-                variable_pool=variable_pool, graph=mock_graph
+                variable_pool=variable_pool,
+                graph=mock_graph,
             )
 
             state.configure(graph=mock_graph)
 
         other_graph = MagicMock()
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            ValueError,
+            match="GraphRuntimeState already attached to a different graph instance",
+        ):
             state.attach_graph(other_graph)
 
     def test_read_only_wrapper_exposes_additional_state(self):
@@ -299,7 +304,7 @@ class TestGraphRuntimeState:
     def test_snapshot_restore_preserves_updated_conversation_variable(self):
         variable_pool = VariablePool(
             conversation_variables=[
-                StringVariable(name="session_name", value="before")
+                StringVariable(name="session_name", value="before"),
             ],
         )
         variable_pool.add((CONVERSATION_VARIABLE_NODE_ID, "session_name"), "after")

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -3,8 +3,10 @@ from graphon.variables.segments import (
     BooleanSegment,
     IntegerSegment,
     NoneSegment,
+    ObjectSegment,
     StringSegment,
 )
+from graphon.variables.variables import StringVariable
 
 
 class TestVariablePoolGetAndNestedAttribute:
@@ -40,7 +42,7 @@ class TestVariablePoolGetAndNestedAttribute:
         segment = pool._get_nested_attribute(obj, "a")
         assert segment is not None
         assert isinstance(segment, StringSegment)
-        assert segment.value == ""
+        assert not segment.value
 
     def test_get_simple_variable(self):
         pool = VariablePool.empty()
@@ -93,7 +95,7 @@ class TestVariablePoolGetAndNestedAttribute:
         segment_empty = pool.get(("node1", "obj", "inner_empty"))
         assert segment_empty is not None
         assert isinstance(segment_empty, StringSegment)
-        assert segment_empty.value == ""
+        assert not segment_empty.value
 
         segment_zero = pool.get(("node1", "obj", "inner_zero"))
         assert segment_zero is not None
@@ -104,6 +106,17 @@ class TestVariablePoolGetAndNestedAttribute:
         assert segment_false is not None
         assert isinstance(segment_false, BooleanSegment)
         assert segment_false.value is False
+
+    def test_add_keeps_variable_instances_and_supports_segments(self):
+        pool = VariablePool.empty()
+        variable = StringVariable(name="name", selector=["node1", "name"], value="Joe")
+        pool.add(("node1", "name"), variable)
+        pool.add(("node1", "profile"), ObjectSegment(value={"city": "Paris"}))
+
+        assert pool.variable_dictionary["node1"]["name"] is variable
+        segment = pool.get(("node1", "profile", "city"))
+        assert segment is not None
+        assert segment.value == "Paris"
 
 
 class TestVariablePoolGetNotModifyVariableDictionary:

--- a/tests/test_protocols_exports.py
+++ b/tests/test_protocols_exports.py
@@ -1,3 +1,4 @@
+from graphon import protocols
 from graphon.file.protocols import WorkflowFileRuntimeProtocol
 from graphon.graph.graph import NodeFactory
 from graphon.graph.validation import GraphValidationRule
@@ -94,8 +95,6 @@ def test_public_protocol_exports_match_canonical_definitions():
 
 
 def test_public_protocol_package_exports_are_stable():
-    from graphon import protocols
-
     assert protocols.__all__ == [
         "CredentialsProvider",
         "FileManagerProtocol",

--- a/tests/utils/test_condition_processor.py
+++ b/tests/utils/test_condition_processor.py
@@ -3,7 +3,7 @@ from graphon.utils.condition.entities import Condition
 from graphon.utils.condition.processor import ConditionProcessor
 
 
-def test_number_formatting():
+def test_number_formatting() -> None:
     condition_processor = ConditionProcessor()
     variable_pool = VariablePool()
     variable_pool.add(["test_node_id", "zone"], 0)
@@ -18,7 +18,7 @@ def test_number_formatting():
                     variable_selector=["test_node_id", "zone"],
                     comparison_operator="≤",
                     value="0.95",
-                )
+                ),
             ],
             operator="or",
         ).final_result
@@ -33,7 +33,7 @@ def test_number_formatting():
                     variable_selector=["test_node_id", "one"],
                     comparison_operator="≥",
                     value="0.95",
-                )
+                ),
             ],
             operator="or",
         ).final_result
@@ -48,7 +48,7 @@ def test_number_formatting():
                     variable_selector=["test_node_id", "one_one"],
                     comparison_operator="≥",
                     value="0.95",
-                )
+                ),
             ],
             operator="or",
         ).final_result
@@ -63,9 +63,62 @@ def test_number_formatting():
                     variable_selector=["test_node_id", "one_one"],
                     comparison_operator=">",
                     value="0",
-                )
+                ),
             ],
             operator="or",
         ).final_result
         is True
     )
+
+
+def test_process_conditions_converts_boolean_expected_from_string() -> None:
+    condition_processor = ConditionProcessor()
+    variable_pool = VariablePool()
+    variable_pool.add(["test_node_id", "enabled"], False)
+
+    result = condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "enabled"],
+                comparison_operator="is",
+                value="false",
+            ),
+        ],
+        operator="and",
+    )
+
+    assert result.final_result is True
+
+
+def test_process_conditions_contains_supports_string_and_list_values() -> None:
+    condition_processor = ConditionProcessor()
+    variable_pool = VariablePool()
+    variable_pool.add(["test_node_id", "text"], "graphon")
+    variable_pool.add(["test_node_id", "tags"], ["a", "b"])
+
+    text_result = condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "text"],
+                comparison_operator="contains",
+                value="pho",
+            ),
+        ],
+        operator="and",
+    )
+    list_result = condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "tags"],
+                comparison_operator="contains",
+                value="a",
+            ),
+        ],
+        operator="and",
+    )
+
+    assert text_result.final_result is True
+    assert list_result.final_result is True

--- a/tests/utils/test_variable_utils.py
+++ b/tests/utils/test_variable_utils.py
@@ -1,0 +1,11 @@
+from graphon.variables.segment_group import SegmentGroup
+from graphon.variables.segments import StringSegment
+from graphon.variables.utils import segment_orjson_default
+
+
+def test_segment_orjson_default_uses_match_dispatch() -> None:
+    segment = StringSegment(value="value")
+    group = SegmentGroup(value=[segment])
+
+    assert segment_orjson_default(segment) == "value"
+    assert segment_orjson_default(group) == ["value"]


### PR DESCRIPTION
## Summary
- clean up runtime, node, and model-layer dispatch paths with `match case` or stable module-level lookup maps where appropriate
- remove obsolete Ruff ignore entries by fixing the underlying implementations instead of suppressing them
- add focused regression coverage for dispatch, HTTP request handling, prompt message serialization, variable handling, and condition processing

## Why
The runtime layer had accumulated mixed dispatch styles, nested condition branches, and stale lint suppressions. This branch standardizes the control flow and makes subtype-sensitive behavior easier to reason about and maintain.

Closes #10

## Validation
- `make check`
