### PR TITLE
ci: harden workflow permissions and validate PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,11 +4,61 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions: {}
 
 jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title against CONTRIBUTING.md
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+
+  validate-commit-messages:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate commit history against CONTRIBUTING.md
+        uses: cocogitto/cocogitto-action@v4
+        with:
+          command: check
+
   check:
     name: Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -21,4 +71,6 @@ jobs:
 
   test:
     needs: check
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
 
   build:
     name: Build release distributions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/.github/workflows/test_pypi_publish.yml
+++ b/.github/workflows/test_pypi_publish.yml
@@ -3,9 +3,13 @@ name: Publish to TestPyPI
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
 
   build:
     name: Build release distributions


### PR DESCRIPTION
## Summary
- add pull request title validation using the Conventional Commit types documented in CONTRIBUTING.md
- add commit message validation for pull requests on opened, reopened, edited, and synchronize events
- make workflow token permissions explicit and minimal across PR, test, and publish workflows

## Why
The repository requires Conventional Commits for both pull request titles and commit history, and the workflows should enforce those rules without relying on default token permissions.

Closes #14

## Validation
- git diff --check
- repository hooks during git commit, including YAML checks, make format, and make lint
- no additional runtime tests run for these workflow-only changes