### PR TITLE
chore: resolve ty diagnostics across runtime and nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ homepage = 'https://github.com/langgenius/graphon'
 issues = 'https://github.com/langgenius/graphon/issues'
 
 [dependency-groups]
-dev = ['pytest', 'pytest-cov', 'pytest-mock', 'pytest-xdist', 'ruff', 'prek']
+dev = ['pytest', 'pytest-cov', 'pytest-mock', 'pytest-xdist', 'ruff', 'prek', 'ty']
 
 [build-system]
 requires = ['uv_build>=0.11.1,<0.12.0']
@@ -87,6 +87,9 @@ ignore-one-line-docstrings = true
 'tests/**/*.py' = [
     'S101', # Pytest convention relies on plain assert statements.
 ]
+
+[tool.ty.environment]
+python-platform = "linux"
 
 [tool.pytest]
 minversion = '9.0'

--- a/src/graphon/graph_engine/command_processing/command_handlers.py
+++ b/src/graphon/graph_engine/command_processing/command_handlers.py
@@ -2,9 +2,9 @@ import logging
 from typing import final, override
 
 from graphon.entities.pause_reason import SchedulingPause
+from graphon.runtime.graph_runtime_state import GraphExecutionProtocol
 from graphon.runtime.variable_pool import VariablePool
 
-from ..domain.graph_execution import GraphExecution
 from ..entities.commands import (
     AbortCommand,
     GraphEngineCommand,
@@ -19,7 +19,11 @@ logger = logging.getLogger(__name__)
 @final
 class AbortCommandHandler(CommandHandler):
     @override
-    def handle(self, command: GraphEngineCommand, execution: GraphExecution) -> None:
+    def handle(
+        self,
+        command: GraphEngineCommand,
+        execution: GraphExecutionProtocol,
+    ) -> None:
         assert isinstance(command, AbortCommand)
         logger.debug("Aborting workflow %s: %s", execution.workflow_id, command.reason)
         execution.abort(command.reason or "User requested abort")
@@ -28,7 +32,11 @@ class AbortCommandHandler(CommandHandler):
 @final
 class PauseCommandHandler(CommandHandler):
     @override
-    def handle(self, command: GraphEngineCommand, execution: GraphExecution) -> None:
+    def handle(
+        self,
+        command: GraphEngineCommand,
+        execution: GraphExecutionProtocol,
+    ) -> None:
         assert isinstance(command, PauseCommand)
         logger.debug("Pausing workflow %s: %s", execution.workflow_id, command.reason)
         # Convert string reason to PauseReason if needed
@@ -43,7 +51,11 @@ class UpdateVariablesCommandHandler(CommandHandler):
         self._variable_pool = variable_pool
 
     @override
-    def handle(self, command: GraphEngineCommand, execution: GraphExecution) -> None:
+    def handle(
+        self,
+        command: GraphEngineCommand,
+        execution: GraphExecutionProtocol,
+    ) -> None:
         assert isinstance(command, UpdateVariablesCommand)
         for update in command.updates:
             try:

--- a/src/graphon/graph_engine/command_processing/command_processor.py
+++ b/src/graphon/graph_engine/command_processing/command_processor.py
@@ -3,8 +3,9 @@
 import logging
 from typing import Protocol, final
 
+from graphon.runtime.graph_runtime_state import GraphExecutionProtocol
+
 from ..command_channels import CommandChannel
-from ..domain.graph_execution import GraphExecution
 from ..entities.commands import GraphEngineCommand
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ class CommandHandler(Protocol):
     def handle(
         self,
         command: GraphEngineCommand,
-        execution: GraphExecution,
+        execution: GraphExecutionProtocol,
     ) -> None: ...
 
 
@@ -31,7 +32,7 @@ class CommandProcessor:
     def __init__(
         self,
         command_channel: CommandChannel,
-        graph_execution: GraphExecution,
+        graph_execution: GraphExecutionProtocol,
     ) -> None:
         """Initialize the command processor.
 

--- a/src/graphon/graph_engine/error_handler.py
+++ b/src/graphon/graph_engine/error_handler.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from typing import TYPE_CHECKING, final
+from typing import final
 
 from graphon.enums import (
     ErrorStrategy as ErrorStrategyEnum,
@@ -19,9 +19,7 @@ from graphon.graph_events.node import (
     NodeRunRetryEvent,
 )
 from graphon.node_events.base import NodeRunResult
-
-if TYPE_CHECKING:
-    from .domain import GraphExecution
+from graphon.runtime.graph_runtime_state import GraphExecutionProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +33,11 @@ class ErrorHandler:
     node configuration.
     """
 
-    def __init__(self, graph: Graph, graph_execution: "GraphExecution") -> None:
+    def __init__(
+        self,
+        graph: Graph,
+        graph_execution: GraphExecutionProtocol,
+    ) -> None:
         """Initialize the error handler.
 
         Args:

--- a/src/graphon/graph_engine/event_management/event_handlers.py
+++ b/src/graphon/graph_engine/event_management/event_handlers.py
@@ -33,10 +33,11 @@ from graphon.graph_events.node import (
     NodeRunVariableUpdatedEvent,
 )
 from graphon.model_runtime.entities.llm_entities import LLMUsage
-from graphon.runtime.graph_runtime_state import GraphRuntimeState
-
-from ..domain.graph_execution import GraphExecution
-from ..response_coordinator import ResponseStreamCoordinator
+from graphon.runtime.graph_runtime_state import (
+    GraphExecutionProtocol,
+    GraphRuntimeState,
+    ResponseStreamCoordinatorProtocol,
+)
 
 if TYPE_CHECKING:
     from ..error_handler import ErrorHandler
@@ -59,8 +60,8 @@ class EventHandler:
         self,
         graph: Graph,
         graph_runtime_state: GraphRuntimeState,
-        graph_execution: GraphExecution,
-        response_coordinator: ResponseStreamCoordinator,
+        graph_execution: GraphExecutionProtocol,
+        response_coordinator: ResponseStreamCoordinatorProtocol,
         event_collector: "EventManager",
         edge_processor: "EdgeProcessor",
         state_manager: "GraphStateManager",

--- a/src/graphon/graph_engine/graph_traversal/edge_processor.py
+++ b/src/graphon/graph_engine/graph_traversal/edge_processor.py
@@ -7,9 +7,9 @@ from graphon.enums import NodeExecutionType
 from graphon.graph.edge import Edge
 from graphon.graph.graph import Graph
 from graphon.graph_events.node import NodeRunStreamChunkEvent
+from graphon.runtime.graph_runtime_state import ResponseStreamCoordinatorProtocol
 
 from ..graph_state_manager import GraphStateManager
-from ..response_coordinator import ResponseStreamCoordinator
 
 if TYPE_CHECKING:
     from .skip_propagator import SkipPropagator
@@ -28,7 +28,7 @@ class EdgeProcessor:
         self,
         graph: Graph,
         state_manager: GraphStateManager,
-        response_coordinator: ResponseStreamCoordinator,
+        response_coordinator: ResponseStreamCoordinatorProtocol,
         skip_propagator: "SkipPropagator",
     ) -> None:
         """Initialize the edge processor.

--- a/src/graphon/graph_engine/orchestration/execution_coordinator.py
+++ b/src/graphon/graph_engine/orchestration/execution_coordinator.py
@@ -2,8 +2,9 @@
 
 from typing import final
 
+from graphon.runtime.graph_runtime_state import GraphExecutionProtocol
+
 from ..command_processing import CommandProcessor
-from ..domain import GraphExecution
 from ..graph_state_manager import GraphStateManager
 from ..worker_management import WorkerPool
 
@@ -18,7 +19,7 @@ class ExecutionCoordinator:
 
     def __init__(
         self,
-        graph_execution: GraphExecution,
+        graph_execution: GraphExecutionProtocol,
         state_manager: GraphStateManager,
         command_processor: CommandProcessor,
         worker_pool: WorkerPool,

--- a/src/graphon/model_runtime/entities/message_entities.py
+++ b/src/graphon/model_runtime/entities/message_entities.py
@@ -64,7 +64,7 @@ class PromptMessageContent(ABC, BaseModel):
 class TextPromptMessageContent(PromptMessageContent):
     """Model class for text prompt message content."""
 
-    type: Literal[PromptMessageContentType.TEXT] = PromptMessageContentType.TEXT  # type: ignore
+    type: Literal[PromptMessageContentType.TEXT] = PromptMessageContentType.TEXT
     data: str
 
 
@@ -86,11 +86,11 @@ class MultiModalPromptMessageContent(PromptMessageContent):
 
 
 class VideoPromptMessageContent(MultiModalPromptMessageContent):
-    type: Literal[PromptMessageContentType.VIDEO] = PromptMessageContentType.VIDEO  # type: ignore
+    type: Literal[PromptMessageContentType.VIDEO] = PromptMessageContentType.VIDEO
 
 
 class AudioPromptMessageContent(MultiModalPromptMessageContent):
-    type: Literal[PromptMessageContentType.AUDIO] = PromptMessageContentType.AUDIO  # type: ignore
+    type: Literal[PromptMessageContentType.AUDIO] = PromptMessageContentType.AUDIO
 
 
 class ImagePromptMessageContent(MultiModalPromptMessageContent):
@@ -102,12 +102,12 @@ class ImagePromptMessageContent(MultiModalPromptMessageContent):
         LOW = auto()
         HIGH = auto()
 
-    type: Literal[PromptMessageContentType.IMAGE] = PromptMessageContentType.IMAGE  # type: ignore
+    type: Literal[PromptMessageContentType.IMAGE] = PromptMessageContentType.IMAGE
     detail: DETAIL = DETAIL.LOW
 
 
 class DocumentPromptMessageContent(MultiModalPromptMessageContent):
-    type: Literal[PromptMessageContentType.DOCUMENT] = PromptMessageContentType.DOCUMENT  # type: ignore
+    type: Literal[PromptMessageContentType.DOCUMENT] = PromptMessageContentType.DOCUMENT
 
 
 type PromptMessageContentUnionTypes = Annotated[

--- a/src/graphon/model_runtime/entities/provider_entities.py
+++ b/src/graphon/model_runtime/entities/provider_entities.py
@@ -42,7 +42,7 @@ class FormOption(BaseModel):
     @model_validator(mode="after")
     def _(self) -> Self:
         if not self.label:
-            self.label = I18nObject(en_us=self.value)
+            self.label = I18nObject(en_US=self.value)
         return self
 
 

--- a/src/graphon/model_runtime/model_providers/base/ai_model.py
+++ b/src/graphon/model_runtime/model_providers/base/ai_model.py
@@ -209,7 +209,7 @@ class AIModel:
                         parameter_rule.required = default_parameter_rule["required"]
                     if not parameter_rule.help and "help" in default_parameter_rule:
                         parameter_rule.help = I18nObject(
-                            en_us=default_parameter_rule["help"]["en_US"],
+                            en_US=default_parameter_rule["help"]["en_US"],
                         )
                     if (
                         parameter_rule.help

--- a/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
+++ b/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-
 from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
 from graphon.model_runtime.entities.text_embedding_entities import (
     EmbeddingInputType,
@@ -26,30 +24,24 @@ class TextEmbeddingModel(AIModel):
             msg = "No texts or files provided"
             raise ValueError(msg)
 
-        invoke_embedding: Callable[..., EmbeddingResult]
-        invoke_kwargs: dict[str, object]
-        if texts:
-            invoke_embedding = self.model_runtime.invoke_text_embedding
-            invoke_kwargs = {
-                "provider": self.provider,
-                "model": model,
-                "credentials": credentials,
-                "texts": texts,
-                "input_type": input_type,
-            }
-        else:
-            assert multimodel_documents is not None
-            invoke_embedding = self.model_runtime.invoke_multimodal_embedding
-            invoke_kwargs = {
-                "provider": self.provider,
-                "model": model,
-                "credentials": credentials,
-                "documents": multimodel_documents,
-                "input_type": input_type,
-            }
-
         try:
-            return invoke_embedding(**invoke_kwargs)
+            if texts:
+                return self.model_runtime.invoke_text_embedding(
+                    provider=self.provider,
+                    model=model,
+                    credentials=credentials,
+                    texts=texts,
+                    input_type=input_type,
+                )
+
+            assert multimodel_documents is not None
+            return self.model_runtime.invoke_multimodal_embedding(
+                provider=self.provider,
+                model=model,
+                credentials=credentials,
+                documents=multimodel_documents,
+                input_type=input_type,
+            )
         except Exception as e:
             raise self._transform_invoke_error(e) from e
 

--- a/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
+++ b/src/graphon/model_runtime/model_providers/base/text_embedding_model.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from graphon.model_runtime.entities.model_entities import ModelPropertyKey, ModelType
 from graphon.model_runtime.entities.text_embedding_entities import (
     EmbeddingInputType,
@@ -24,23 +26,30 @@ class TextEmbeddingModel(AIModel):
             msg = "No texts or files provided"
             raise ValueError(msg)
 
+        invoke_embedding: Callable[..., EmbeddingResult]
+        invoke_kwargs: dict[str, object]
+        if texts:
+            invoke_embedding = self.model_runtime.invoke_text_embedding
+            invoke_kwargs = {
+                "provider": self.provider,
+                "model": model,
+                "credentials": credentials,
+                "texts": texts,
+                "input_type": input_type,
+            }
+        else:
+            assert multimodel_documents is not None
+            invoke_embedding = self.model_runtime.invoke_multimodal_embedding
+            invoke_kwargs = {
+                "provider": self.provider,
+                "model": model,
+                "credentials": credentials,
+                "documents": multimodel_documents,
+                "input_type": input_type,
+            }
+
         try:
-            if texts:
-                return self.model_runtime.invoke_text_embedding(
-                    provider=self.provider,
-                    model=model,
-                    credentials=credentials,
-                    texts=texts,
-                    input_type=input_type,
-                )
-            if multimodel_documents:
-                return self.model_runtime.invoke_multimodal_embedding(
-                    provider=self.provider,
-                    model=model,
-                    credentials=credentials,
-                    documents=multimodel_documents,
-                    input_type=input_type,
-                )
+            return invoke_embedding(**invoke_kwargs)
         except Exception as e:
             raise self._transform_invoke_error(e) from e
 

--- a/src/graphon/model_runtime/model_providers/base/tokenizers/gpt2_tokenizer.py
+++ b/src/graphon/model_runtime/model_providers/base/tokenizers/gpt2_tokenizer.py
@@ -27,7 +27,7 @@ class GPT2Tokenizer:
     def _get_num_tokens_by_gpt2(text: str) -> int:
         """Use gpt2 tokenizer to get num tokens"""
         tokenizer = GPT2Tokenizer.get_encoder()
-        tokens = tokenizer.encode(text)  # type: ignore
+        tokens = tokenizer.encode(text)
         return len(tokens)
 
     @staticmethod

--- a/src/graphon/model_runtime/slim/package_loader.py
+++ b/src/graphon/model_runtime/slim/package_loader.py
@@ -315,7 +315,10 @@ class SlimPackageLoader:
         if not en_us:
             msg = f"Missing en_US translation in {value}"
             raise ValueError(msg)
-        return I18nObject(en_us=str(en_us), zh_hans=str(zh_hans or en_us))
+        return I18nObject.model_validate({
+            "en_US": str(en_us),
+            "zh_Hans": str(zh_hans or en_us),
+        })
 
     def _convert_optional_i18n(self, value: dict[str, Any] | None) -> I18nObject | None:
         if value is None:

--- a/src/graphon/model_runtime/slim/prepared_llm.py
+++ b/src/graphon/model_runtime/slim/prepared_llm.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator, Mapping, Sequence
-from typing import Any, Literal, overload, override
+from typing import Any, Literal, cast, overload, override
 
 from graphon.model_runtime.entities.llm_entities import (
     LLMResult,
@@ -171,23 +171,29 @@ class SlimPreparedLLM(PreparedLLMProtocol):
         structured_parameters = dict(model_parameters)
         structured_parameters["json_schema"] = json.dumps(json_schema)
         if stream:
-            return self.invoke_llm(
+            return cast(
+                "Generator[LLMResultChunkWithStructuredOutput, None, None]",
+                self.invoke_llm(
+                    prompt_messages=prompt_messages,
+                    model_parameters=structured_parameters,
+                    tools=None,
+                    stop=stop,
+                    stream=True,
+                ),
+            )
+        return cast(
+            "LLMResultWithStructuredOutput",
+            self.invoke_llm(
                 prompt_messages=prompt_messages,
                 model_parameters=structured_parameters,
                 tools=None,
                 stop=stop,
-                stream=True,
-            )
-        return self.invoke_llm(
-            prompt_messages=prompt_messages,
-            model_parameters=structured_parameters,
-            tools=None,
-            stop=stop,
-            stream=False,
+                stream=False,
+            ),
         )
 
-    @staticmethod
     @override
-    def is_structured_output_parse_error(error: Exception) -> bool:
+    def is_structured_output_parse_error(self, error: Exception) -> bool:
+        _ = self
         _ = error
         return False

--- a/src/graphon/model_runtime/slim/runtime.py
+++ b/src/graphon/model_runtime/slim/runtime.py
@@ -10,7 +10,7 @@ from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import IO, Any
+from typing import IO, Any, cast
 
 from graphon.model_runtime.entities.llm_entities import (
     LLMResult,
@@ -19,6 +19,7 @@ from graphon.model_runtime.entities.llm_entities import (
     LLMResultChunkWithStructuredOutput,
     LLMResultWithStructuredOutput,
     LLMUsage,
+    LLMUsageMetadata,
 )
 from graphon.model_runtime.entities.message_entities import (
     AssistantPromptMessage,
@@ -777,22 +778,27 @@ class SlimRuntime(ModelRuntime):
                 system_fingerprint = chunk.system_fingerprint
 
         _ = finish_reason
-        result_kwargs = {
-            "model": model,
-            "prompt_messages": list(prompt_messages),
-            "message": AssistantPromptMessage(
-                content=content_text or content_parts,
-                tool_calls=tool_calls,
-            ),
-            "usage": usage,
-            "system_fingerprint": system_fingerprint,
-        }
+        prompt_messages_list = list(prompt_messages)
+        assistant_message = AssistantPromptMessage(
+            content=content_text or content_parts,
+            tool_calls=tool_calls,
+        )
         if structured_output is not None:
             return LLMResultWithStructuredOutput(
-                **result_kwargs,
+                model=model,
+                prompt_messages=prompt_messages_list,
+                message=assistant_message,
+                usage=usage,
+                system_fingerprint=system_fingerprint,
                 structured_output=structured_output,
             )
-        return LLMResult(**result_kwargs)
+        return LLMResult(
+            model=model,
+            prompt_messages=prompt_messages_list,
+            message=assistant_message,
+            usage=usage,
+            system_fingerprint=system_fingerprint,
+        )
 
     def _parse_llm_chunk(
         self,
@@ -803,29 +809,37 @@ class SlimRuntime(ModelRuntime):
     ) -> LLMResultChunk:
         delta_payload = chunk.get("delta") or {}
         usage_payload = delta_payload.get("usage")
-        message = self._deserialize_prompt_message(delta_payload.get("message") or {})
+        message = cast(
+            AssistantPromptMessage,
+            self._deserialize_prompt_message(delta_payload.get("message") or {}),
+        )
         finish_reason = delta_payload.get("finish_reason")
-        base_kwargs = {
-            "model": model,
-            "prompt_messages": list(prompt_messages),
-            "system_fingerprint": chunk.get("system_fingerprint"),
-            "delta": LLMResultChunkDelta(
-                index=int(delta_payload.get("index", 0)),
-                message=message,
-                usage=(
-                    self._parse_llm_usage(usage_payload)
-                    if usage_payload is not None
-                    else None
-                ),
-                finish_reason=str(finish_reason) if finish_reason is not None else None,
+        delta = LLMResultChunkDelta(
+            index=int(delta_payload.get("index", 0)),
+            message=message,
+            usage=(
+                self._parse_llm_usage(usage_payload)
+                if usage_payload is not None
+                else None
             ),
-        }
+            finish_reason=str(finish_reason) if finish_reason is not None else None,
+        )
+        prompt_messages_list = list(prompt_messages)
+        system_fingerprint = cast("str | None", chunk.get("system_fingerprint"))
         if "structured_output" in chunk:
             return LLMResultChunkWithStructuredOutput(
-                **base_kwargs,
+                model=model,
+                prompt_messages=prompt_messages_list,
+                system_fingerprint=system_fingerprint,
+                delta=delta,
                 structured_output=chunk.get("structured_output"),
             )
-        return LLMResultChunk(**base_kwargs)
+        return LLMResultChunk(
+            model=model,
+            prompt_messages=prompt_messages_list,
+            system_fingerprint=system_fingerprint,
+            delta=delta,
+        )
 
     def _serialize_prompt_message(self, message: PromptMessage) -> dict[str, Any]:
         return jsonable_encoder(message)
@@ -851,7 +865,7 @@ class SlimRuntime(ModelRuntime):
 
     @staticmethod
     def _parse_llm_usage(payload: Mapping[str, Any]) -> LLMUsage:
-        return LLMUsage.from_metadata(dict(payload))
+        return LLMUsage.from_metadata(cast("LLMUsageMetadata", dict(payload)))
 
     @staticmethod
     def _parse_embedding_usage(payload: Mapping[str, Any]) -> EmbeddingUsage:

--- a/src/graphon/model_runtime/utils/encoders.py
+++ b/src/graphon/model_runtime/utils/encoders.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 from collections import defaultdict, deque
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from decimal import Decimal
 from enum import Enum
 from ipaddress import (
@@ -58,7 +58,8 @@ def decimal_encoder(dec_value: Decimal) -> int | float:
         An `int` for integral decimals, otherwise a `float`.
 
     """
-    if dec_value.as_tuple().exponent >= 0:  # type: ignore[operator]
+    exponent = dec_value.as_tuple().exponent
+    if isinstance(exponent, int) and exponent >= 0:
         return int(dec_value)
     return float(dec_value)
 
@@ -94,7 +95,7 @@ ENCODERS_BY_TYPE: dict[type[Any], Callable[[Any], Any]] = {
 
 
 def generate_encoders_by_class_tuples(
-    type_encoder_map: dict[Any, Callable[[Any], Any]],
+    type_encoder_map: Mapping[type[Any], Callable[[Any], Any]],
 ) -> dict[Callable[[Any], Any], tuple[Any, ...]]:
     encoders_by_class_tuples: dict[Callable[[Any], Any], tuple[Any, ...]] = defaultdict(
         tuple,
@@ -110,7 +111,7 @@ _ENCODER_UNSET = object()
 
 def _encode_with_custom_encoder(
     obj: Any,
-    custom_encoder: dict[Any, Callable[[Any], Any]],
+    custom_encoder: Mapping[type[Any], Callable[[Any], Any]],
 ) -> Any:
     if type(obj) in custom_encoder:
         return custom_encoder[type(obj)](obj)
@@ -156,7 +157,7 @@ def _encode_dataclass(
     exclude_unset: bool,
     exclude_defaults: bool,
     exclude_none: bool,
-    custom_encoder: dict[Any, Callable[[Any], Any]],
+    custom_encoder: Mapping[type[Any], Callable[[Any], Any]],
     excluded_key_prefixes: Sequence[str],
 ) -> Any:
     obj_dict = dataclasses.asdict(obj)
@@ -172,12 +173,12 @@ def _encode_dataclass(
 
 
 def _encode_mapping(
-    obj: dict[Any, Any],
+    obj: Mapping[Any, Any],
     *,
     by_alias: bool,
     exclude_unset: bool,
     exclude_none: bool,
-    custom_encoder: dict[Any, Callable[[Any], Any]],
+    custom_encoder: Mapping[type[Any], Callable[[Any], Any]],
     excluded_key_prefixes: Sequence[str],
 ) -> dict[Any, Any]:
     encoded_dict = {}
@@ -221,7 +222,7 @@ def _encode_collection(
     exclude_unset: bool,
     exclude_defaults: bool,
     exclude_none: bool,
-    custom_encoder: dict[Any, Callable[[Any], Any]],
+    custom_encoder: Mapping[type[Any], Callable[[Any], Any]],
     excluded_key_prefixes: Sequence[str],
 ) -> list[Any]:
     return [
@@ -265,7 +266,7 @@ def jsonable_encoder(
     exclude_unset: bool = False,
     exclude_defaults: bool = False,
     exclude_none: bool = False,
-    custom_encoder: dict[Any, Callable[[Any], Any]] | None = None,
+    custom_encoder: Mapping[type[Any], Callable[[Any], Any]] | None = None,
     excluded_key_prefixes: Sequence[str] = (),
 ) -> Any:
     custom_encoder = custom_encoder or {}

--- a/src/graphon/node_events/node.py
+++ b/src/graphon/node_events/node.py
@@ -41,7 +41,7 @@ class StreamChunkEvent(NodeEventBase):
     selector: Sequence[str] = Field(
         ...,
         description=(
-            "selector identifying the output location (e.g., ['nodeA', 'text'])",
+            "selector identifying the output location (e.g., ['nodeA', 'text'])"
         ),
     )
     chunk: str = Field(..., description="the actual chunk content")

--- a/src/graphon/nodes/base/node.py
+++ b/src/graphon/nodes/base/node.py
@@ -82,12 +82,12 @@ class _NodeRegistryMixin[NodeDataT: BaseNodeData]:
     """Node registry and config helpers kept separate from execution flow."""
 
     @classmethod
-    def get_registry_version(cls) -> int:
+    def get_registry_version(cls: type[Node[NodeDataT]]) -> int:
         return cls._registry_version
 
     @classmethod
     def extract_variable_selector_to_variable_mapping(
-        cls,
+        cls: type[Node[NodeDataT]],
         *,
         graph_config: Mapping[str, Any],
         config: NodeConfigDict,
@@ -144,7 +144,7 @@ class _NodeRegistryMixin[NodeDataT: BaseNodeData]:
 
     @classmethod
     def get_default_config(
-        cls,
+        cls: type[Node[NodeDataT]],
         filters: Mapping[str, object] | None = None,
     ) -> Mapping[str, object]:
         _ = filters
@@ -152,7 +152,7 @@ class _NodeRegistryMixin[NodeDataT: BaseNodeData]:
 
     @classmethod
     def get_node_type_classes_mapping(
-        cls,
+        cls: type[Node[NodeDataT]],
     ) -> Mapping[NodeType, Mapping[str, type[Node]]]:
         """Return a read-only view of the currently registered node classes.
 
@@ -176,7 +176,7 @@ class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
 
     @classmethod
     def validate_node_data(
-        cls,
+        cls: type[Node[NodeDataT]],
         node_data: BaseNodeData | Mapping[str, Any],
     ) -> NodeDataT:
         """Validate shared graph node payloads against the subclass-declared
@@ -197,7 +197,10 @@ class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
             payload = dict(node_data)
         return cast("NodeDataT", cls._node_data_type.model_validate(payload))
 
-    def init_node_data(self, data: BaseNodeData | Mapping[str, Any]) -> None:
+    def init_node_data(
+        self: Node[NodeDataT],
+        data: BaseNodeData | Mapping[str, Any],
+    ) -> None:
         """Hydrate `_node_data` for legacy callers that bypass `__init__`."""
         self._node_data = self.validate_node_data(cast("BaseNodeData", data))
 
@@ -259,22 +262,26 @@ class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
 class _NodeRuntimeMixin[NodeDataT: BaseNodeData]:
     """Run-context and execution-lifecycle accessors."""
 
-    def post_init(self) -> None:
+    def post_init(self: Node[NodeDataT]) -> None:
         """Optional hook for subclasses requiring extra initialization."""
         return
 
     @property
-    def graph_init_params(self) -> GraphInitParams:
+    def graph_init_params(self: Node[NodeDataT]) -> GraphInitParams:
         return self._graph_init_params
 
     @property
-    def run_context(self) -> Mapping[str, Any]:
+    def run_context(self: Node[NodeDataT]) -> Mapping[str, Any]:
         return self._run_context
 
-    def get_run_context_value(self, key: str, default: Any = None) -> Any:
+    def get_run_context_value(
+        self: Node[NodeDataT],
+        key: str,
+        default: Any = None,
+    ) -> Any:
         return self._run_context.get(key, default)
 
-    def require_run_context_value(self, key: str) -> Any:
+    def require_run_context_value(self: Node[NodeDataT], key: str) -> Any:
         value = self.get_run_context_value(key, _MISSING_RUN_CONTEXT_VALUE)
         if value is _MISSING_RUN_CONTEXT_VALUE:
             msg = f"run_context missing required key: {key}"
@@ -282,10 +289,10 @@ class _NodeRuntimeMixin[NodeDataT: BaseNodeData]:
         return value
 
     @property
-    def execution_id(self) -> str:
+    def execution_id(self: Node[NodeDataT]) -> str:
         return self._node_execution_id
 
-    def ensure_execution_id(self) -> str:
+    def ensure_execution_id(self: Node[NodeDataT]) -> str:
         if self._node_execution_id:
             return self._node_execution_id
 
@@ -297,13 +304,19 @@ class _NodeRuntimeMixin[NodeDataT: BaseNodeData]:
         self._node_execution_id = str(uuid4())
         return self._node_execution_id
 
-    def populate_start_event(self, event: NodeRunStartedEvent) -> None:
+    def populate_start_event(
+        self: Node[NodeDataT],
+        event: NodeRunStartedEvent,
+    ) -> None:
         """Allow subclasses to enrich the started event without cross-node imports
         in the base class.
         """
         _ = event
 
-    def blocks_variable_output(self, variable_selectors: set[tuple[str, ...]]) -> bool:
+    def blocks_variable_output(
+        self: Node[NodeDataT],
+        variable_selectors: set[tuple[str, ...]],
+    ) -> bool:
         """Check if this node blocks the output of specific variables.
 
         This method is used to determine if a node must complete execution before

--- a/src/graphon/nodes/code/code_node.py
+++ b/src/graphon/nodes/code/code_node.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Protocol, override
+from typing import TYPE_CHECKING, Any, Protocol, cast, override
 
 from graphon.entities.graph_config import NodeConfigDict
 from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
@@ -214,11 +214,8 @@ class CodeNode(Node[CodeNodeData]):
 
         if isinstance(value, float):
             decimal_value = Decimal(str(value)).normalize()
-            precision = (
-                -decimal_value.as_tuple().exponent
-                if decimal_value.as_tuple().exponent < 0
-                else 0
-            )  # type: ignore[operator]
+            exponent = decimal_value.as_tuple().exponent
+            precision = -exponent if isinstance(exponent, int) and exponent < 0 else 0
             # raise error if precision is too high
             if precision > self._limits.max_precision:
                 msg = (
@@ -343,7 +340,7 @@ class CodeNode(Node[CodeNodeData]):
         prefix: str,
         depth: int,
         output_schema: dict[str, CodeNodeData.Output] | None,
-    ) -> dict[str, Any] | None:
+    ) -> Mapping[str, Any] | None:
         output_path = self._output_path(prefix, output_name)
         if not isinstance(value, dict):
             if value is None:
@@ -445,13 +442,21 @@ class CodeNode(Node[CodeNodeData]):
             )
             raise OutputValidationError(msg)
 
-        return [
-            self._check_string(
-                value=inner_value,
-                variable=self._output_path_with_index(prefix, output_name, i),
+        normalized_values: list[str | None] = []
+        for i, inner_value in enumerate(value):
+            if inner_value is not None and not isinstance(inner_value, str):
+                msg = (
+                    f"Output {output_path}[{i}] must be a string, got "
+                    f"{type(inner_value).__name__} instead."
+                )
+                raise OutputValidationError(msg)
+            normalized_values.append(
+                self._check_string(
+                    value=inner_value,
+                    variable=self._output_path_with_index(prefix, output_name, i),
+                ),
             )
-            for i, inner_value in enumerate(value)
-        ]
+        return normalized_values
 
     def _transform_array_object_output(
         self,
@@ -461,7 +466,7 @@ class CodeNode(Node[CodeNodeData]):
         prefix: str,
         depth: int,
         output_schema: dict[str, CodeNodeData.Output] | None,
-    ) -> list[dict[str, Any] | None] | None:
+    ) -> list[Mapping[str, Any] | None] | None:
         output_path = self._output_path(prefix, output_name)
         if not isinstance(value, list):
             if value is None:
@@ -486,17 +491,20 @@ class CodeNode(Node[CodeNodeData]):
                 )
                 raise OutputValidationError(msg)
 
-        return [
-            None
-            if inner_value is None
-            else self._transform_result(
-                result=inner_value,
-                output_schema=output_schema,
-                prefix=self._output_path_with_index(prefix, output_name, i),
-                depth=depth + 1,
+        normalized_values: list[Mapping[str, Any] | None] = []
+        for i, inner_value in enumerate(value):
+            if inner_value is None:
+                normalized_values.append(None)
+                continue
+            normalized_values.append(
+                self._transform_result(
+                    result=cast("Mapping[str, Any]", inner_value),
+                    output_schema=output_schema,
+                    prefix=self._output_path_with_index(prefix, output_name, i),
+                    depth=depth + 1,
+                ),
             )
-            for i, inner_value in enumerate(value)
-        ]
+        return normalized_values
 
     def _transform_array_boolean_output(
         self,

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -6,7 +6,7 @@ import pathlib
 import tempfile
 import zipfile
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 import charset_normalizer
 import docx
@@ -126,6 +126,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
                 error=error_message,
             )
 
+        assert variable is not None
         value = variable.value
         inputs = {"variable_selector": variable_selector}
         if isinstance(value, list):
@@ -573,15 +574,11 @@ def _iter_docx_content_items(doc: Document) -> list[tuple[str, Table | Paragraph
 
 
 def _extract_docx_item_text(item_type: str, item: Table | Paragraph) -> str | None:
-    result: str | None
-    match item_type, item:
-        case "paragraph", Paragraph():
-            result = item.text
-        case "table", Table():
-            result = _extract_docx_table_text(item)
-        case _:
-            result = None
-    return result
+    if item_type == "paragraph" and isinstance(item, Paragraph):
+        return item.text
+    if item_type == "table" and isinstance(item, Table):
+        return _extract_docx_table_text(item)
+    return None
 
 
 def _extract_docx_table_text(item: Table) -> str | None:
@@ -619,7 +616,9 @@ def _download_file_content(http_client: HttpClientProtocol, file: File) -> bytes
 
     try:
         if file.transfer_method == FileTransferMethod.REMOTE_URL:
-            response = http_client.get(file.remote_url)
+            remote_url = file.remote_url
+            assert remote_url is not None
+            response = http_client.get(remote_url)
             response.raise_for_status()
             return response.content
         return file_manager.download(file)
@@ -721,7 +720,7 @@ def _extract_text_from_excel(file_content: bytes) -> str:
         markdown_table = ""
         for sheet_name in excel_file.sheet_names:
             try:
-                df = excel_file.parse(sheet_name=sheet_name)
+                df = cast("pd.DataFrame", excel_file.parse(sheet_name=sheet_name))
                 df = df.dropna(how="all")
 
                 # Combine multi-line text in each cell into a single line

--- a/src/graphon/nodes/if_else/if_else_node.py
+++ b/src/graphon/nodes/if_else/if_else_node.py
@@ -13,7 +13,7 @@ from graphon.nodes.base.node import Node
 from graphon.nodes.if_else.entities import IfElseNodeData
 from graphon.runtime.variable_pool import VariablePool
 from graphon.utils.condition.entities import Condition
-from graphon.utils.condition.processor import ConditionProcessor
+from graphon.utils.condition.processor import ConditionCheckResult, ConditionProcessor
 
 
 class IfElseNode(Node[IfElseNodeData]):
@@ -66,8 +66,7 @@ class IfElseNode(Node[IfElseNodeData]):
                 # the `cases` structure.
                 # Fallback to the legacy node shape when `cases` are not defined.
                 input_conditions, group_result, final_result = (
-                    _should_not_use_old_function(  # pyright: ignore [reportDeprecated]
-                        condition_processor=condition_processor,
+                    condition_processor.process_conditions(
                         variable_pool=self.graph_runtime_state.variable_pool,
                         conditions=self.node_data.conditions or [],
                         operator=self.node_data.logical_operator or "and",
@@ -128,7 +127,7 @@ def _should_not_use_old_function(
     variable_pool: VariablePool,
     conditions: list[Condition],
     operator: Literal["and", "or"],
-) -> bool:
+) -> ConditionCheckResult:
     return condition_processor.process_conditions(
         variable_pool=variable_pool,
         conditions=conditions,

--- a/src/graphon/nodes/template_transform/template_transform_node.py
+++ b/src/graphon/nodes/template_transform/template_transform_node.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, cast, override
 
 from graphon.entities.graph_config import NodeConfigDict
 from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
@@ -142,6 +142,9 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
                     isinstance(selector_part, str) for selector_part in value_selector
                 )
             ):
-                variable_mapping[node_id + "." + variable] = list(value_selector)
+                variable_mapping[node_id + "." + variable] = cast(
+                    Sequence[str],
+                    value_selector,
+                )
 
         return variable_mapping

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
 from pydantic import BaseModel, Field
@@ -264,51 +264,484 @@ class _GraphRuntimeStateSnapshot:
     graph_edge_states: dict[str, NodeState]
 
 
-class _GraphRuntimeStateBindingMixin:
-    """Graph attachment and child-engine orchestration helpers."""
+@dataclass(slots=True)
+class _GraphRuntimeExecutionData:
+    """Owned runtime data persisted across the graph execution lifecycle."""
 
-    def attach_graph(self: GraphRuntimeState, graph: GraphProtocol) -> None:
-        """Attach the materialized graph to the runtime state."""
-        if self._graph is not None and self._graph is not graph:
+    variable_pool: VariablePool
+    start_at: float
+    total_tokens: int = 0
+    llm_usage: LLMUsage = field(default_factory=LLMUsage.empty_usage)
+    outputs: dict[str, Any] = field(default_factory=dict)
+    node_run_steps: int = 0
+
+    def __post_init__(self) -> None:
+        if self.total_tokens < 0:
+            msg = "total_tokens must be non-negative"
+            raise ValueError(msg)
+        if self.node_run_steps < 0:
+            msg = "node_run_steps must be non-negative"
+            raise ValueError(msg)
+        self.llm_usage = self.llm_usage.model_copy()
+        self.outputs = deepcopy(self.outputs)
+
+    def get_llm_usage(self) -> LLMUsage:
+        return self.llm_usage.model_copy()
+
+    def set_llm_usage(self, value: LLMUsage) -> None:
+        self.llm_usage = value.model_copy()
+
+    def get_outputs(self) -> dict[str, Any]:
+        return deepcopy(self.outputs)
+
+    def set_outputs(self, value: dict[str, Any]) -> None:
+        self.outputs = deepcopy(value)
+
+    def set_output(self, key: str, value: object) -> None:
+        self.outputs[key] = deepcopy(value)
+
+    def get_output(self, key: str, default: object = None) -> object:
+        return deepcopy(self.outputs.get(key, default))
+
+    def update_outputs(self, updates: dict[str, object]) -> None:
+        for key, value in updates.items():
+            self.outputs[key] = deepcopy(value)
+
+    def set_total_tokens(self, value: int) -> None:
+        if value < 0:
+            msg = "total_tokens must be non-negative"
+            raise ValueError(msg)
+        self.total_tokens = value
+
+    def add_tokens(self, tokens: int) -> None:
+        if tokens < 0:
+            msg = "tokens must be non-negative"
+            raise ValueError(msg)
+        self.total_tokens += tokens
+
+    def set_node_run_steps(self, value: int) -> None:
+        if value < 0:
+            msg = "node_run_steps must be non-negative"
+            raise ValueError(msg)
+        self.node_run_steps = value
+
+    def increment_node_run_steps(self) -> None:
+        self.node_run_steps += 1
+
+    def apply_snapshot(self, snapshot: _GraphRuntimeStateSnapshot) -> None:
+        self.start_at = snapshot.start_at
+        self.total_tokens = snapshot.total_tokens
+        self.node_run_steps = snapshot.node_run_steps
+        self.llm_usage = snapshot.llm_usage.model_copy()
+        self.outputs = deepcopy(snapshot.outputs)
+        if snapshot.has_variable_pool:
+            self.variable_pool = snapshot.variable_pool
+
+
+@dataclass(slots=True)
+class _GraphRuntimeSuspensionState:
+    """Owned suspend/resume state that is restored around graph execution."""
+
+    pending_response_coordinator_dump: str | None = None
+    pending_graph_execution_workflow_id: str | None = None
+    paused_nodes: set[str] = field(default_factory=set)
+    deferred_nodes: set[str] = field(default_factory=set)
+    pending_graph_node_states: dict[str, NodeState] | None = None
+    pending_graph_edge_states: dict[str, NodeState] | None = None
+
+    def register_paused_node(self, node_id: str) -> None:
+        self.paused_nodes.add(node_id)
+
+    def get_paused_nodes(self) -> list[str]:
+        return list(self.paused_nodes)
+
+    def consume_paused_nodes(self) -> list[str]:
+        nodes = list(self.paused_nodes)
+        self.paused_nodes.clear()
+        return nodes
+
+    def register_deferred_node(self, node_id: str) -> None:
+        self.deferred_nodes.add(node_id)
+
+    def get_deferred_nodes(self) -> list[str]:
+        return list(self.deferred_nodes)
+
+    def consume_deferred_nodes(self) -> list[str]:
+        nodes = list(self.deferred_nodes)
+        self.deferred_nodes.clear()
+        return nodes
+
+    def apply_snapshot(self, snapshot: _GraphRuntimeStateSnapshot) -> None:
+        self.paused_nodes = set(snapshot.paused_nodes)
+        self.deferred_nodes = set(snapshot.deferred_nodes)
+        self.pending_graph_node_states = snapshot.graph_node_states or None
+        self.pending_graph_edge_states = snapshot.graph_edge_states or None
+
+    def snapshot_graph_state(
+        self,
+        graph: GraphProtocol | None,
+    ) -> _GraphStateSnapshot:
+        if graph is None:
+            if (
+                self.pending_graph_node_states is None
+                and self.pending_graph_edge_states is None
+            ):
+                return _GraphStateSnapshot()
+            return _GraphStateSnapshot(
+                nodes=self.pending_graph_node_states or {},
+                edges=self.pending_graph_edge_states or {},
+            )
+
+        nodes = graph.nodes
+        edges = graph.edges
+        if not isinstance(nodes, Mapping) or not isinstance(edges, Mapping):
+            return _GraphStateSnapshot()
+
+        node_states = {}
+        for node_id, node in nodes.items():
+            if isinstance(node_id, str):
+                node_states[node_id] = node.state
+
+        edge_states = {}
+        for edge_id, edge in edges.items():
+            if isinstance(edge_id, str):
+                edge_states[edge_id] = edge.state
+
+        return _GraphStateSnapshot(nodes=node_states, edges=edge_states)
+
+    def apply_pending_graph_state(self, graph: GraphProtocol | None) -> None:
+        if graph is None:
+            return
+        if self.pending_graph_node_states:
+            for node_id, state in self.pending_graph_node_states.items():
+                node = graph.nodes.get(node_id)
+                if node is not None:
+                    node.state = state
+        if self.pending_graph_edge_states:
+            for edge_id, state in self.pending_graph_edge_states.items():
+                edge = graph.edges.get(edge_id)
+                if edge is not None:
+                    edge.state = state
+        self.pending_graph_node_states = None
+        self.pending_graph_edge_states = None
+
+
+class _GraphRuntimeBindings:
+    """Owned runtime collaborators and graph attachment lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        runtime_state: GraphRuntimeState,
+        ready_queue: ReadyQueueProtocol | None = None,
+        graph_execution: GraphExecutionProtocol | None = None,
+        response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
+        graph: GraphProtocol | None = None,
+        execution_context: AbstractContextManager[object] | None = None,
+    ) -> None:
+        self._runtime_state = runtime_state
+        self.graph: GraphProtocol | None = None
+        self.ready_queue: ReadyQueueProtocol | None = ready_queue
+        self.graph_execution: GraphExecutionProtocol | None = graph_execution
+        self.response_coordinator: ResponseStreamCoordinatorProtocol | None = (
+            response_coordinator
+        )
+        self.execution_context: AbstractContextManager[object] = (
+            execution_context if execution_context is not None else nullcontext(None)
+        )
+        self.child_engine_builder: ChildGraphEngineBuilderProtocol | None = None
+
+        if graph is not None:
+            self.attach_graph(graph, runtime_state._suspension_state)
+
+    def attach_graph(
+        self,
+        graph: GraphProtocol,
+        suspension_state: _GraphRuntimeSuspensionState,
+    ) -> None:
+        if self.graph is not None and self.graph is not graph:
             msg = "GraphRuntimeState already attached to a different graph instance"
             raise ValueError(msg)
 
-        self._graph = graph
+        self.graph = graph
 
-        if self._response_coordinator is None:
-            self._response_coordinator = self._build_response_coordinator(graph)
+        if self.response_coordinator is None:
+            self.response_coordinator = self._runtime_state._build_response_coordinator(
+                graph,
+            )
 
         if (
-            self._pending_response_coordinator_dump is not None
-            and self._response_coordinator is not None
+            suspension_state.pending_response_coordinator_dump is not None
+            and self.response_coordinator is not None
         ):
-            self._response_coordinator.loads(self._pending_response_coordinator_dump)
-            self._pending_response_coordinator_dump = None
-        self._apply_pending_graph_state()
+            self.response_coordinator.loads(
+                suspension_state.pending_response_coordinator_dump,
+            )
+            suspension_state.pending_response_coordinator_dump = None
+
+        suspension_state.apply_pending_graph_state(graph)
 
     def configure(
-        self: GraphRuntimeState,
+        self,
+        suspension_state: _GraphRuntimeSuspensionState,
+        *,
+        graph: GraphProtocol | None = None,
+    ) -> None:
+        if graph is not None:
+            self.attach_graph(graph, suspension_state)
+
+        _ = self.get_ready_queue()
+        _ = self.get_graph_execution()
+        if self.graph is not None:
+            _ = self.get_response_coordinator()
+
+    def bind_child_engine_builder(
+        self,
+        builder: ChildGraphEngineBuilderProtocol,
+    ) -> None:
+        self.child_engine_builder = builder
+
+    def create_child_engine(
+        self,
+        *,
+        workflow_id: str,
+        graph_init_params: GraphInitParams,
+        root_node_id: str,
+        variable_pool: VariablePool | None = None,
+    ) -> Any:
+        if self.child_engine_builder is None:
+            msg = "Child engine builder is not configured."
+            raise ChildEngineBuilderNotConfiguredError(msg)
+
+        return self.child_engine_builder.build_child_engine(
+            workflow_id=workflow_id,
+            graph_init_params=graph_init_params,
+            parent_graph_runtime_state=self._runtime_state,
+            root_node_id=root_node_id,
+            variable_pool=variable_pool,
+        )
+
+    def get_ready_queue(self) -> ReadyQueueProtocol:
+        if self.ready_queue is None:
+            self.ready_queue = self._runtime_state._build_ready_queue()
+        return self.ready_queue
+
+    def get_graph_execution(self) -> GraphExecutionProtocol:
+        if self.graph_execution is None:
+            self.graph_execution = self._runtime_state._build_graph_execution()
+        return self.graph_execution
+
+    def get_response_coordinator(self) -> ResponseStreamCoordinatorProtocol:
+        if self.response_coordinator is None:
+            if self.graph is None:
+                msg = "Graph must be attached before accessing response coordinator"
+                raise ValueError(msg)
+            self.response_coordinator = self._runtime_state._build_response_coordinator(
+                self.graph,
+            )
+        return self.response_coordinator
+
+    def set_execution_context(
+        self,
+        value: AbstractContextManager[object] | None,
+    ) -> None:
+        self.execution_context = value if value is not None else nullcontext(None)
+
+    def restore_ready_queue(self, payload: str | None) -> None:
+        if payload is None:
+            self.ready_queue = None
+            return
+        self.ready_queue = self._runtime_state._build_ready_queue()
+        self.ready_queue.loads(payload)
+
+    def restore_graph_execution(
+        self,
+        payload: str | None,
+        suspension_state: _GraphRuntimeSuspensionState,
+    ) -> None:
+        self.graph_execution = None
+        suspension_state.pending_graph_execution_workflow_id = None
+
+        if payload is None:
+            return
+
+        try:
+            execution_payload = json.loads(payload)
+            workflow_id = execution_payload.get("workflow_id")
+            suspension_state.pending_graph_execution_workflow_id = workflow_id
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            suspension_state.pending_graph_execution_workflow_id = None
+
+        self.get_graph_execution().loads(payload)
+
+    def restore_response_coordinator(
+        self,
+        payload: str | None,
+        suspension_state: _GraphRuntimeSuspensionState,
+    ) -> None:
+        if payload is None:
+            suspension_state.pending_response_coordinator_dump = None
+            self.response_coordinator = None
+            return
+
+        if self.graph is not None:
+            self.get_response_coordinator().loads(payload)
+            suspension_state.pending_response_coordinator_dump = None
+            return
+
+        suspension_state.pending_response_coordinator_dump = payload
+        self.response_coordinator = None
+
+
+class GraphRuntimeState:  # noqa: PLR0904
+    """Mutable runtime state shared across graph execution components.
+
+    `GraphRuntimeState` encapsulates the runtime state of workflow execution,
+    including scheduling details, variable values, and timing information.
+
+    Values that are initialized prior to workflow execution and remain constant
+    throughout the execution should be part of `GraphInitParams` instead.
+    """
+
+    _execution_data: _GraphRuntimeExecutionData
+    _bindings: _GraphRuntimeBindings
+    _suspension_state: _GraphRuntimeSuspensionState
+
+    def __init__(
+        self,
+        *,
+        variable_pool: VariablePool,
+        start_at: float,
+        total_tokens: int = 0,
+        llm_usage: LLMUsage | None = None,
+        outputs: dict[str, object] | None = None,
+        node_run_steps: int = 0,
+        ready_queue: ReadyQueueProtocol | None = None,
+        graph_execution: GraphExecutionProtocol | None = None,
+        response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
+        graph: GraphProtocol | None = None,
+        execution_context: AbstractContextManager[object] | None = None,
+    ) -> None:
+        self._execution_data = _GraphRuntimeExecutionData(
+            variable_pool=variable_pool,
+            start_at=start_at,
+            total_tokens=total_tokens,
+            llm_usage=llm_usage or LLMUsage.empty_usage(),
+            outputs=outputs or {},
+            node_run_steps=node_run_steps,
+        )
+        self._suspension_state = _GraphRuntimeSuspensionState()
+        self._bindings = _GraphRuntimeBindings(
+            runtime_state=self,
+            ready_queue=ready_queue,
+            graph_execution=graph_execution,
+            response_coordinator=response_coordinator,
+            graph=graph,
+            execution_context=execution_context,
+        )
+
+    @property
+    def variable_pool(self) -> VariablePool:
+        return self._execution_data.variable_pool
+
+    @property
+    def ready_queue(self) -> ReadyQueueProtocol:
+        return self._bindings.get_ready_queue()
+
+    @property
+    def graph_execution(self) -> GraphExecutionProtocol:
+        return self._bindings.get_graph_execution()
+
+    @property
+    def response_coordinator(self) -> ResponseStreamCoordinatorProtocol:
+        return self._bindings.get_response_coordinator()
+
+    @property
+    def execution_context(self) -> AbstractContextManager[object]:
+        return self._bindings.execution_context
+
+    @execution_context.setter
+    def execution_context(
+        self,
+        value: AbstractContextManager[object] | None,
+    ) -> None:
+        self._bindings.set_execution_context(value)
+
+    @property
+    def start_at(self) -> float:
+        return self._execution_data.start_at
+
+    @start_at.setter
+    def start_at(self, value: float) -> None:
+        self._execution_data.start_at = value
+
+    @property
+    def total_tokens(self) -> int:
+        return self._execution_data.total_tokens
+
+    @total_tokens.setter
+    def total_tokens(self, value: int) -> None:
+        self._execution_data.set_total_tokens(value)
+
+    @property
+    def llm_usage(self) -> LLMUsage:
+        return self._execution_data.get_llm_usage()
+
+    @llm_usage.setter
+    def llm_usage(self, value: LLMUsage) -> None:
+        self._execution_data.set_llm_usage(value)
+
+    @property
+    def outputs(self) -> dict[str, Any]:
+        return self._execution_data.get_outputs()
+
+    @outputs.setter
+    def outputs(self, value: dict[str, Any]) -> None:
+        self._execution_data.set_outputs(value)
+
+    def set_output(self, key: str, value: object) -> None:
+        self._execution_data.set_output(key, value)
+
+    def get_output(self, key: str, default: object = None) -> object:
+        return self._execution_data.get_output(key, default)
+
+    def update_outputs(self, updates: dict[str, object]) -> None:
+        self._execution_data.update_outputs(updates)
+
+    @property
+    def node_run_steps(self) -> int:
+        return self._execution_data.node_run_steps
+
+    @node_run_steps.setter
+    def node_run_steps(self, value: int) -> None:
+        self._execution_data.set_node_run_steps(value)
+
+    def increment_node_run_steps(self) -> None:
+        self._execution_data.increment_node_run_steps()
+
+    def add_tokens(self, tokens: int) -> None:
+        self._execution_data.add_tokens(tokens)
+
+    def attach_graph(self, graph: GraphProtocol) -> None:
+        """Attach the materialized graph to the runtime state."""
+        self._bindings.attach_graph(graph, self._suspension_state)
+
+    def configure(
+        self,
         *,
         graph: GraphProtocol | None = None,
     ) -> None:
         """Ensure core collaborators are initialized with the provided context."""
-        if graph is not None:
-            self.attach_graph(graph)
-
-        # Ensure collaborators are instantiated
-        _ = self.ready_queue
-        _ = self.graph_execution
-        if self._graph is not None:
-            _ = self.response_coordinator
+        self._bindings.configure(self._suspension_state, graph=graph)
 
     def bind_child_engine_builder(
-        self: GraphRuntimeState,
+        self,
         builder: ChildGraphEngineBuilderProtocol,
     ) -> None:
-        self._child_engine_builder = builder
+        self._bindings.bind_child_engine_builder(builder)
 
     def create_child_engine(
-        self: GraphRuntimeState,
+        self,
         *,
         workflow_id: str,
         graph_init_params: GraphInitParams,
@@ -316,158 +749,40 @@ class _GraphRuntimeStateBindingMixin:
         variable_pool: VariablePool | None = None,
     ) -> Any:
         """Create a child graph engine whose runtime state derives from this parent."""
-        if self._child_engine_builder is None:
-            msg = "Child engine builder is not configured."
-            raise ChildEngineBuilderNotConfiguredError(msg)
-
-        return self._child_engine_builder.build_child_engine(
+        return self._bindings.create_child_engine(
             workflow_id=workflow_id,
             graph_init_params=graph_init_params,
-            parent_graph_runtime_state=self,
             root_node_id=root_node_id,
             variable_pool=variable_pool,
         )
 
-
-class _GraphRuntimeStateAccessorsMixin:
-    """Public scalar state and collaborator accessors."""
-
-    @property
-    def variable_pool(self: GraphRuntimeState) -> VariablePool:
-        return self._variable_pool
-
-    @property
-    def ready_queue(self: GraphRuntimeState) -> ReadyQueueProtocol:
-        if self._ready_queue is None:
-            self._ready_queue = self._build_ready_queue()
-        return self._ready_queue
-
-    @property
-    def graph_execution(self: GraphRuntimeState) -> GraphExecutionProtocol:
-        if self._graph_execution is None:
-            self._graph_execution = self._build_graph_execution()
-        return self._graph_execution
-
-    @property
-    def response_coordinator(
-        self: GraphRuntimeState,
-    ) -> ResponseStreamCoordinatorProtocol:
-        if self._response_coordinator is None:
-            if self._graph is None:
-                msg = "Graph must be attached before accessing response coordinator"
-                raise ValueError(msg)
-            self._response_coordinator = self._build_response_coordinator(self._graph)
-        return self._response_coordinator
-
-    @property
-    def execution_context(self: GraphRuntimeState) -> AbstractContextManager[object]:
-        return self._execution_context
-
-    @execution_context.setter
-    def execution_context(
-        self: GraphRuntimeState,
-        value: AbstractContextManager[object] | None,
-    ) -> None:
-        self._execution_context = value if value is not None else nullcontext(None)
-
-    @property
-    def start_at(self: GraphRuntimeState) -> float:
-        return self._start_at
-
-    @start_at.setter
-    def start_at(self: GraphRuntimeState, value: float) -> None:
-        self._start_at = value
-
-    @property
-    def total_tokens(self: GraphRuntimeState) -> int:
-        return self._total_tokens
-
-    @total_tokens.setter
-    def total_tokens(self: GraphRuntimeState, value: int) -> None:
-        if value < 0:
-            msg = "total_tokens must be non-negative"
-            raise ValueError(msg)
-        self._total_tokens = value
-
-    @property
-    def llm_usage(self: GraphRuntimeState) -> LLMUsage:
-        return self._llm_usage.model_copy()
-
-    @llm_usage.setter
-    def llm_usage(self: GraphRuntimeState, value: LLMUsage) -> None:
-        self._llm_usage = value.model_copy()
-
-    @property
-    def outputs(self: GraphRuntimeState) -> dict[str, Any]:
-        return deepcopy(self._outputs)
-
-    @outputs.setter
-    def outputs(self: GraphRuntimeState, value: dict[str, Any]) -> None:
-        self._outputs = deepcopy(value)
-
-    def set_output(self: GraphRuntimeState, key: str, value: object) -> None:
-        self._outputs[key] = deepcopy(value)
-
-    def get_output(
-        self: GraphRuntimeState,
-        key: str,
-        default: object = None,
-    ) -> object:
-        return deepcopy(self._outputs.get(key, default))
-
-    def update_outputs(
-        self: GraphRuntimeState,
-        updates: dict[str, object],
-    ) -> None:
-        for key, value in updates.items():
-            self._outputs[key] = deepcopy(value)
-
-    @property
-    def node_run_steps(self: GraphRuntimeState) -> int:
-        return self._node_run_steps
-
-    @node_run_steps.setter
-    def node_run_steps(self: GraphRuntimeState, value: int) -> None:
-        if value < 0:
-            msg = "node_run_steps must be non-negative"
-            raise ValueError(msg)
-        self._node_run_steps = value
-
-    def increment_node_run_steps(self: GraphRuntimeState) -> None:
-        self._node_run_steps += 1
-
-    def add_tokens(self: GraphRuntimeState, tokens: int) -> None:
-        if tokens < 0:
-            msg = "tokens must be non-negative"
-            raise ValueError(msg)
-        self._total_tokens += tokens
-
-
-class _GraphRuntimeStateSnapshotMixin:
-    """Snapshot serialization and suspension queue management."""
-
-    def dumps(self: GraphRuntimeState) -> str:
+    def dumps(self) -> str:
         """Serialize runtime state into a JSON string."""
         snapshot: dict[str, Any] = {
             "version": "1.0",
-            "start_at": self._start_at,
-            "total_tokens": self._total_tokens,
-            "node_run_steps": self._node_run_steps,
-            "llm_usage": self._llm_usage.model_dump(mode="json"),
-            "outputs": self.outputs,
+            "start_at": self._execution_data.start_at,
+            "total_tokens": self._execution_data.total_tokens,
+            "node_run_steps": self._execution_data.node_run_steps,
+            "llm_usage": self._execution_data.llm_usage.model_dump(mode="json"),
+            "outputs": self._execution_data.get_outputs(),
             "variable_pool": self.variable_pool.model_dump(mode="json"),
             "ready_queue": self.ready_queue.dumps(),
             "graph_execution": self.graph_execution.dumps(),
-            "paused_nodes": list(self._paused_nodes),
-            "deferred_nodes": list(self._deferred_nodes),
+            "paused_nodes": list(self._suspension_state.paused_nodes),
+            "deferred_nodes": list(self._suspension_state.deferred_nodes),
         }
 
-        graph_state = self._snapshot_graph_state()
-        if graph_state is not None:
-            snapshot["graph_state"] = graph_state
+        snapshot["graph_state"] = self._suspension_state.snapshot_graph_state(
+            self._bindings.graph,
+        )
 
-        if self._response_coordinator is not None and self._graph is not None:
-            snapshot["response_coordinator"] = self._response_coordinator.dumps()
+        if (
+            self._bindings.response_coordinator is not None
+            and self._bindings.graph is not None
+        ):
+            snapshot["response_coordinator"] = (
+                self._bindings.response_coordinator.dumps()
+            )
 
         return json.dumps(to_jsonable_python(snapshot))
 
@@ -490,130 +805,34 @@ class _GraphRuntimeStateSnapshotMixin:
         state._apply_snapshot(snapshot)
         return state
 
-    def loads(self: GraphRuntimeState, data: str | Mapping[str, Any]) -> None:
+    def loads(self, data: str | Mapping[str, Any]) -> None:
         """Restore runtime state from a serialized snapshot (legacy API)."""
         snapshot = self._parse_snapshot_payload(data)
         self._apply_snapshot(snapshot)
 
-    def register_paused_node(self: GraphRuntimeState, node_id: str) -> None:
+    def register_paused_node(self, node_id: str) -> None:
         """Record a node that should resume when execution is continued."""
-        self._paused_nodes.add(node_id)
+        self._suspension_state.register_paused_node(node_id)
 
-    def get_paused_nodes(self: GraphRuntimeState) -> list[str]:
+    def get_paused_nodes(self) -> list[str]:
         """Retrieve the list of paused nodes without mutating internal state."""
-        return list(self._paused_nodes)
+        return self._suspension_state.get_paused_nodes()
 
-    def consume_paused_nodes(self: GraphRuntimeState) -> list[str]:
+    def consume_paused_nodes(self) -> list[str]:
         """Retrieve and clear the list of paused nodes awaiting resume."""
-        nodes = list(self._paused_nodes)
-        self._paused_nodes.clear()
-        return nodes
+        return self._suspension_state.consume_paused_nodes()
 
-    def register_deferred_node(self: GraphRuntimeState, node_id: str) -> None:
+    def register_deferred_node(self, node_id: str) -> None:
         """Record a node that became ready during pause and should resume later."""
-        self._deferred_nodes.add(node_id)
+        self._suspension_state.register_deferred_node(node_id)
 
-    def get_deferred_nodes(self: GraphRuntimeState) -> list[str]:
+    def get_deferred_nodes(self) -> list[str]:
         """Retrieve deferred nodes without mutating internal state."""
-        return list(self._deferred_nodes)
+        return self._suspension_state.get_deferred_nodes()
 
-    def consume_deferred_nodes(self: GraphRuntimeState) -> list[str]:
+    def consume_deferred_nodes(self) -> list[str]:
         """Retrieve and clear deferred nodes awaiting resume."""
-        nodes = list(self._deferred_nodes)
-        self._deferred_nodes.clear()
-        return nodes
-
-
-class GraphRuntimeState(
-    _GraphRuntimeStateBindingMixin,
-    _GraphRuntimeStateAccessorsMixin,
-    _GraphRuntimeStateSnapshotMixin,
-):
-    """Mutable runtime state shared across graph execution components.
-
-    `GraphRuntimeState` encapsulates the runtime state of workflow execution,
-    including scheduling details, variable values, and timing information.
-
-    Values that are initialized prior to workflow execution and remain constant
-    throughout the execution should be part of `GraphInitParams` instead.
-    """
-
-    _variable_pool: VariablePool
-    _start_at: float
-    _total_tokens: int
-    _llm_usage: LLMUsage
-    _outputs: dict[str, Any]
-    _node_run_steps: int
-    _graph: GraphProtocol | None
-    _ready_queue: ReadyQueueProtocol | None
-    _graph_execution: GraphExecutionProtocol | None
-    _response_coordinator: ResponseStreamCoordinatorProtocol | None
-    _execution_context: AbstractContextManager[object]
-    _pending_response_coordinator_dump: str | None
-    _pending_graph_execution_workflow_id: str | None
-    _paused_nodes: set[str]
-    _deferred_nodes: set[str]
-    _child_engine_builder: ChildGraphEngineBuilderProtocol | None
-    _pending_graph_node_states: dict[str, NodeState] | None
-    _pending_graph_edge_states: dict[str, NodeState] | None
-
-    def __init__(
-        self,
-        *,
-        variable_pool: VariablePool,
-        start_at: float,
-        total_tokens: int = 0,
-        llm_usage: LLMUsage | None = None,
-        outputs: dict[str, object] | None = None,
-        node_run_steps: int = 0,
-        ready_queue: ReadyQueueProtocol | None = None,
-        graph_execution: GraphExecutionProtocol | None = None,
-        response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
-        graph: GraphProtocol | None = None,
-        execution_context: AbstractContextManager[object] | None = None,
-    ) -> None:
-        self._variable_pool = variable_pool
-        self._start_at = start_at
-
-        if total_tokens < 0:
-            msg = "total_tokens must be non-negative"
-            raise ValueError(msg)
-        self._total_tokens = total_tokens
-
-        self._llm_usage = (llm_usage or LLMUsage.empty_usage()).model_copy()
-        self._outputs = deepcopy(outputs) if outputs is not None else {}
-
-        if node_run_steps < 0:
-            msg = "node_run_steps must be non-negative"
-            raise ValueError(msg)
-        self._node_run_steps = node_run_steps
-
-        self._graph: GraphProtocol | None = None
-
-        self._ready_queue = ready_queue
-        self._graph_execution = graph_execution
-        self._response_coordinator = response_coordinator
-        # Application code injects this when worker threads must restore request
-        # or framework-local state. It is intentionally excluded from snapshots.
-        self._execution_context = (
-            execution_context if execution_context is not None else nullcontext(None)
-        )
-        self._pending_response_coordinator_dump: str | None = None
-        self._pending_graph_execution_workflow_id: str | None = None
-        self._paused_nodes: set[str] = set()
-        self._deferred_nodes: set[str] = set()
-        self._child_engine_builder: ChildGraphEngineBuilderProtocol | None = None
-
-        # Node and edges states needed to be restored into
-        # graph object.
-        #
-        # These two fields are non-None only when resuming from a snapshot.
-        # Once the graph is attached, these two fields will be set to None.
-        self._pending_graph_node_states: dict[str, NodeState] | None = None
-        self._pending_graph_edge_states: dict[str, NodeState] | None = None
-
-        if graph is not None:
-            self.attach_graph(graph)
+        return self._suspension_state.consume_deferred_nodes()
 
     # ------------------------------------------------------------------
     # Builders
@@ -629,8 +848,8 @@ class GraphRuntimeState(
         # Lazily import to keep the runtime domain decoupled from graph_engine modules.
         module = importlib.import_module("graphon.graph_engine.domain.graph_execution")
         graph_execution_cls = module.GraphExecution
-        workflow_id = self._pending_graph_execution_workflow_id or ""
-        self._pending_graph_execution_workflow_id = None
+        workflow_id = self._suspension_state.pending_graph_execution_workflow_id or ""
+        self._suspension_state.pending_graph_execution_workflow_id = None
         return cast(
             GraphExecutionProtocol, graph_execution_cls(workflow_id=workflow_id)
         )
@@ -706,111 +925,18 @@ class GraphRuntimeState(
         )
 
     def _apply_snapshot(self, snapshot: _GraphRuntimeStateSnapshot) -> None:
-        self._start_at = snapshot.start_at
-        self._total_tokens = snapshot.total_tokens
-        self._node_run_steps = snapshot.node_run_steps
-        self._llm_usage = snapshot.llm_usage.model_copy()
-        self._outputs = deepcopy(snapshot.outputs)
-        if snapshot.has_variable_pool or self._variable_pool is None:
-            self._variable_pool = snapshot.variable_pool
-
-        self._restore_ready_queue(snapshot.ready_queue_dump)
-        self._restore_graph_execution(snapshot.graph_execution_dump)
-        self._restore_response_coordinator(snapshot.response_coordinator_dump)
-        self._paused_nodes = set(snapshot.paused_nodes)
-        self._deferred_nodes = set(snapshot.deferred_nodes)
-        self._pending_graph_node_states = snapshot.graph_node_states or None
-        self._pending_graph_edge_states = snapshot.graph_edge_states or None
-        self._apply_pending_graph_state()
-
-    def _restore_ready_queue(self, payload: str | None) -> None:
-        if payload is not None:
-            self._ready_queue = self._build_ready_queue()
-            self._ready_queue.loads(payload)
-        else:
-            self._ready_queue = None
-
-    def _restore_graph_execution(self, payload: str | None) -> None:
-        self._graph_execution = None
-        self._pending_graph_execution_workflow_id = None
-
-        if payload is None:
-            return
-
-        try:
-            execution_payload = json.loads(payload)
-            self._pending_graph_execution_workflow_id = execution_payload.get(
-                "workflow_id",
-            )
-        except (json.JSONDecodeError, TypeError, AttributeError):
-            self._pending_graph_execution_workflow_id = None
-
-        self.graph_execution.loads(payload)
-
-    def _restore_response_coordinator(self, payload: str | None) -> None:
-        if payload is None:
-            self._pending_response_coordinator_dump = None
-            self._response_coordinator = None
-            return
-
-        if self._graph is not None:
-            self.response_coordinator.loads(payload)
-            self._pending_response_coordinator_dump = None
-            return
-
-        self._pending_response_coordinator_dump = payload
-        self._response_coordinator = None
-
-    def _snapshot_graph_state(self) -> _GraphStateSnapshot:
-        graph = self._graph
-        if graph is None:
-            if (
-                self._pending_graph_node_states is None
-                and self._pending_graph_edge_states is None
-            ):
-                return _GraphStateSnapshot()
-            return _GraphStateSnapshot(
-                nodes=self._pending_graph_node_states or {},
-                edges=self._pending_graph_edge_states or {},
-            )
-
-        nodes = graph.nodes
-        edges = graph.edges
-        if not isinstance(nodes, Mapping) or not isinstance(edges, Mapping):
-            return _GraphStateSnapshot()
-
-        node_states = {}
-        for node_id, node in nodes.items():
-            if not isinstance(node_id, str):
-                continue
-            node_states[node_id] = node.state
-
-        edge_states = {}
-        for edge_id, edge in edges.items():
-            if not isinstance(edge_id, str):
-                continue
-            edge_states[edge_id] = edge.state
-
-        return _GraphStateSnapshot(nodes=node_states, edges=edge_states)
-
-    def _apply_pending_graph_state(self) -> None:
-        if self._graph is None:
-            return
-        if self._pending_graph_node_states:
-            for node_id, state in self._pending_graph_node_states.items():
-                node = self._graph.nodes.get(node_id)
-                if node is None:
-                    continue
-                node.state = state
-        if self._pending_graph_edge_states:
-            for edge_id, state in self._pending_graph_edge_states.items():
-                edge = self._graph.edges.get(edge_id)
-                if edge is None:
-                    continue
-                edge.state = state
-
-        self._pending_graph_node_states = None
-        self._pending_graph_edge_states = None
+        self._execution_data.apply_snapshot(snapshot)
+        self._bindings.restore_ready_queue(snapshot.ready_queue_dump)
+        self._bindings.restore_graph_execution(
+            snapshot.graph_execution_dump,
+            self._suspension_state,
+        )
+        self._bindings.restore_response_coordinator(
+            snapshot.response_coordinator_dump,
+            self._suspension_state,
+        )
+        self._suspension_state.apply_snapshot(snapshot)
+        self._suspension_state.apply_pending_graph_state(self._bindings.graph)
 
 
 def _coerce_graph_state_map(payload: Any, key: str) -> dict[str, NodeState]:

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
 from pydantic import BaseModel, Field
 from pydantic_core import to_jsonable_python
@@ -18,6 +18,7 @@ from graphon.runtime.variable_pool import VariablePool
 if TYPE_CHECKING:
     from graphon.entities.graph_init_params import GraphInitParams
     from graphon.entities.pause_reason import PauseReason
+    from graphon.graph_events.node import NodeRunStreamChunkEvent, NodeRunSucceededEvent
 
 
 class ReadyQueueProtocol(Protocol):
@@ -57,7 +58,25 @@ class ReadyQueueProtocol(Protocol):
 class NodeExecutionProtocol(Protocol):
     """Structural interface for persisted per-node execution state."""
 
+    state: NodeState
+    retry_count: int
     execution_id: str | None
+
+    def mark_started(self, execution_id: str) -> None:
+        """Mark the node execution as started."""
+        ...
+
+    def mark_taken(self) -> None:
+        """Mark the node execution as successfully completed."""
+        ...
+
+    def mark_failed(self, error: str) -> None:
+        """Mark the node execution as failed with an error."""
+        ...
+
+    def increment_retry(self) -> None:
+        """Increment the retry counter for the node execution."""
+        ...
 
 
 class GraphExecutionProtocol(Protocol):
@@ -72,6 +91,7 @@ class GraphExecutionProtocol(Protocol):
     started: bool
     completed: bool
     aborted: bool
+    paused: bool
     error: Exception | None
     exceptions_count: int
     pause_reasons: list[PauseReason]
@@ -93,8 +113,30 @@ class GraphExecutionProtocol(Protocol):
         """Abort execution in response to an external stop request."""
         ...
 
+    def pause(self, reason: PauseReason) -> None:
+        """Pause execution with a recorded reason."""
+        ...
+
     def fail(self, error: Exception) -> None:
         """Record an unrecoverable error and end execution."""
+        ...
+
+    def record_node_failure(self) -> None:
+        """Increment the count of node failures observed during execution."""
+        ...
+
+    def get_or_create_node_execution(self, node_id: str) -> NodeExecutionProtocol:
+        """Return the execution entity for a node, creating it when needed."""
+        ...
+
+    @property
+    def is_paused(self) -> bool:
+        """Return whether the execution is currently paused."""
+        ...
+
+    @property
+    def has_error(self) -> bool:
+        """Return whether the execution has recorded an error."""
         ...
 
     def dumps(self) -> str:
@@ -111,6 +153,21 @@ class ResponseStreamCoordinatorProtocol(Protocol):
 
     def register(self, response_node_id: str) -> None:
         """Register a response node so its outputs can be streamed."""
+        ...
+
+    def track_node_execution(self, node_id: str, execution_id: str) -> None:
+        """Track the current execution id for a node."""
+        ...
+
+    def on_edge_taken(self, edge_id: str) -> Sequence[NodeRunStreamChunkEvent]:
+        """Update pending response sessions after an edge is taken."""
+        ...
+
+    def intercept_event(
+        self,
+        event: NodeRunStreamChunkEvent | NodeRunSucceededEvent,
+    ) -> Sequence[NodeRunStreamChunkEvent]:
+        """Translate node events into streamed response events."""
         ...
 
     def loads(self, data: str) -> None:
@@ -210,7 +267,7 @@ class _GraphRuntimeStateSnapshot:
 class _GraphRuntimeStateBindingMixin:
     """Graph attachment and child-engine orchestration helpers."""
 
-    def attach_graph(self, graph: GraphProtocol) -> None:
+    def attach_graph(self: GraphRuntimeState, graph: GraphProtocol) -> None:
         """Attach the materialized graph to the runtime state."""
         if self._graph is not None and self._graph is not graph:
             msg = "GraphRuntimeState already attached to a different graph instance"
@@ -229,7 +286,11 @@ class _GraphRuntimeStateBindingMixin:
             self._pending_response_coordinator_dump = None
         self._apply_pending_graph_state()
 
-    def configure(self, *, graph: GraphProtocol | None = None) -> None:
+    def configure(
+        self: GraphRuntimeState,
+        *,
+        graph: GraphProtocol | None = None,
+    ) -> None:
         """Ensure core collaborators are initialized with the provided context."""
         if graph is not None:
             self.attach_graph(graph)
@@ -241,13 +302,13 @@ class _GraphRuntimeStateBindingMixin:
             _ = self.response_coordinator
 
     def bind_child_engine_builder(
-        self,
+        self: GraphRuntimeState,
         builder: ChildGraphEngineBuilderProtocol,
     ) -> None:
         self._child_engine_builder = builder
 
     def create_child_engine(
-        self,
+        self: GraphRuntimeState,
         *,
         workflow_id: str,
         graph_init_params: GraphInitParams,
@@ -272,23 +333,25 @@ class _GraphRuntimeStateAccessorsMixin:
     """Public scalar state and collaborator accessors."""
 
     @property
-    def variable_pool(self) -> VariablePool:
+    def variable_pool(self: GraphRuntimeState) -> VariablePool:
         return self._variable_pool
 
     @property
-    def ready_queue(self) -> ReadyQueueProtocol:
+    def ready_queue(self: GraphRuntimeState) -> ReadyQueueProtocol:
         if self._ready_queue is None:
             self._ready_queue = self._build_ready_queue()
         return self._ready_queue
 
     @property
-    def graph_execution(self) -> GraphExecutionProtocol:
+    def graph_execution(self: GraphRuntimeState) -> GraphExecutionProtocol:
         if self._graph_execution is None:
             self._graph_execution = self._build_graph_execution()
         return self._graph_execution
 
     @property
-    def response_coordinator(self) -> ResponseStreamCoordinatorProtocol:
+    def response_coordinator(
+        self: GraphRuntimeState,
+    ) -> ResponseStreamCoordinatorProtocol:
         if self._response_coordinator is None:
             if self._graph is None:
                 msg = "Graph must be attached before accessing response coordinator"
@@ -297,73 +360,83 @@ class _GraphRuntimeStateAccessorsMixin:
         return self._response_coordinator
 
     @property
-    def execution_context(self) -> AbstractContextManager[object]:
+    def execution_context(self: GraphRuntimeState) -> AbstractContextManager[object]:
         return self._execution_context
 
     @execution_context.setter
-    def execution_context(self, value: AbstractContextManager[object] | None) -> None:
+    def execution_context(
+        self: GraphRuntimeState,
+        value: AbstractContextManager[object] | None,
+    ) -> None:
         self._execution_context = value if value is not None else nullcontext(None)
 
     @property
-    def start_at(self) -> float:
+    def start_at(self: GraphRuntimeState) -> float:
         return self._start_at
 
     @start_at.setter
-    def start_at(self, value: float) -> None:
+    def start_at(self: GraphRuntimeState, value: float) -> None:
         self._start_at = value
 
     @property
-    def total_tokens(self) -> int:
+    def total_tokens(self: GraphRuntimeState) -> int:
         return self._total_tokens
 
     @total_tokens.setter
-    def total_tokens(self, value: int) -> None:
+    def total_tokens(self: GraphRuntimeState, value: int) -> None:
         if value < 0:
             msg = "total_tokens must be non-negative"
             raise ValueError(msg)
         self._total_tokens = value
 
     @property
-    def llm_usage(self) -> LLMUsage:
+    def llm_usage(self: GraphRuntimeState) -> LLMUsage:
         return self._llm_usage.model_copy()
 
     @llm_usage.setter
-    def llm_usage(self, value: LLMUsage) -> None:
+    def llm_usage(self: GraphRuntimeState, value: LLMUsage) -> None:
         self._llm_usage = value.model_copy()
 
     @property
-    def outputs(self) -> dict[str, Any]:
+    def outputs(self: GraphRuntimeState) -> dict[str, Any]:
         return deepcopy(self._outputs)
 
     @outputs.setter
-    def outputs(self, value: dict[str, Any]) -> None:
+    def outputs(self: GraphRuntimeState, value: dict[str, Any]) -> None:
         self._outputs = deepcopy(value)
 
-    def set_output(self, key: str, value: object) -> None:
+    def set_output(self: GraphRuntimeState, key: str, value: object) -> None:
         self._outputs[key] = deepcopy(value)
 
-    def get_output(self, key: str, default: object = None) -> object:
+    def get_output(
+        self: GraphRuntimeState,
+        key: str,
+        default: object = None,
+    ) -> object:
         return deepcopy(self._outputs.get(key, default))
 
-    def update_outputs(self, updates: dict[str, object]) -> None:
+    def update_outputs(
+        self: GraphRuntimeState,
+        updates: dict[str, object],
+    ) -> None:
         for key, value in updates.items():
             self._outputs[key] = deepcopy(value)
 
     @property
-    def node_run_steps(self) -> int:
+    def node_run_steps(self: GraphRuntimeState) -> int:
         return self._node_run_steps
 
     @node_run_steps.setter
-    def node_run_steps(self, value: int) -> None:
+    def node_run_steps(self: GraphRuntimeState, value: int) -> None:
         if value < 0:
             msg = "node_run_steps must be non-negative"
             raise ValueError(msg)
         self._node_run_steps = value
 
-    def increment_node_run_steps(self) -> None:
+    def increment_node_run_steps(self: GraphRuntimeState) -> None:
         self._node_run_steps += 1
 
-    def add_tokens(self, tokens: int) -> None:
+    def add_tokens(self: GraphRuntimeState, tokens: int) -> None:
         if tokens < 0:
             msg = "tokens must be non-negative"
             raise ValueError(msg)
@@ -373,7 +446,7 @@ class _GraphRuntimeStateAccessorsMixin:
 class _GraphRuntimeStateSnapshotMixin:
     """Snapshot serialization and suspension queue management."""
 
-    def dumps(self) -> str:
+    def dumps(self: GraphRuntimeState) -> str:
         """Serialize runtime state into a JSON string."""
         snapshot: dict[str, Any] = {
             "version": "1.0",
@@ -399,7 +472,10 @@ class _GraphRuntimeStateSnapshotMixin:
         return json.dumps(to_jsonable_python(snapshot))
 
     @classmethod
-    def from_snapshot(cls, data: str | Mapping[str, Any]) -> GraphRuntimeState:
+    def from_snapshot(
+        cls: type[GraphRuntimeState],
+        data: str | Mapping[str, Any],
+    ) -> GraphRuntimeState:
         """Restore runtime state from a serialized snapshot."""
         snapshot = cls._parse_snapshot_payload(data)
 
@@ -414,34 +490,34 @@ class _GraphRuntimeStateSnapshotMixin:
         state._apply_snapshot(snapshot)
         return state
 
-    def loads(self, data: str | Mapping[str, Any]) -> None:
+    def loads(self: GraphRuntimeState, data: str | Mapping[str, Any]) -> None:
         """Restore runtime state from a serialized snapshot (legacy API)."""
         snapshot = self._parse_snapshot_payload(data)
         self._apply_snapshot(snapshot)
 
-    def register_paused_node(self, node_id: str) -> None:
+    def register_paused_node(self: GraphRuntimeState, node_id: str) -> None:
         """Record a node that should resume when execution is continued."""
         self._paused_nodes.add(node_id)
 
-    def get_paused_nodes(self) -> list[str]:
+    def get_paused_nodes(self: GraphRuntimeState) -> list[str]:
         """Retrieve the list of paused nodes without mutating internal state."""
         return list(self._paused_nodes)
 
-    def consume_paused_nodes(self) -> list[str]:
+    def consume_paused_nodes(self: GraphRuntimeState) -> list[str]:
         """Retrieve and clear the list of paused nodes awaiting resume."""
         nodes = list(self._paused_nodes)
         self._paused_nodes.clear()
         return nodes
 
-    def register_deferred_node(self, node_id: str) -> None:
+    def register_deferred_node(self: GraphRuntimeState, node_id: str) -> None:
         """Record a node that became ready during pause and should resume later."""
         self._deferred_nodes.add(node_id)
 
-    def get_deferred_nodes(self) -> list[str]:
+    def get_deferred_nodes(self: GraphRuntimeState) -> list[str]:
         """Retrieve deferred nodes without mutating internal state."""
         return list(self._deferred_nodes)
 
-    def consume_deferred_nodes(self) -> list[str]:
+    def consume_deferred_nodes(self: GraphRuntimeState) -> list[str]:
         """Retrieve and clear deferred nodes awaiting resume."""
         nodes = list(self._deferred_nodes)
         self._deferred_nodes.clear()
@@ -461,6 +537,25 @@ class GraphRuntimeState(
     Values that are initialized prior to workflow execution and remain constant
     throughout the execution should be part of `GraphInitParams` instead.
     """
+
+    _variable_pool: VariablePool
+    _start_at: float
+    _total_tokens: int
+    _llm_usage: LLMUsage
+    _outputs: dict[str, Any]
+    _node_run_steps: int
+    _graph: GraphProtocol | None
+    _ready_queue: ReadyQueueProtocol | None
+    _graph_execution: GraphExecutionProtocol | None
+    _response_coordinator: ResponseStreamCoordinatorProtocol | None
+    _execution_context: AbstractContextManager[object]
+    _pending_response_coordinator_dump: str | None
+    _pending_graph_execution_workflow_id: str | None
+    _paused_nodes: set[str]
+    _deferred_nodes: set[str]
+    _child_engine_builder: ChildGraphEngineBuilderProtocol | None
+    _pending_graph_node_states: dict[str, NodeState] | None
+    _pending_graph_edge_states: dict[str, NodeState] | None
 
     def __init__(
         self,
@@ -536,7 +631,9 @@ class GraphRuntimeState(
         graph_execution_cls = module.GraphExecution
         workflow_id = self._pending_graph_execution_workflow_id or ""
         self._pending_graph_execution_workflow_id = None
-        return graph_execution_cls(workflow_id=workflow_id)  # type: ignore[invalid-return-type]
+        return cast(
+            GraphExecutionProtocol, graph_execution_cls(workflow_id=workflow_id)
+        )
 
     def _build_response_coordinator(
         self,

--- a/src/graphon/utils/condition/processor.py
+++ b/src/graphon/utils/condition/processor.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Mapping, Sequence
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, cast
 
 from graphon.file import file_manager
 from graphon.file.enums import FileAttribute
@@ -67,7 +67,7 @@ class ConditionProcessor:
                     msg = "Sub variable is required"
                     raise ValueError(msg)
                 result = _process_sub_conditions(
-                    variable=variable,
+                    variable=cast("ArrayFileSegment", variable),
                     sub_conditions=condition.sub_variable_condition.conditions,
                     operator=condition.sub_variable_condition.logical_operator,
                 )
@@ -193,14 +193,15 @@ def _prepare_expected_value(
     if normalized_expected_value is None:
         return None
 
-    match variable, normalized_expected_value:
-        case ((BooleanSegment() | ArrayBooleanSegment()), list()):
-            result = [_convert_to_bool(item) for item in normalized_expected_value]
-        case ((BooleanSegment() | ArrayBooleanSegment()), _):
-            result = _convert_to_bool(normalized_expected_value)
-        case _:
-            result = normalized_expected_value
-    return result
+    if isinstance(variable, BooleanSegment | ArrayBooleanSegment):
+        if isinstance(normalized_expected_value, list):
+            return [_convert_to_bool(item) for item in normalized_expected_value]
+        return _convert_to_bool(normalized_expected_value)
+
+    return cast(
+        "str | Sequence[str] | bool | list[bool] | None",
+        normalized_expected_value,
+    )
 
 
 def _evaluate_all_of_condition(*, value: object, expected: object) -> bool:
@@ -263,32 +264,26 @@ def _assert_start_with(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    match value, expected:
-        case str(), str():
-            result = value.startswith(expected)
-        case str(), _:
-            msg = "Expected value must be a string for startswith"
-            raise ValueError(msg)
-        case _:
-            msg = "Invalid actual value type: string"
-            raise ValueError(msg)
-    return result
+    if not isinstance(value, str):
+        msg = "Invalid actual value type: string"
+        raise ValueError(msg)
+    if not isinstance(expected, str):
+        msg = "Expected value must be a string for startswith"
+        raise ValueError(msg)
+    return value.startswith(expected)
 
 
 def _assert_end_with(*, value: object, expected: object) -> bool:
     if not value:
         return False
 
-    match value, expected:
-        case str(), str():
-            result = value.endswith(expected)
-        case str(), _:
-            msg = "Expected value must be a string for endswith"
-            raise ValueError(msg)
-        case _:
-            msg = "Invalid actual value type: string"
-            raise ValueError(msg)
-    return result
+    if not isinstance(value, str):
+        msg = "Invalid actual value type: string"
+        raise ValueError(msg)
+    if not isinstance(expected, str):
+        msg = "Expected value must be a string for endswith"
+        raise ValueError(msg)
+    return value.endswith(expected)
 
 
 def _assert_is(*, value: object, expected: object) -> bool:

--- a/src/graphon/variables/factory.py
+++ b/src/graphon/variables/factory.py
@@ -5,7 +5,7 @@ independent from top-level API factory modules so graph nodes and state
 containers can operate without importing application-layer packages.
 """
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, cast
 from uuid import uuid4
 
@@ -96,6 +96,8 @@ _EMPTY_ARRAY_SEGMENT_FACTORY: Mapping[SegmentType, type[Segment]] = {
     SegmentType.ARRAY_FILE: ArrayFileSegment,
 }
 
+type SegmentFactory = Callable[..., Segment]
+
 
 def _build_non_list_segment(value: Any) -> Segment | None:
     match value:
@@ -137,7 +139,7 @@ def _build_list_segment(value: list[Any]) -> Segment:
     if segment_class is None:
         msg = f"not supported value {value}"
         raise ValueError(msg)
-    return segment_class(value=value)
+    return cast(SegmentFactory, segment_class)(value=value)
 
 
 def _build_empty_array_segment(
@@ -146,7 +148,13 @@ def _build_empty_array_segment(
     value: list[Any],
 ) -> Segment | None:
     segment_class = _EMPTY_ARRAY_SEGMENT_FACTORY.get(segment_type)
-    return None if segment_class is None else segment_class(value=value)
+    return (
+        None
+        if segment_class is None
+        else cast(SegmentFactory, segment_class)(
+            value=value,
+        )
+    )
 
 
 def _resolve_segment_class_for_type_match(

--- a/tests/entities/test_pause_reason.py
+++ b/tests/entities/test_pause_reason.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic import BaseModel, ValidationError
@@ -73,7 +73,7 @@ class TestPauseReasonDiscriminator:
 
     def test_model_construct_with_invalid_type(self):
         with pytest.raises(ValidationError):
-            _Holder(reason=object())  # type: ignore[arg-type]
+            _Holder(reason=cast(Any, object()))
 
     def test_unknown_type_fails_validation(self):
         with pytest.raises(ValidationError):

--- a/tests/entities/test_workflow_node_execution.py
+++ b/tests/entities/test_workflow_node_execution.py
@@ -127,62 +127,63 @@ class ProcessDataScenario:
     expected_response_data: dict[str, Any] | None
 
 
-class TestWorkflowNodeExecutionProcessDataScenarios:
-    def get_process_data_scenarios(self) -> list[ProcessDataScenario]:
-        return [
-            ProcessDataScenario(
-                name="no_process_data",
-                original_data=None,
-                truncated_data=None,
-                expected_truncated_flag=False,
-                expected_response_data=None,
-            ),
-            ProcessDataScenario(
-                name="process_data_without_truncation",
-                original_data={"small": "data"},
-                truncated_data=None,
-                expected_truncated_flag=False,
-                expected_response_data={"small": "data"},
-            ),
-            ProcessDataScenario(
-                name="process_data_with_truncation",
-                original_data={"large": "x" * 10000, "metadata": "info"},
-                truncated_data={"large": "[TRUNCATED]", "metadata": "info"},
-                expected_truncated_flag=True,
-                expected_response_data={"large": "[TRUNCATED]", "metadata": "info"},
-            ),
-            ProcessDataScenario(
-                name="empty_process_data",
-                original_data={},
-                truncated_data=None,
-                expected_truncated_flag=False,
-                expected_response_data={},
-            ),
-            ProcessDataScenario(
-                name="complex_nested_data_with_truncation",
-                original_data={
-                    "config": {"setting": "value"},
-                    "logs": ["log1", "log2"] * 1000,
-                    "status": "running",
-                },
-                truncated_data={
-                    "config": {"setting": "value"},
-                    "logs": "[TRUNCATED: 2000 items]",
-                    "status": "running",
-                },
-                expected_truncated_flag=True,
-                expected_response_data={
-                    "config": {"setting": "value"},
-                    "logs": "[TRUNCATED: 2000 items]",
-                    "status": "running",
-                },
-            ),
-        ]
+def _get_process_data_scenarios() -> list[ProcessDataScenario]:
+    return [
+        ProcessDataScenario(
+            name="no_process_data",
+            original_data=None,
+            truncated_data=None,
+            expected_truncated_flag=False,
+            expected_response_data=None,
+        ),
+        ProcessDataScenario(
+            name="process_data_without_truncation",
+            original_data={"small": "data"},
+            truncated_data=None,
+            expected_truncated_flag=False,
+            expected_response_data={"small": "data"},
+        ),
+        ProcessDataScenario(
+            name="process_data_with_truncation",
+            original_data={"large": "x" * 10000, "metadata": "info"},
+            truncated_data={"large": "[TRUNCATED]", "metadata": "info"},
+            expected_truncated_flag=True,
+            expected_response_data={"large": "[TRUNCATED]", "metadata": "info"},
+        ),
+        ProcessDataScenario(
+            name="empty_process_data",
+            original_data={},
+            truncated_data=None,
+            expected_truncated_flag=False,
+            expected_response_data={},
+        ),
+        ProcessDataScenario(
+            name="complex_nested_data_with_truncation",
+            original_data={
+                "config": {"setting": "value"},
+                "logs": ["log1", "log2"] * 1000,
+                "status": "running",
+            },
+            truncated_data={
+                "config": {"setting": "value"},
+                "logs": "[TRUNCATED: 2000 items]",
+                "status": "running",
+            },
+            expected_truncated_flag=True,
+            expected_response_data={
+                "config": {"setting": "value"},
+                "logs": "[TRUNCATED: 2000 items]",
+                "status": "running",
+            },
+        ),
+    ]
 
+
+class TestWorkflowNodeExecutionProcessDataScenarios:
     @pytest.mark.parametrize(
         "scenario",
-        get_process_data_scenarios(None),
-        ids=[scenario.name for scenario in get_process_data_scenarios(None)],
+        _get_process_data_scenarios(),
+        ids=[scenario.name for scenario in _get_process_data_scenarios()],
     )
     def test_process_data_scenarios(self, scenario: ProcessDataScenario):
         execution = WorkflowNodeExecution(

--- a/tests/graph/test_graph_validation.py
+++ b/tests/graph/test_graph_validation.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from dataclasses import dataclass
 
 import pytest
 
 from graphon.entities.base_node_data import BaseNodeData
+from graphon.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
 from graphon.entities.graph_init_params import GraphInitParams
 from graphon.enums import BuiltinNodeTypes, ErrorStrategy, NodeExecutionType, NodeType
 from graphon.graph.graph import Graph
 from graphon.graph.validation import GraphValidationError
+from graphon.node_events.base import NodeEventBase, NodeRunResult
 from graphon.nodes.base.node import Node
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.runtime.variable_pool import VariablePool
@@ -35,7 +37,7 @@ class _TestNode(Node[_TestNodeData]):
         self,
         *,
         node_id: str,
-        config: Mapping[str, object],
+        config: NodeConfigDict,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
@@ -50,7 +52,7 @@ class _TestNode(Node[_TestNodeData]):
         if isinstance(node_type_value, str):
             self.node_type = node_type_value
 
-    def _run(self) -> None:
+    def _run(self) -> NodeRunResult | Generator[NodeEventBase, None, None]:
         raise NotImplementedError
 
     def post_init(self) -> None:
@@ -77,7 +79,7 @@ class _SimpleNodeFactory:
         node_id = str(node_config["id"])
         return _TestNode(
             node_id=node_id,
-            config=node_config,
+            config=NodeConfigDictAdapter.validate_python(node_config),
             graph_init_params=self.graph_init_params,
             graph_runtime_state=self.graph_runtime_state,
         )

--- a/tests/helpers/builders.py
+++ b/tests/helpers/builders.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from graphon.entities.graph_init_params import GraphInitParams
 from graphon.runtime.variable_pool import VariablePool
-from graphon.variables.variables import VariableBase
+from graphon.variables.variables import Variable
 
 _FILE_REFERENCE_PREFIX = "dify-file-ref:"
 
@@ -40,8 +40,8 @@ def build_graph_init_params(
 
 def build_variable_pool(
     *,
-    system_variables: Sequence[VariableBase] = (),
-    conversation_variables: Sequence[VariableBase] = (),
+    system_variables: Sequence[Variable] = (),
+    conversation_variables: Sequence[Variable] = (),
     variables: Sequence[tuple[Sequence[str], Any]] = (),
 ) -> VariablePool:
     variable_pool = VariablePool(

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from pytest_mock import MockerFixture
 
+from graphon.entities.graph_config import NodeConfigDictAdapter
 from graphon.http import (
     HttpClientMaxRetriesExceededError,
     HttpResponse,
@@ -145,7 +146,7 @@ def test_httpx_http_client_raises_request_error_without_retry_wrapping(
 def test_http_request_node_uses_default_http_client_when_not_injected():
     node = HttpRequestNode(
         node_id="http",
-        config={
+        config=NodeConfigDictAdapter.validate_python({
             "id": "http",
             "data": {
                 "type": "http-request",
@@ -157,7 +158,7 @@ def test_http_request_node_uses_default_http_client_when_not_injected():
                 "params": "",
                 "body": {"type": "none", "data": []},
             },
-        },
+        }),
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),
@@ -174,14 +175,14 @@ def test_http_request_node_uses_default_http_client_when_not_injected():
 def test_document_extractor_node_uses_default_http_client_when_not_injected():
     node = DocumentExtractorNode(
         node_id="extractor",
-        config={
+        config=NodeConfigDictAdapter.validate_python({
             "id": "extractor",
             "data": {
                 "type": "document-extractor",
                 "title": "Document Extractor",
                 "variable_selector": ["inputs", "file"],
             },
-        },
+        }),
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),

--- a/tests/model_runtime/slim/test_runtime.py
+++ b/tests/model_runtime/slim/test_runtime.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import sys
 import textwrap
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 
-from graphon.model_runtime.entities.llm_entities import LLMResultWithStructuredOutput
+from graphon.model_runtime.entities.llm_entities import (
+    LLMResult,
+    LLMResultWithStructuredOutput,
+)
 from graphon.model_runtime.entities.message_entities import (
     PromptMessageTool,
     UserPromptMessage,
@@ -525,6 +529,7 @@ def test_slim_runtime_merges_non_stream_tool_call_deltas(tmp_path: Path) -> None
         stream=False,
     )
 
+    result = cast(LLMResult, result)
     assert len(result.message.tool_calls) == 1
     assert result.message.tool_calls[0].function.name == "extract"
     assert result.message.tool_calls[0].function.arguments == '{"query": "Hello"}'

--- a/tests/model_runtime/test_common_entities.py
+++ b/tests/model_runtime/test_common_entities.py
@@ -10,7 +10,7 @@ def test_i18n_object_accepts_alias_keys_and_fills_missing_zh_hans():
 
 
 def test_i18n_object_serializes_with_locale_aliases():
-    i18n = I18nObject(en_us="Temperature", zh_hans="温度")
+    i18n = I18nObject.model_validate({"en_US": "Temperature", "zh_Hans": "温度"})
 
     assert i18n.model_dump() == {"zh_Hans": "温度", "en_US": "Temperature"}
     assert jsonable_encoder(i18n) == {"zh_Hans": "温度", "en_US": "Temperature"}

--- a/tests/model_runtime/test_encoders.py
+++ b/tests/model_runtime/test_encoders.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from decimal import Decimal
 from enum import Enum
 from ipaddress import (
@@ -85,7 +85,7 @@ class TestEncoders:
         assert decimal_encoder(Decimal(-1)) == -1
 
     def test_generate_encoders_by_class_tuples(self):
-        type_map = {int: str, float: str, str: int}
+        type_map: dict[Any, Callable[[Any], Any]] = {int: str, float: str, str: int}
         result = generate_encoders_by_class_tuples(type_map)
         assert result[str] == (int, float)
         assert result[int] == (str,)
@@ -148,7 +148,7 @@ class TestEncoders:
         assert jsonable_encoder(gen()) == [1, 2]
 
     def test_jsonable_encoder_custom_encoder(self):
-        custom = {int: lambda x: str(x + 1)}
+        custom: dict[Any, Callable[[Any], Any]] = {int: lambda x: str(x + 1)}
         assert jsonable_encoder(1, custom_encoder=custom) == "2"
 
         class SubInt(int):

--- a/tests/model_runtime/test_large_language_model_non_stream_result.py
+++ b/tests/model_runtime/test_large_language_model_non_stream_result.py
@@ -8,6 +8,7 @@ from graphon.model_runtime.entities.llm_entities import (
 )
 from graphon.model_runtime.entities.message_entities import (
     AssistantPromptMessage,
+    PromptMessageContentUnionTypes,
     TextPromptMessageContent,
     UserPromptMessage,
 )
@@ -19,7 +20,7 @@ from graphon.model_runtime.model_providers.base.large_language_model import (
 def _make_chunk(
     *,
     model: str = "test-model",
-    content: str | list[TextPromptMessageContent] | None,
+    content: str | list[PromptMessageContentUnionTypes] | None,
     tool_calls: list[AssistantPromptMessage.ToolCall] | None = None,
     usage: LLMUsage | None = None,
     system_fingerprint: str | None = None,
@@ -99,7 +100,7 @@ def test_non_stream_result_merges_first_chunk_content_and_tool_calls():
 def test__normalize_non_stream_runtime_result__from_first_chunk_list_content():
     prompt_messages = [UserPromptMessage(content="hi")]
 
-    content_list = [
+    content_list: list[PromptMessageContentUnionTypes] = [
         TextPromptMessageContent(data="a"),
         TextPromptMessageContent(data="b"),
     ]

--- a/tests/model_runtime/test_message_entities.py
+++ b/tests/model_runtime/test_message_entities.py
@@ -22,9 +22,9 @@ def test_user_prompt_message_get_text_content_keeps_only_text_items() -> None:
 
 
 def test_prompt_message_normalizes_dict_content_items_for_serialization() -> None:
-    message = UserPromptMessage(
-        content=[{"type": "text", "data": "hello"}],
-    )
+    message = UserPromptMessage.model_validate({
+        "content": [{"type": "text", "data": "hello"}],
+    })
 
     assert isinstance(message.content, list)
     assert isinstance(message.content[0], TextPromptMessageContent)

--- a/tests/model_runtime/test_model_dispatch.py
+++ b/tests/model_runtime/test_model_dispatch.py
@@ -79,7 +79,7 @@ def test_model_provider_factory_uses_model_class_map(
 ) -> None:
     provider = ProviderEntity(
         provider="test-provider",
-        label=I18nObject(en_us="Test Provider"),
+        label=I18nObject(en_US="Test Provider"),
         supported_model_types=[model_type],
         configurate_methods=[],
     )

--- a/tests/node_events/test_node_event_aliases.py
+++ b/tests/node_events/test_node_event_aliases.py
@@ -1,3 +1,5 @@
+from graphon.entities.pause_reason import SchedulingPause
+from graphon.enums import WorkflowNodeExecutionStatus
 from graphon.graph_events.node import (
     NodeRunPauseRequestedEvent,
     NodeRunVariableUpdatedEvent,
@@ -22,7 +24,9 @@ def test_variable_alias_still_validates_in_event_models() -> None:
         "id": "evt-1",
         "node_id": "start",
         "node_type": "start",
-        "node_run_result": NodeRunResult(status="succeeded").model_dump(mode="python"),
+        "node_run_result": NodeRunResult(
+            status=WorkflowNodeExecutionStatus.SUCCEEDED,
+        ).model_dump(mode="python"),
     })
 
     assert node_event.variable.value == "hello"
@@ -38,8 +42,12 @@ def test_pause_reason_alias_still_validates_in_event_models() -> None:
         "id": "evt-2",
         "node_id": "start",
         "node_type": "start",
-        "node_run_result": NodeRunResult(status="succeeded").model_dump(mode="python"),
+        "node_run_result": NodeRunResult(
+            status=WorkflowNodeExecutionStatus.SUCCEEDED,
+        ).model_dump(mode="python"),
     })
 
+    assert isinstance(node_event.reason, SchedulingPause)
+    assert isinstance(graph_event.reason, SchedulingPause)
     assert node_event.reason.message == "Hold on"
     assert graph_event.reason.message == "Hold on"

--- a/tests/nodes/http_request/test_dispatch.py
+++ b/tests/nodes/http_request/test_dispatch.py
@@ -23,13 +23,13 @@ def _build_http_request_config() -> HttpRequestNodeConfig:
 
 
 def test_http_request_node_extracts_variable_selectors_from_form_data() -> None:
-    node_data = HttpRequestNodeData(
-        method="post",
-        url="https://example.com/{{#start.id#}}",
-        authorization={"type": "no-auth"},
-        headers="X-Trace: {{#sys.trace#}}",
-        params="q: {{#input.query#}}",
-        body={
+    node_data = HttpRequestNodeData.model_validate({
+        "method": "post",
+        "url": "https://example.com/{{#start.id#}}",
+        "authorization": {"type": "no-auth"},
+        "headers": "X-Trace: {{#sys.trace#}}",
+        "params": "q: {{#input.query#}}",
+        "body": {
             "type": "form-data",
             "data": [
                 {
@@ -44,7 +44,7 @@ def test_http_request_node_extracts_variable_selectors_from_form_data() -> None:
                 },
             ],
         },
-    )
+    })
 
     mapping = HttpRequestNode._extract_variable_selector_to_variable_mapping(
         graph_config={},
@@ -63,13 +63,13 @@ def test_http_request_node_extracts_variable_selectors_from_form_data() -> None:
 
 def test_executor_initializes_json_body_with_body_handler_map() -> None:
     executor = Executor(
-        node_data=HttpRequestNodeData(
-            method="post",
-            url="https://example.com",
-            authorization={"type": "no-auth"},
-            headers="",
-            params="",
-            body={
+        node_data=HttpRequestNodeData.model_validate({
+            "method": "post",
+            "url": "https://example.com",
+            "authorization": {"type": "no-auth"},
+            "headers": "",
+            "params": "",
+            "body": {
                 "type": "json",
                 "data": [
                     {
@@ -78,7 +78,7 @@ def test_executor_initializes_json_body_with_body_handler_map() -> None:
                     },
                 ],
             },
-        ),
+        }),
         timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
         variable_pool=build_variable_pool(),
         http_request_config=_build_http_request_config(),
@@ -92,13 +92,13 @@ def test_executor_initializes_json_body_with_body_handler_map() -> None:
 def test_executor_initializes_form_data_placeholder_when_no_files_resolve() -> None:
     file_manager = MagicMock()
     executor = Executor(
-        node_data=HttpRequestNodeData(
-            method="post",
-            url="https://example.com",
-            authorization={"type": "no-auth"},
-            headers="",
-            params="",
-            body={
+        node_data=HttpRequestNodeData.model_validate({
+            "method": "post",
+            "url": "https://example.com",
+            "authorization": {"type": "no-auth"},
+            "headers": "",
+            "params": "",
+            "body": {
                 "type": "form-data",
                 "data": [
                     {"key": "note", "type": "text", "value": "hello"},
@@ -109,7 +109,7 @@ def test_executor_initializes_form_data_placeholder_when_no_files_resolve() -> N
                     },
                 ],
             },
-        ),
+        }),
         timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
         variable_pool=build_variable_pool(),
         http_request_config=_build_http_request_config(),
@@ -126,23 +126,23 @@ def test_executor_initializes_form_data_placeholder_when_no_files_resolve() -> N
 
 def test_executor_assembling_headers_applies_bearer_auth_and_content_type() -> None:
     executor = Executor(
-        node_data=HttpRequestNodeData(
-            method="post",
-            url="https://example.com",
-            authorization={
+        node_data=HttpRequestNodeData.model_validate({
+            "method": "post",
+            "url": "https://example.com",
+            "authorization": {
                 "type": "api-key",
                 "config": {
                     "type": "bearer",
                     "api_key": "secret-token",
                 },
             },
-            headers="X-Test: 1",
-            params="",
-            body={
+            "headers": "X-Test: 1",
+            "params": "",
+            "body": {
                 "type": "raw-text",
                 "data": [{"type": "text", "value": "payload"}],
             },
-        ),
+        }),
         timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
         variable_pool=build_variable_pool(),
         http_request_config=_build_http_request_config(),
@@ -159,23 +159,23 @@ def test_executor_assembling_headers_applies_bearer_auth_and_content_type() -> N
 
 def test_executor_to_log_masks_authorization_and_logs_raw_text_body() -> None:
     executor = Executor(
-        node_data=HttpRequestNodeData(
-            method="post",
-            url="https://example.com/api?debug=1",
-            authorization={
+        node_data=HttpRequestNodeData.model_validate({
+            "method": "post",
+            "url": "https://example.com/api?debug=1",
+            "authorization": {
                 "type": "api-key",
                 "config": {
                     "type": "bearer",
                     "api_key": "secret-token",
                 },
             },
-            headers="X-Test: 1",
-            params="",
-            body={
+            "headers": "X-Test: 1",
+            "params": "",
+            "body": {
                 "type": "raw-text",
                 "data": [{"type": "text", "value": "payload"}],
             },
-        ),
+        }),
         timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
         variable_pool=build_variable_pool(),
         http_request_config=_build_http_request_config(),
@@ -193,17 +193,17 @@ def test_executor_to_log_masks_authorization_and_logs_raw_text_body() -> None:
 
 def test_executor_to_log_renders_file_entries_for_multipart_body() -> None:
     executor = Executor(
-        node_data=HttpRequestNodeData(
-            method="post",
-            url="https://example.com/upload",
-            authorization={"type": "no-auth"},
-            headers="",
-            params="",
-            body={
+        node_data=HttpRequestNodeData.model_validate({
+            "method": "post",
+            "url": "https://example.com/upload",
+            "authorization": {"type": "no-auth"},
+            "headers": "",
+            "params": "",
+            "body": {
                 "type": "form-data",
                 "data": [{"key": "note", "type": "text", "value": "hello"}],
             },
-        ),
+        }),
         timeout=HttpRequestNodeTimeout(connect=1, read=1, write=1),
         variable_pool=build_variable_pool(),
         http_request_config=_build_http_request_config(),

--- a/tests/nodes/parameter_extractor/test_entities.py
+++ b/tests/nodes/parameter_extractor/test_entities.py
@@ -11,30 +11,30 @@ from graphon.variables.types import SegmentType
 
 def test_parameter_config_maps_legacy_types() -> None:
     assert (
-        ParameterConfig(
-            name="flag",
-            type="bool",
-            description="legacy bool",
-            required=True,
-        ).type
+        ParameterConfig.model_validate({
+            "name": "flag",
+            "type": "bool",
+            "description": "legacy bool",
+            "required": True,
+        }).type
         == SegmentType.BOOLEAN
     )
     assert (
-        ParameterConfig(
-            name="choice",
-            type="select",
-            description="legacy select",
-            required=False,
-        ).type
+        ParameterConfig.model_validate({
+            "name": "choice",
+            "type": "select",
+            "description": "legacy select",
+            "required": False,
+        }).type
         == SegmentType.STRING
     )
 
 
 def test_parameter_extractor_node_data_builds_parameter_json_schema() -> None:
-    node_data = ParameterExtractorNodeData(
-        model={"provider": "test", "name": "model", "mode": LLMMode.CHAT},
-        query=["start", "query"],
-        parameters=[
+    node_data = ParameterExtractorNodeData.model_validate({
+        "model": {"provider": "test", "name": "model", "mode": LLMMode.CHAT},
+        "query": ["start", "query"],
+        "parameters": [
             {
                 "name": "location",
                 "type": "string",
@@ -49,8 +49,8 @@ def test_parameter_extractor_node_data_builds_parameter_json_schema() -> None:
                 "options": ["a", "b"],
             },
         ],
-        reasoning_mode="function_call",
-    )
+        "reasoning_mode": "function_call",
+    })
 
     assert node_data.get_parameter_json_schema() == {
         "type": "object",
@@ -72,10 +72,10 @@ def test_parameter_extractor_node_data_builds_parameter_json_schema() -> None:
 
 def test_parameter_extractor_transform_result_uses_type_dispatch() -> None:
     node = ParameterExtractorNode.__new__(ParameterExtractorNode)
-    node_data = ParameterExtractorNodeData(
-        model={"provider": "test", "name": "model", "mode": LLMMode.CHAT},
-        query=["start", "query"],
-        parameters=[
+    node_data = ParameterExtractorNodeData.model_validate({
+        "model": {"provider": "test", "name": "model", "mode": LLMMode.CHAT},
+        "query": ["start", "query"],
+        "parameters": [
             {
                 "name": "age",
                 "type": "number",
@@ -125,8 +125,8 @@ def test_parameter_extractor_transform_result_uses_type_dispatch() -> None:
                 "required": False,
             },
         ],
-        reasoning_mode="function_call",
-    )
+        "reasoning_mode": "function_call",
+    })
 
     transformed = node._transform_result(
         node_data,

--- a/tests/nodes/parameter_extractor/test_prompts.py
+++ b/tests/nodes/parameter_extractor/test_prompts.py
@@ -1,6 +1,7 @@
 import time
 from unittest.mock import Mock
 
+from graphon.entities.graph_config import NodeConfigDictAdapter
 from graphon.enums import BuiltinNodeTypes
 from graphon.model_runtime.entities.llm_entities import LLMMode
 from graphon.model_runtime.entities.message_entities import PromptMessageRole
@@ -16,11 +17,12 @@ from graphon.nodes.parameter_extractor.prompts import (
     FUNCTION_CALLING_EXTRACTOR_USER_TEMPLATE,
 )
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
+from graphon.runtime.variable_pool import VariablePool
 
 from ...helpers import build_graph_init_params, build_variable_pool
 
 
-def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, object]:
+def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, VariablePool]:
     variable_pool = build_variable_pool(variables=[(("start", "rule"), "strictly")])
     runtime_state = GraphRuntimeState(
         variable_pool=variable_pool,
@@ -29,7 +31,7 @@ def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, object]:
     init_params = build_graph_init_params(graph_config={"nodes": [], "edges": []})
     node = ParameterExtractorNode(
         node_id="extractor",
-        config={
+        config=NodeConfigDictAdapter.validate_python({
             "id": "extractor",
             "data": {
                 "type": BuiltinNodeTypes.PARAMETER_EXTRACTOR,
@@ -51,7 +53,7 @@ def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, object]:
                 "instruction": "Follow {{#start.rule#}} instructions.",
                 "reasoning_mode": "function_call",
             },
-        },
+        }),
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
         model_instance=Mock(),

--- a/tests/nodes/test_code_node.py
+++ b/tests/nodes/test_code_node.py
@@ -33,3 +33,21 @@ def test_transform_result_reports_nested_missing_field_without_leading_dot() -> 
 
     with pytest.raises(OutputValidationError, match=r"Output root\.child is missing\."):
         node._transform_result(result={"root": {}}, output_schema=output_schema)
+
+
+def test_transform_result_rejects_non_string_array_elements_with_validation_error() -> (
+    None
+):
+    node = _build_code_node()
+    output_schema = {
+        "items": CodeNodeData.Output(type=SegmentType.ARRAY_STRING),
+    }
+
+    with pytest.raises(
+        OutputValidationError,
+        match=r"Output items\[1\] must be a string, got int instead\.",
+    ):
+        node._transform_result(
+            result={"items": ["valid", 1]},
+            output_schema=output_schema,
+        )

--- a/tests/nodes/tool/test_entities.py
+++ b/tests/nodes/tool/test_entities.py
@@ -20,29 +20,29 @@ def test_tool_entity_rejects_non_scalar_configuration_value() -> None:
         ValueError,
         match="timeout must be one of: str, int, float, bool",
     ):
-        ToolEntity(
-            provider_id="provider-1",
-            provider_type="builtin",
-            provider_name="Built-in",
-            tool_name="tool",
-            tool_label="Tool",
-            tool_configurations={"timeout": ["10"]},
-        )
+        ToolEntity.model_validate({
+            "provider_id": "provider-1",
+            "provider_type": "builtin",
+            "provider_name": "Built-in",
+            "tool_name": "tool",
+            "tool_label": "Tool",
+            "tool_configurations": {"timeout": ["10"]},
+        })
 
 
 def test_tool_node_filters_none_and_empty_tool_inputs() -> None:
-    node_data = ToolNodeData(
-        provider_id="provider-1",
-        provider_type="builtin",
-        provider_name="Built-in",
-        tool_name="tool",
-        tool_label="Tool",
-        tool_configurations={"timeout": 10},
-        tool_parameters={
+    node_data = ToolNodeData.model_validate({
+        "provider_id": "provider-1",
+        "provider_type": "builtin",
+        "provider_name": "Built-in",
+        "tool_name": "tool",
+        "tool_label": "Tool",
+        "tool_configurations": {"timeout": 10},
+        "tool_parameters": {
             "answer": {"type": "mixed", "value": "ok"},
             "ignored_none": None,
             "ignored_empty": {"type": "mixed", "value": None},
         },
-    )
+    })
 
     assert set(node_data.tool_parameters) == {"answer"}

--- a/tests/nodes/tool/test_tool_node.py
+++ b/tests/nodes/tool/test_tool_node.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,24 +13,32 @@ from graphon.nodes.tool.tool_node import ToolNode
 from graphon.nodes.tool_runtime_entities import ToolRuntimeHandle, ToolRuntimeMessage
 
 
-def _build_tool_node() -> ToolNode:
+def _message_stream(
+    *messages: ToolRuntimeMessage,
+) -> Generator[ToolRuntimeMessage, None, None]:
+    yield from messages
+
+
+def _build_tool_node() -> tuple[ToolNode, MagicMock, MagicMock]:
     node = ToolNode.__new__(ToolNode)
     node._node_id = "node-1"
-    node._runtime = MagicMock()
-    node._runtime.get_usage.return_value = LLMUsage.empty_usage()
-    node._tool_file_manager_factory = MagicMock()
-    return node
+    runtime = MagicMock()
+    runtime.get_usage.return_value = LLMUsage.empty_usage()
+    tool_file_manager_factory = MagicMock()
+    node._runtime = cast(Any, runtime)
+    node._tool_file_manager_factory = cast(Any, tool_file_manager_factory)
+    return node, runtime, tool_file_manager_factory
 
 
 def test_transform_message_dispatches_text_variable_and_file_messages() -> None:
-    node = _build_tool_node()
+    node, _runtime, _tool_file_manager_factory = _build_tool_node()
     file_obj = File(
         file_type=FileType.DOCUMENT,
         transfer_method=FileTransferMethod.LOCAL_FILE,
         reference="file-ref",
         filename="doc.txt",
     )
-    messages = iter([
+    messages = _message_stream(
         ToolRuntimeMessage(
             type=ToolRuntimeMessage.MessageType.TEXT,
             message=ToolRuntimeMessage.TextMessage(text="hello"),
@@ -46,7 +56,7 @@ def test_transform_message_dispatches_text_variable_and_file_messages() -> None:
             message=ToolRuntimeMessage.FileMessage(),
             meta={"file": file_obj},
         ),
-    ])
+    )
 
     events = list(
         node._transform_message(
@@ -80,7 +90,7 @@ def test_transform_message_dispatches_text_variable_and_file_messages() -> None:
 
 
 def test_transform_message_dispatches_image_link_with_handler_map() -> None:
-    node = _build_tool_node()
+    node, runtime, tool_file_manager_factory = _build_tool_node()
     tool_file = File(
         file_type=FileType.IMAGE,
         transfer_method=FileTransferMethod.TOOL_FILE,
@@ -92,15 +102,15 @@ def test_transform_message_dispatches_image_link_with_handler_map() -> None:
         transfer_method=FileTransferMethod.TOOL_FILE,
         reference="tool-file-1",
     )
-    node._tool_file_manager_factory.get_file_generator_by_tool_file_id.return_value = (
+    tool_file_manager_factory.get_file_generator_by_tool_file_id.return_value = (
         None,
         tool_file,
     )
-    node._runtime.build_file_reference.return_value = built_file
+    runtime.build_file_reference.return_value = built_file
 
     events = list(
         node._transform_message(
-            messages=iter([
+            messages=_message_stream(
                 ToolRuntimeMessage(
                     type=ToolRuntimeMessage.MessageType.IMAGE_LINK,
                     message=ToolRuntimeMessage.TextMessage(
@@ -108,7 +118,7 @@ def test_transform_message_dispatches_image_link_with_handler_map() -> None:
                     ),
                     meta={"tool_file_id": "tool-file-1"},
                 ),
-            ]),
+            ),
             tool_info={},
             parameters_for_log={},
             node_id="node-1",
@@ -119,7 +129,7 @@ def test_transform_message_dispatches_image_link_with_handler_map() -> None:
     completed_event = events[-1]
     assert isinstance(completed_event, StreamCompletedEvent)
     assert completed_event.node_run_result.outputs["files"].value == [built_file]
-    node._runtime.build_file_reference.assert_called_once_with(
+    runtime.build_file_reference.assert_called_once_with(
         mapping={
             "tool_file_id": "tool-file-1",
             "type": FileType.IMAGE,
@@ -130,18 +140,18 @@ def test_transform_message_dispatches_image_link_with_handler_map() -> None:
 
 
 def test_transform_message_rejects_non_file_payload_in_file_message() -> None:
-    node = _build_tool_node()
+    node, _runtime, _tool_file_manager_factory = _build_tool_node()
 
     with pytest.raises(ToolNodeError, match="Expected File object"):
         list(
             node._transform_message(
-                messages=iter([
+                messages=_message_stream(
                     ToolRuntimeMessage(
                         type=ToolRuntimeMessage.MessageType.FILE,
                         message=ToolRuntimeMessage.FileMessage(),
                         meta={"file": "not-a-file"},
                     ),
-                ]),
+                ),
                 tool_info={},
                 parameters_for_log={},
                 node_id="node-1",

--- a/tests/nodes/variable_assigner/test_v1_node.py
+++ b/tests/nodes/variable_assigner/test_v1_node.py
@@ -1,6 +1,8 @@
 import time
 from typing import Any
 
+from graphon.entities.graph_config import NodeConfigDictAdapter
+from graphon.enums import BuiltinNodeTypes
 from graphon.graph_events.node import NodeRunSucceededEvent, NodeRunVariableUpdatedEvent
 from graphon.nodes.variable_assigner.common import helpers as common_helpers
 from graphon.nodes.variable_assigner.v1.node import VariableAssignerNode
@@ -32,15 +34,16 @@ def _build_node(
         node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
-        config={
+        config=NodeConfigDictAdapter.validate_python({
             "id": "assigner",
             "data": {
+                "type": BuiltinNodeTypes.VARIABLE_ASSIGNER,
                 "title": "Variable Assigner",
                 "assigned_variable_selector": assigned_selector,
                 "write_mode": write_mode,
                 "input_variable_selector": input_selector,
             },
-        },
+        }),
     )
 
 

--- a/tests/nodes/variable_assigner/test_v2_node.py
+++ b/tests/nodes/variable_assigner/test_v2_node.py
@@ -1,7 +1,8 @@
 import time
 from typing import Any
 
-from graphon.enums import WorkflowNodeExecutionStatus
+from graphon.entities.graph_config import NodeConfigDictAdapter
+from graphon.enums import BuiltinNodeTypes, WorkflowNodeExecutionStatus
 from graphon.graph_events.node import (
     NodeRunFailedEvent,
     NodeRunSucceededEvent,
@@ -34,14 +35,15 @@ def _build_node(
         node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
-        config={
+        config=NodeConfigDictAdapter.validate_python({
             "id": "assigner",
             "data": {
+                "type": BuiltinNodeTypes.VARIABLE_ASSIGNER,
                 "title": "Variable Assigner",
                 "version": "2",
                 "items": items,
             },
-        },
+        }),
     )
 
 

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import (
     BooleanSegment,
@@ -26,7 +28,7 @@ class TestVariablePoolGetAndNestedAttribute:
     def test__get_nested_attribute_non_dict(self):
         pool = VariablePool.empty()
         obj = ["not", "a", "dict"]
-        segment = pool._get_nested_attribute(obj, "a")
+        segment = pool._get_nested_attribute(cast(Any, obj), "a")
         assert segment is None
 
     def test__get_nested_attribute_with_none_value(self):

--- a/uv.lock
+++ b/uv.lock
@@ -571,6 +571,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -602,6 +603,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [[package]]
@@ -2524,6 +2526,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/e5cf1f151cf52fe1189e42d03d90909d7d1354fdc0c1847cbb63a0baa3da/ty-0.0.27.tar.gz", hash = "sha256:d7a8de3421d92420b40c94fe7e7d4816037560621903964dd035cf9bd0204a73", size = 5424130, upload-time = "2026-03-31T19:07:20.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/20/2a9ea661758bd67f2bfd54ce9daacb5a26c56c5f8b49fbd9a43b365a8a7d/ty-0.0.27-py3-none-linux_armv6l.whl", hash = "sha256:eb14456b8611c9e8287aa9b633f4d2a0d9f3082a31796969e0b50bdda8930281", size = 10571211, upload-time = "2026-03-31T19:07:23.28Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b2/8887a51f705d075ddbe78ae7f0d4755ef48d0a90235f67aee289e9cee950/ty-0.0.27-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:02e662184703db7586118df611cf24a000d35dae38d950053d1dd7b6736fd2c4", size = 10427576, upload-time = "2026-03-31T19:07:15.499Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c3/79d88163f508fb709ce19bc0b0a66c7c64b53d372d4caa56172c3d9b3ae8/ty-0.0.27-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be5fc2899441f7f8f7ef40f9ffd006075a5ff6b06c44e8d2aa30e1b900c12f51", size = 9870359, upload-time = "2026-03-31T19:07:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/ed1b0db0e1e46b5ed4976bbfe0d1825faf003b4e3774ef28c785ed73e4bb/ty-0.0.27-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30231e652b14742a76b64755e54bf0cb1cd4c128bcaf625222e0ca92a2094887", size = 10380488, upload-time = "2026-03-31T19:07:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/20372f6d510b01570028433064880adec2f8abe68bf0c4603be61a560bef/ty-0.0.27-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a119b1168f64261b3205a37e40b5b6c4aac8fd58e4587988f4e4b22c3c79847", size = 10390248, upload-time = "2026-03-31T19:07:28.345Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/46b31a7311306be1a560f7f20fdc37b5bf718787f60626cd265d9b637554/ty-0.0.27-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e38f4e187b6975d2cbebf0f1eb1221f8f64f6e509bad14d7bb2a91afc97e4956", size = 10878479, upload-time = "2026-03-31T19:07:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ba/5231a2a1fb1cebe053a25de8fded95e1a30a1e77d3628a9e58487297bafc/ty-0.0.27-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a07b1a8fbb23844f6d22091275430d9ac617175f34aa99159b268193de210389", size = 11461232, upload-time = "2026-03-31T19:07:02.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/558abab3e1f6670493524f61280b4dfcc3219555f13889223e733381dfab/ty-0.0.27-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ec4033031f240836bb0337274bac5c49dde312c7c6d7575451ed719bf8ffa3", size = 11133002, upload-time = "2026-03-31T19:07:18.371Z" },
+    { url = "https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f", size = 10986624, upload-time = "2026-03-31T19:07:13.066Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/667a71393f47d2cd6ba9ed07541b8df3eb63aab1f2ee658e77d91b8362fa/ty-0.0.27-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d8270026c07e7423a1b3a3fd065b46ed1478748f0662518b523b57744f3fa025", size = 10366721, upload-time = "2026-03-31T19:07:00.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/aa/8edafe41be898bda774249abc5be6edd733e53fb1777d59ea9331e38537d/ty-0.0.27-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e26e9735d3bdfd95d881111ad1cf570eab8188d8c3be36d6bcaad044d38984d8", size = 10412239, upload-time = "2026-03-31T19:07:05.297Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/8bafaed4a18d38264f46bdfc427de7ea2974cf9064e4e0bdb1b6e6c724e3/ty-0.0.27-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7c09cc9a699810609acc0090af8d0db68adaee6e60a7c3e05ab80cc954a83db7", size = 10573507, upload-time = "2026-03-31T19:06:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/63a8284a2fefd08ab56ecbad0fde7dd4b2d4045a31cf24c1d1fcd9643227/ty-0.0.27-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2d3e02853bb037221a456e034b1898aaa573e6374fbb53884e33cb7513ccb85a", size = 11090233, upload-time = "2026-03-31T19:07:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- resolve the remaining `ty` diagnostics across graph runtime, model runtime, nodes, variables, and the associated tests
- split the cleanup into low-risk/protocol-only fixes first, then handle the remaining path-sensitive diagnostics with explicit narrowing and constructors
- add a regression test for the intentional `array[string]` validation error path

## Why
`uv run ty check` was failing on a mix of protocol mismatches, over-narrow annotations, and a handful of code paths where the checker could not prove the existing invariants. This branch makes those invariants explicit without broad runtime rewrites.

## Impact
- `ty check` is green again
- `make pre` stays green after the cleanup
- invalid `array[string]` outputs now raise a deliberate `OutputValidationError` instead of surfacing a raw `TypeError`
- the second batch of fixes was reviewed separately for logic-change risk; no material regression risk was identified

## Validation
- `make pre`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run ty check`

Closes #22