### PR TITLE
refactor: remove SLF001 private member access violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,15 @@ homepage = 'https://github.com/langgenius/graphon'
 issues = 'https://github.com/langgenius/graphon/issues'
 
 [dependency-groups]
-dev = ['pytest', 'pytest-cov', 'pytest-mock', 'pytest-xdist', 'ruff', 'prek', 'ty']
+dev = [
+    'pytest',
+    'pytest-cov',
+    'pytest-mock',
+    'pytest-xdist',
+    'ruff',
+    'prek',
+    'ty',
+]
 
 [build-system]
 requires = ['uv_build~=0.11']
@@ -51,19 +59,17 @@ required-version = '>=0.15'
 [tool.ruff.lint]
 select = ['ALL']
 ignore = [
-    'COM812', # Conflicts with `ruff format`.
-    'ERA001', # False positives are common.
-    'TC',     # Runtime use of typing constructs is common now.
-    'CPY',    # Covered by the standalone LICENSE file.
-    'D',      # Too verbose.
-    'FBT',    # Too strict.
-    'TID252', # Too absolute.
-    ########### Temporarily disabled while the existing violations are worked down ###########
-    'SLF001',
-    'ANN401',
-    'PLR6301',
-    'PLR0917',
-    'PLR0913',
+    'COM812',  # Conflicts with `ruff format`.
+    'ERA001',  # False positives are common.
+    'TC',      # Runtime use of typing constructs is common now.
+    'CPY',     # Covered by the standalone LICENSE file.
+    'PLR0913', # Explicit is better than implicit.
+    'PLR0917', # Complex is better than complicated.
+    'PLR6301', # Violates the usual practice.
+    'D',       # Too verbose.
+    'FBT',     # Too strict.
+    'TID252',  # Too absolute.
+    'ANN401',  # We hope to enforce this, but typing is still evolving.
 ]
 
 [tool.ruff.lint.pydoclint]

--- a/src/graphon/graph/graph.py
+++ b/src/graphon/graph/graph.py
@@ -202,6 +202,24 @@ class Graph:
                 node.execution_type = NodeExecutionType.BRANCH
 
     @classmethod
+    def mark_inactive_root_branches(
+        cls,
+        nodes: dict[str, Node],
+        edges: dict[str, Edge],
+        in_edges: dict[str, list[str]],
+        out_edges: dict[str, list[str]],
+        active_root_id: str,
+    ) -> None:
+        """Mark nodes and edges that belong to inactive root branches."""
+        cls._mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            active_root_id,
+        )
+
+    @classmethod
     def _mark_inactive_root_branches(
         cls,
         nodes: dict[str, Node],

--- a/src/graphon/graph_engine/command_channels/redis_channel.py
+++ b/src/graphon/graph_engine/command_channels/redis_channel.py
@@ -118,6 +118,13 @@ class RedisChannel:
             pipe.set(self._pending_key, "1", ex=self._command_ttl)
             pipe.execute()
 
+    def deserialize_command(
+        self,
+        data: dict[str, Any],
+    ) -> GraphEngineCommand | None:
+        """Deserialize a command payload into a typed command model."""
+        return self._deserialize_command(data)
+
     def _deserialize_command(self, data: dict[str, Any]) -> GraphEngineCommand | None:
         """Deserialize a command from dictionary data.
 

--- a/src/graphon/graph_engine/graph_traversal/skip_propagator.py
+++ b/src/graphon/graph_engine/graph_traversal/skip_propagator.py
@@ -65,6 +65,10 @@ class SkipPropagator:
         if edge_states["all_skipped"]:
             self._propagate_skip_to_node(downstream_node_id)
 
+    def propagate_skip_to_node(self, node_id: str) -> None:
+        """Mark a node and its downstream edges as skipped."""
+        self._propagate_skip_to_node(node_id)
+
     def _propagate_skip_to_node(self, node_id: str) -> None:
         """Mark a node and all its outgoing edges as skipped.
 

--- a/src/graphon/graph_engine/layers/execution_limits.py
+++ b/src/graphon/graph_engine/layers/execution_limits.py
@@ -152,6 +152,10 @@ class ExecutionLimitsLayer(GraphEngineLayer):
         except Exception:
             self.logger.exception("Failed to send abort command")
 
+    def send_abort_command(self, limit_type: LimitType) -> None:
+        """Send an abort command when tests or callers need explicit control."""
+        self._send_abort_command(limit_type)
+
     def _build_abort_reason(self, limit_type: LimitType) -> str:
         match limit_type:
             case LimitType.STEP_LIMIT:

--- a/src/graphon/graph_engine/response_coordinator/coordinator.py
+++ b/src/graphon/graph_engine/response_coordinator/coordinator.py
@@ -138,6 +138,11 @@ class ResponseStreamCoordinator:
         with self._lock:
             self._node_execution_ids[node_id] = execution_id
 
+    def activate_session(self, session: ResponseSession) -> None:
+        """Activate a prepared response session for controlled flushing."""
+        with self._lock:
+            self._active_session = session
+
     def _get_or_create_execution_id(self, node_id: NodeID) -> str:
         """Get the execution ID for a node, creating one if it doesn't exist.
 
@@ -479,6 +484,13 @@ class ResponseStreamCoordinator:
             is_final=is_last_segment,
         )
         return [event]
+
+    def process_text_segment(
+        self,
+        segment: TextSegment,
+    ) -> Sequence[NodeRunStreamChunkEvent]:
+        """Process a text segment for the currently active session."""
+        return self._process_text_segment(segment)
 
     def _get_text_segment_selector(self, response_node_id: str) -> Sequence[str]:
         response_node = self._graph.nodes[response_node_id]

--- a/src/graphon/model_runtime/slim/package_loader.py
+++ b/src/graphon/model_runtime/slim/package_loader.py
@@ -60,6 +60,13 @@ class SlimPackageLoader:
     def __init__(self, config: SlimConfig) -> None:
         self._config = config
 
+    def convert_model_entity(
+        self,
+        raw_model: dict[str, Any],
+    ) -> AIModelEntity | None:
+        """Convert a raw provider-declared model into a validated entity."""
+        return self._convert_model_entity(raw_model)
+
     def load(self, binding: SlimProviderBinding) -> LoadedSlimProvider:
         plugin_root = (
             binding.plugin_root

--- a/src/graphon/model_runtime/slim/runtime.py
+++ b/src/graphon/model_runtime/slim/runtime.py
@@ -123,6 +123,11 @@ class SlimRuntime(ModelRuntime):
         self._providers_by_name: dict[str, LoadedSlimProvider] = {}
         self._lock = Lock()
 
+    @property
+    def binary_path(self) -> str:
+        """Return the resolved slim daemon binary path."""
+        return self._binary_path
+
     def _resolve_binary_path(self) -> str:
         configured_path = os.environ.get(_SLIM_BINARY_PATH_ENV, "").strip()
         if configured_path:
@@ -262,7 +267,7 @@ class SlimRuntime(ModelRuntime):
         if model_schema is None:
             return None
 
-        converted = self._package_loader._convert_model_entity(model_schema)
+        converted = self._package_loader.convert_model_entity(model_schema)
         if converted is None:
             return None
         return converted

--- a/src/graphon/nodes/base/node.py
+++ b/src/graphon/nodes/base/node.py
@@ -204,6 +204,11 @@ class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
         """Hydrate `_node_data` for legacy callers that bypass `__init__`."""
         self._node_data = self.validate_node_data(cast("BaseNodeData", data))
 
+    def init_node_identity(self: Node[NodeDataT], node_id: str) -> None:
+        """Hydrate node identity for legacy callers that bypass `__init__`."""
+        self.id = node_id
+        self._node_id = node_id
+
     @property
     def retry(self) -> bool:
         return False

--- a/src/graphon/nodes/code/code_node.py
+++ b/src/graphon/nodes/code/code_node.py
@@ -99,6 +99,15 @@ class CodeNode(Node[CodeNodeData]):
         self._code_executor: WorkflowCodeExecutor = code_executor
         self._limits = code_limits
 
+    @property
+    def limits(self) -> CodeNodeLimits:
+        """Return the validation limits used by this node."""
+        return self._limits
+
+    @limits.setter
+    def limits(self, value: CodeNodeLimits) -> None:
+        self._limits = value
+
     @classmethod
     @override
     def get_default_config(
@@ -646,6 +655,21 @@ class CodeNode(Node[CodeNodeData]):
             raise CodeNodeError(msg)
 
         return transformed_result
+
+    def transform_result(
+        self,
+        result: Mapping[str, Any],
+        output_schema: dict[str, CodeNodeData.Output] | None,
+        prefix: str = "",
+        depth: int = 1,
+    ) -> Mapping[str, Any]:
+        """Validate and normalize code-node outputs against the schema."""
+        return self._transform_result(
+            result=result,
+            output_schema=output_schema,
+            prefix=prefix,
+            depth=depth,
+        )
 
     @classmethod
     @override

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -211,6 +211,11 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
         )
         self._http_client = http_client or get_http_client()
 
+    @property
+    def http_client(self) -> HttpClientProtocol:
+        """Return the HTTP client used to retrieve file contents."""
+        return self._http_client
+
     @override
     def _run(self) -> NodeRunResult:
         variable_selector = self.node_data.variable_selector
@@ -563,6 +568,11 @@ def _extract_text_from_docx(file_content: bytes) -> str:
         raise TextExtractionError(msg) from e
 
 
+def extract_text_from_docx(file_content: bytes) -> str:
+    """Extract text from a DOCX payload."""
+    return _extract_text_from_docx(file_content)
+
+
 def _load_docx_document(file_content: bytes) -> Document:
     try:
         return docx.Document(io.BytesIO(file_content))
@@ -634,6 +644,11 @@ def _download_file_content(http_client: HttpClientProtocol, file: File) -> bytes
     except Exception as e:
         msg = f"Error downloading file: {e!s}"
         raise FileDownloadError(msg) from e
+
+
+def download_file_content(http_client: HttpClientProtocol, file: File) -> bytes:
+    """Download file content using the document extractor rules."""
+    return _download_file_content(http_client, file)
 
 
 def _extract_text_from_file(

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -338,6 +338,10 @@ class Executor:
         headers.update(self._build_authorization_headers(authorization))
         return self._apply_content_type_header(headers)
 
+    def build_headers(self) -> dict[str, Any]:
+        """Build the request headers for the current executor state."""
+        return self._assembling_headers()
+
     def _build_authorization_headers(
         self,
         authorization: HttpRequestNodeAuthorization,

--- a/src/graphon/nodes/http_request/node.py
+++ b/src/graphon/nodes/http_request/node.py
@@ -68,6 +68,11 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
         self._file_manager = file_manager
         self._file_reference_factory = file_reference_factory
 
+    @property
+    def http_client(self) -> HttpClientProtocol:
+        """Return the HTTP client used by this node."""
+        return self._http_client
+
     @classmethod
     @override
     def get_default_config(

--- a/src/graphon/nodes/iteration/iteration_node.py
+++ b/src/graphon/nodes/iteration/iteration_node.py
@@ -754,6 +754,20 @@ class IterationNode(LLMUsageTrackingMixin, Node[IterationNodeData]):
 
         return
 
+    def run_single_iter(
+        self,
+        *,
+        variable_pool: VariablePool,
+        outputs: list[object],
+        graph_engine: "GraphEngine",
+    ) -> Generator[GraphNodeEventBase, None, None]:
+        """Run a single iteration with explicit collaborators."""
+        yield from self._run_single_iter(
+            variable_pool=variable_pool,
+            outputs=outputs,
+            graph_engine=graph_engine,
+        )
+
     def _get_current_iteration_index(self, variable_pool: VariablePool) -> int:
         index_variable = variable_pool.get([self._node_id, "index"])
         if not isinstance(index_variable, IntegerVariable):

--- a/src/graphon/nodes/llm/file_saver.py
+++ b/src/graphon/nodes/llm/file_saver.py
@@ -83,6 +83,11 @@ class FileSaverImpl(LLMFileSaver):
         self._file_reference_factory = file_reference_factory
         self._http_client = http_client or get_http_client()
 
+    @property
+    def http_client(self) -> HttpClientProtocol:
+        """Return the HTTP client used for remote file downloads."""
+        return self._http_client
+
     def save_remote_url(self, url: str, file_type: FileType) -> File:
         http_response = self._http_client.get(url)
         http_response.raise_for_status()

--- a/src/graphon/nodes/loop/loop_node.py
+++ b/src/graphon/nodes/loop/loop_node.py
@@ -443,6 +443,20 @@ class LoopNode(LLMUsageTrackingMixin, Node[LoopNodeData]):
             self.node_data.outputs[key] = segment.value if segment else None
         self.node_data.outputs["loop_round"] = current_index + 1
 
+    def run_single_loop(
+        self,
+        *,
+        graph_engine: "GraphEngine",
+        current_index: int,
+        loop_state: dict[str, bool],
+    ) -> Generator[NodeEventBase | GraphNodeEventBase, None, None]:
+        """Run one loop iteration with explicit collaborators."""
+        yield from self._run_single_loop(
+            graph_engine=graph_engine,
+            current_index=current_index,
+            loop_state=loop_state,
+        )
+
     def _append_loop_info_to_event(
         self,
         event: GraphNodeEventBase,

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -716,6 +716,14 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
 
         return transformed_result
 
+    def transform_result(
+        self,
+        data: ParameterExtractorNodeData,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Transform model output into the node's normalized result shape."""
+        return self._transform_result(data, result)
+
     def _transform_parameter_value(
         self,
         *,
@@ -885,6 +893,24 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
             return [system_prompt_messages, user_prompt_message]
         msg = f"Model mode {node_data.model.mode} not support."
         raise InvalidModelModeError(msg)
+
+    def get_function_calling_prompt_template(
+        self,
+        *,
+        node_data: ParameterExtractorNodeData,
+        query: str,
+        variable_pool: VariablePool,
+        memory: PromptMessageMemory | None,
+        max_token_limit: int = 2000,
+    ) -> list[LLMNodeChatModelMessage]:
+        """Build the function-calling prompt template for the current request."""
+        return self._get_function_calling_prompt_template(
+            node_data=node_data,
+            query=query,
+            variable_pool=variable_pool,
+            memory=memory,
+            max_token_limit=max_token_limit,
+        )
 
     def _get_prompt_engineering_prompt_template(
         self,

--- a/src/graphon/nodes/tool/tool_node.py
+++ b/src/graphon/nodes/tool/tool_node.py
@@ -80,6 +80,16 @@ class ToolNode(Node[ToolNodeData]):
             raise ValueError(msg)
         self._runtime = runtime
 
+    def init_tool_runtime(
+        self,
+        *,
+        runtime: ToolNodeRuntimeProtocol,
+        tool_file_manager_factory: ToolFileManagerProtocol,
+    ) -> None:
+        """Hydrate tool-runtime collaborators for callers bypassing `__init__`."""
+        self._runtime = runtime
+        self._tool_file_manager_factory = tool_file_manager_factory
+
     @classmethod
     @override
     def version(cls) -> str:
@@ -275,6 +285,25 @@ class ToolNode(Node[ToolNodeData]):
                 inputs=parameters_for_log,
                 llm_usage=usage,
             ),
+        )
+
+    def transform_message(
+        self,
+        messages: Generator[ToolRuntimeMessage, None, None],
+        tool_info: Mapping[str, Any],
+        parameters_for_log: dict[str, Any],
+        node_id: str,
+        tool_runtime: ToolRuntimeHandle,
+        **kwargs: Any,
+    ) -> Generator[NodeEventBase, None, None]:
+        """Convert tool runtime messages using the node's public test seam."""
+        yield from self._transform_message(
+            messages=messages,
+            tool_info=tool_info,
+            parameters_for_log=parameters_for_log,
+            node_id=node_id,
+            tool_runtime=tool_runtime,
+            **kwargs,
         )
 
     def _dispatch_message(

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -436,7 +436,6 @@ class _GraphRuntimeBindings:
         ready_queue: ReadyQueueProtocol | None = None,
         graph_execution: GraphExecutionProtocol | None = None,
         response_coordinator: ResponseStreamCoordinatorProtocol | None = None,
-        graph: GraphProtocol | None = None,
         execution_context: AbstractContextManager[object] | None = None,
     ) -> None:
         self._runtime_state = runtime_state
@@ -451,9 +450,6 @@ class _GraphRuntimeBindings:
         )
         self.child_engine_builder: ChildGraphEngineBuilderProtocol | None = None
 
-        if graph is not None:
-            self.attach_graph(graph, runtime_state._suspension_state)
-
     def attach_graph(
         self,
         graph: GraphProtocol,
@@ -466,7 +462,7 @@ class _GraphRuntimeBindings:
         self.graph = graph
 
         if self.response_coordinator is None:
-            self.response_coordinator = self._runtime_state._build_response_coordinator(
+            self.response_coordinator = self._runtime_state.create_response_coordinator(
                 graph,
             )
 
@@ -523,12 +519,12 @@ class _GraphRuntimeBindings:
 
     def get_ready_queue(self) -> ReadyQueueProtocol:
         if self.ready_queue is None:
-            self.ready_queue = self._runtime_state._build_ready_queue()
+            self.ready_queue = self._runtime_state.create_ready_queue()
         return self.ready_queue
 
     def get_graph_execution(self) -> GraphExecutionProtocol:
         if self.graph_execution is None:
-            self.graph_execution = self._runtime_state._build_graph_execution()
+            self.graph_execution = self._runtime_state.create_graph_execution()
         return self.graph_execution
 
     def get_response_coordinator(self) -> ResponseStreamCoordinatorProtocol:
@@ -536,7 +532,7 @@ class _GraphRuntimeBindings:
             if self.graph is None:
                 msg = "Graph must be attached before accessing response coordinator"
                 raise ValueError(msg)
-            self.response_coordinator = self._runtime_state._build_response_coordinator(
+            self.response_coordinator = self._runtime_state.create_response_coordinator(
                 self.graph,
             )
         return self.response_coordinator
@@ -551,7 +547,7 @@ class _GraphRuntimeBindings:
         if payload is None:
             self.ready_queue = None
             return
-        self.ready_queue = self._runtime_state._build_ready_queue()
+        self.ready_queue = self._runtime_state.create_ready_queue()
         self.ready_queue.loads(payload)
 
     def restore_graph_execution(
@@ -636,9 +632,10 @@ class GraphRuntimeState:  # noqa: PLR0904
             ready_queue=ready_queue,
             graph_execution=graph_execution,
             response_coordinator=response_coordinator,
-            graph=graph,
             execution_context=execution_context,
         )
+        if graph is not None:
+            self.attach_graph(graph)
 
     @property
     def variable_pool(self) -> VariablePool:
@@ -848,6 +845,21 @@ class GraphRuntimeState:  # noqa: PLR0904
     # ------------------------------------------------------------------
     # Builders
     # ------------------------------------------------------------------
+    def create_ready_queue(self) -> ReadyQueueProtocol:
+        """Create the ready queue collaborator used by this runtime state."""
+        return self._build_ready_queue()
+
+    def create_graph_execution(self) -> GraphExecutionProtocol:
+        """Create the graph execution aggregate used by this runtime state."""
+        return self._build_graph_execution()
+
+    def create_response_coordinator(
+        self,
+        graph: GraphProtocol,
+    ) -> ResponseStreamCoordinatorProtocol:
+        """Create the response coordinator bound to the attached graph."""
+        return self._build_response_coordinator(graph)
+
     def _build_ready_queue(self) -> ReadyQueueProtocol:
         # Import lazily to avoid breaching architecture boundaries
         # enforced by import-linter.

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -51,7 +51,13 @@ class TestMarkInactiveRootBranches:
         in_edges = {"child1": ["edge1"]}
         out_edges = {"root1": ["edge1"]}
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["child1"].state == NodeState.UNKNOWN
@@ -83,7 +89,13 @@ class TestMarkInactiveRootBranches:
         in_edges = {"child1": ["edge1"], "child2": ["edge2"]}
         out_edges = {"root1": ["edge1"], "root2": ["edge2"]}
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["root2"].state == NodeState.SKIPPED
@@ -140,7 +152,13 @@ class TestMarkInactiveRootBranches:
             "child2": ["edge4"],
         }
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["root2"].state == NodeState.SKIPPED
@@ -211,7 +229,13 @@ class TestMarkInactiveRootBranches:
             "level2_b": ["edge5"],
         }
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["root2"].state == NodeState.SKIPPED
@@ -252,7 +276,13 @@ class TestMarkInactiveRootBranches:
         in_edges = {"child1": ["edge1"], "child2": ["edge2"]}
         out_edges = {"root1": ["edge1"], "non_root": ["edge2"]}
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["non_root"].state == NodeState.UNKNOWN
@@ -262,7 +292,7 @@ class TestMarkInactiveRootBranches:
         assert edges["edge2"].state == NodeState.UNKNOWN
 
     def test_empty_graph(self) -> None:
-        Graph._mark_inactive_root_branches({}, {}, {}, {}, "non_existent")
+        Graph.mark_inactive_root_branches({}, {}, {}, {}, "non_existent")
 
     def test_three_roots_mark_two_inactive(self) -> None:
         nodes = {
@@ -306,7 +336,13 @@ class TestMarkInactiveRootBranches:
             "root3": ["edge3"],
         }
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root2")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root2",
+        )
 
         assert nodes["root1"].state == NodeState.SKIPPED
         assert nodes["root2"].state == NodeState.UNKNOWN
@@ -374,7 +410,13 @@ class TestMarkInactiveRootBranches:
             "mid2": ["edge5"],
         }
 
-        Graph._mark_inactive_root_branches(nodes, edges, in_edges, out_edges, "root1")
+        Graph.mark_inactive_root_branches(
+            nodes,
+            edges,
+            in_edges,
+            out_edges,
+            "root1",
+        )
 
         assert nodes["root1"].state == NodeState.UNKNOWN
         assert nodes["root2"].state == NodeState.SKIPPED

--- a/tests/graph_engine/graph_traversal/test_skip_propagator.py
+++ b/tests/graph_engine/graph_traversal/test_skip_propagator.py
@@ -106,7 +106,7 @@ class TestSkipPropagator:
 
         propagator = SkipPropagator(mock_graph, mock_state_manager)
 
-        propagator._propagate_skip_to_node("node_1")
+        propagator.propagate_skip_to_node("node_1")
 
         mock_state_manager.mark_node_skipped.assert_called_once_with("node_1")
         mock_state_manager.mark_edge_skipped.assert_any_call("edge_2")

--- a/tests/graph_engine/test_dispatch_patterns.py
+++ b/tests/graph_engine/test_dispatch_patterns.py
@@ -44,7 +44,7 @@ def test_redis_channel_deserializes_command_with_model_map(
 ) -> None:
     channel = RedisChannel(redis_client=MagicMock(), channel_key="test-channel")
 
-    command = channel._deserialize_command(payload)
+    command = channel.deserialize_command(payload)
 
     assert isinstance(command, expected_command_type)
 
@@ -71,11 +71,11 @@ def test_execution_limits_layer_builds_abort_reason_with_match_case(
 ) -> None:
     layer = ExecutionLimitsLayer(max_steps=3, max_time=10)
     layer.command_channel = MagicMock()
-    layer._execution_started = True
+    layer.on_graph_start()
     layer.step_count = 4
     layer.start_time = time() - 20
 
-    layer._send_abort_command(limit_type)
+    layer.send_abort_command(limit_type)
 
     abort_command = layer.command_channel.send_command.call_args.args[0]
     assert isinstance(abort_command, AbortCommand)

--- a/tests/graph_engine/test_response_coordinator.py
+++ b/tests/graph_engine/test_response_coordinator.py
@@ -26,12 +26,14 @@ def test_process_text_segment_uses_response_node_text_selector() -> None:
         graph=graph,
     )
     coordinator.track_node_execution("end-node", "run-1")
-    coordinator._active_session = ResponseSession(
-        node_id="end-node",
-        template=Template(segments=[TextSegment(text="\n")]),
+    coordinator.activate_session(
+        ResponseSession(
+            node_id="end-node",
+            template=Template(segments=[TextSegment(text="\n")]),
+        )
     )
 
-    [event] = coordinator._process_text_segment(TextSegment(text="\n"))
+    [event] = coordinator.process_text_segment(TextSegment(text="\n"))
 
     assert event.id == "run-1"
     assert event.node_id == "end-node"

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -179,7 +179,7 @@ def test_http_request_node_uses_default_http_client_when_not_injected() -> None:
         file_reference_factory=_FileReferenceFactory(),
     )
 
-    assert node._http_client is get_http_client()
+    assert node.http_client is get_http_client()
 
 
 def test_document_extractor_node_uses_default_http_client_when_not_injected() -> None:
@@ -199,7 +199,7 @@ def test_document_extractor_node_uses_default_http_client_when_not_injected() ->
         graph_runtime_state=_build_runtime_state(),
     )
 
-    assert node._http_client is get_http_client()
+    assert node.http_client is get_http_client()
 
 
 def test_file_saver_impl_uses_default_http_client_when_not_injected() -> None:
@@ -208,7 +208,7 @@ def test_file_saver_impl_uses_default_http_client_when_not_injected() -> None:
         file_reference_factory=_FileReferenceFactory(),
     )
 
-    assert file_saver._http_client is get_http_client()
+    assert file_saver.http_client is get_http_client()
 
 
 @pytest.mark.parametrize(

--- a/tests/model_runtime/slim/test_runtime.py
+++ b/tests/model_runtime/slim/test_runtime.py
@@ -624,7 +624,7 @@ def test_slim_runtime_uses_slim_binary_path_env(
             ),
         )
 
-    assert runtime._binary_path == str(custom_binary)
+    assert runtime.binary_path == str(custom_binary)
 
 
 def test_slim_runtime_rejects_invalid_slim_binary_path_env(

--- a/tests/nodes/document_extractor/test_docx_extraction.py
+++ b/tests/nodes/document_extractor/test_docx_extraction.py
@@ -22,7 +22,7 @@ def test_extract_text_from_docx_keeps_paragraph_and_table_order() -> None:
     buffer = io.BytesIO()
     document.save(buffer)
 
-    extracted = document_extractor_node._extract_text_from_docx(buffer.getvalue())
+    extracted = document_extractor_node.extract_text_from_docx(buffer.getvalue())
 
     assert extracted == (
         "Intro\n| Name | Value |\n| --- | --- |\n| Color | Blue |\n\nOutro"
@@ -36,4 +36,4 @@ def test_download_file_content_requires_remote_url() -> None:
     file.type = FileType.DOCUMENT
 
     with pytest.raises(FileDownloadError, match="Missing URL for remote file"):
-        document_extractor_node._download_file_content(MagicMock(), file)
+        document_extractor_node.download_file_content(MagicMock(), file)

--- a/tests/nodes/http_request/test_dispatch.py
+++ b/tests/nodes/http_request/test_dispatch.py
@@ -46,10 +46,12 @@ def test_http_request_node_extracts_variable_selectors_from_form_data() -> None:
         },
     })
 
-    mapping = HttpRequestNode._extract_variable_selector_to_variable_mapping(
+    mapping = HttpRequestNode.extract_variable_selector_to_variable_mapping(
         graph_config={},
-        node_id="node-1",
-        node_data=node_data,
+        config={
+            "id": "node-1",
+            "data": node_data.model_dump(mode="json"),
+        },
     )
 
     assert mapping == {
@@ -150,7 +152,7 @@ def test_executor_assembling_headers_applies_bearer_auth_and_content_type() -> N
         file_manager=MagicMock(),
     )
 
-    headers = executor._assembling_headers()
+    headers = executor.build_headers()
 
     assert headers["Authorization"] == "Bearer secret-token"
     assert headers["Content-Type"] == "text/plain"

--- a/tests/nodes/if_else/test_entities.py
+++ b/tests/nodes/if_else/test_entities.py
@@ -33,10 +33,12 @@ def test_extract_variable_mapping_includes_legacy_conditions() -> None:
         ],
     )
 
-    mapping = IfElseNode._extract_variable_selector_to_variable_mapping(
+    mapping = IfElseNode.extract_variable_selector_to_variable_mapping(
         graph_config={},
-        node_id="if-node",
-        node_data=node_data,
+        config={
+            "id": "if-node",
+            "data": node_data.model_dump(mode="json"),
+        },
     )
 
     assert mapping == {

--- a/tests/nodes/parameter_extractor/test_entities.py
+++ b/tests/nodes/parameter_extractor/test_entities.py
@@ -128,7 +128,7 @@ def test_parameter_extractor_transform_result_uses_type_dispatch() -> None:
         "reasoning_mode": "function_call",
     })
 
-    transformed = node._transform_result(
+    transformed = node.transform_result(
         node_data,
         {
             "age": "3",

--- a/tests/nodes/parameter_extractor/test_prompts.py
+++ b/tests/nodes/parameter_extractor/test_prompts.py
@@ -113,7 +113,7 @@ def test_parameter_extractor_runtime_prompts_format_with_expected_arguments() ->
 def test_function_calling_prompt_template_renders_system_message() -> None:
     node, variable_pool = _build_parameter_extractor_node()
 
-    prompt_messages = node._get_function_calling_prompt_template(
+    prompt_messages = node.get_function_calling_prompt_template(
         node_data=node.node_data,
         query="Extract the location from this request.",
         variable_pool=variable_pool,

--- a/tests/nodes/test_code_node.py
+++ b/tests/nodes/test_code_node.py
@@ -9,7 +9,7 @@ from graphon.variables.types import SegmentType
 
 def _build_code_node() -> CodeNode:
     node = object.__new__(CodeNode)
-    node._limits = CodeNodeLimits(
+    node.limits = CodeNodeLimits(
         max_string_length=100,
         max_number=100,
         min_number=-100,
@@ -32,7 +32,7 @@ def test_transform_result_reports_nested_missing_field_without_leading_dot() -> 
     }
 
     with pytest.raises(OutputValidationError, match=r"Output root\.child is missing\."):
-        node._transform_result(result={"root": {}}, output_schema=output_schema)
+        node.transform_result(result={"root": {}}, output_schema=output_schema)
 
 
 def test_transform_result_rejects_non_string_array_elements_with_validation_error() -> (
@@ -47,7 +47,7 @@ def test_transform_result_rejects_non_string_array_elements_with_validation_erro
         OutputValidationError,
         match=r"Output items\[1\] must be a string, got int instead\.",
     ):
-        node._transform_result(
+        node.transform_result(
             result={"items": ["valid", 1]},
             output_schema=output_schema,
         )

--- a/tests/nodes/test_container_dispatch.py
+++ b/tests/nodes/test_container_dispatch.py
@@ -14,11 +14,13 @@ from graphon.variables.variables import IntegerVariable
 
 def test_iteration_node_single_iter_keeps_iteration_event_dispatch() -> None:
     node = IterationNode.__new__(IterationNode)
-    node._node_id = "iteration-node"
-    node._node_data = SimpleNamespace(
-        output_selector=["iteration-node", "answer"],
-        error_handle_mode=ErrorHandleMode.TERMINATED,
-    )
+    node.init_node_identity("iteration-node")
+    node.init_node_data({
+        "type": "iteration",
+        "iterator_selector": ["input", "items"],
+        "output_selector": ["iteration-node", "answer"],
+        "error_handle_mode": ErrorHandleMode.TERMINATED,
+    })
 
     variable_pool = MagicMock()
     variable_pool.get.side_effect = lambda selector: {
@@ -43,7 +45,7 @@ def test_iteration_node_single_iter_keeps_iteration_event_dispatch() -> None:
     outputs: list[object] = []
 
     yielded_events = list(
-        node._run_single_iter(
+        node.run_single_iter(
             variable_pool=variable_pool,
             outputs=outputs,
             graph_engine=graph_engine,
@@ -63,8 +65,14 @@ def test_iteration_node_single_iter_keeps_iteration_event_dispatch() -> None:
 
 def test_loop_node_single_loop_keeps_loop_end_dispatch() -> None:
     node = LoopNode.__new__(LoopNode)
-    node._node_id = "loop-node"
-    node._node_data = SimpleNamespace(loop_variables=None, outputs={})
+    node.init_node_identity("loop-node")
+    node.init_node_data({
+        "type": "loop",
+        "loop_count": 1,
+        "break_conditions": [],
+        "logical_operator": "and",
+        "outputs": {},
+    })
     node.graph_runtime_state = SimpleNamespace(variable_pool=MagicMock())
 
     loop_end_event = NodeRunSucceededEvent(
@@ -77,7 +85,7 @@ def test_loop_node_single_loop_keeps_loop_end_dispatch() -> None:
     loop_state: dict[str, bool] = {}
 
     yielded_events = list(
-        node._run_single_loop(
+        node.run_single_loop(
             graph_engine=graph_engine,
             current_index=1,
             loop_state=loop_state,

--- a/tests/nodes/tool/test_tool_node.py
+++ b/tests/nodes/tool/test_tool_node.py
@@ -21,12 +21,14 @@ def _message_stream(
 
 def _build_tool_node() -> tuple[ToolNode, MagicMock, MagicMock]:
     node = ToolNode.__new__(ToolNode)
-    node._node_id = "node-1"
+    node.init_node_identity("node-1")
     runtime = MagicMock()
     runtime.get_usage.return_value = LLMUsage.empty_usage()
     tool_file_manager_factory = MagicMock()
-    node._runtime = cast(Any, runtime)
-    node._tool_file_manager_factory = cast(Any, tool_file_manager_factory)
+    node.init_tool_runtime(
+        runtime=cast(Any, runtime),
+        tool_file_manager_factory=cast(Any, tool_file_manager_factory),
+    )
     return node, runtime, tool_file_manager_factory
 
 
@@ -59,7 +61,7 @@ def test_transform_message_dispatches_text_variable_and_file_messages() -> None:
     )
 
     events = list(
-        node._transform_message(
+        node.transform_message(
             messages=messages,
             tool_info={},
             parameters_for_log={},
@@ -109,7 +111,7 @@ def test_transform_message_dispatches_image_link_with_handler_map() -> None:
     runtime.build_file_reference.return_value = built_file
 
     events = list(
-        node._transform_message(
+        node.transform_message(
             messages=_message_stream(
                 ToolRuntimeMessage(
                     type=ToolRuntimeMessage.MessageType.IMAGE_LINK,
@@ -144,7 +146,7 @@ def test_transform_message_rejects_non_file_payload_in_file_message() -> None:
 
     with pytest.raises(ToolNodeError, match="Expected File object"):
         list(
-            node._transform_message(
+            node.transform_message(
                 messages=_message_stream(
                     ToolRuntimeMessage(
                         type=ToolRuntimeMessage.MessageType.FILE,

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -1,5 +1,3 @@
-from typing import Any, cast
-
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import (
     BooleanSegment,
@@ -14,34 +12,34 @@ from graphon.variables.variables import StringVariable
 class TestVariablePoolGetAndNestedAttribute:
     def test__get_nested_attribute_existing_key(self) -> None:
         pool = VariablePool.empty()
-        obj = {"a": 123}
-        segment = pool._get_nested_attribute(obj, "a")
+        pool.add(("node1", "obj"), {"a": 123})
+        segment = pool.get(("node1", "obj", "a"))
         assert segment is not None
         assert segment.value == 123
 
     def test__get_nested_attribute_missing_key(self) -> None:
         pool = VariablePool.empty()
-        obj = {"a": 123}
-        segment = pool._get_nested_attribute(obj, "b")
+        pool.add(("node1", "obj"), {"a": 123})
+        segment = pool.get(("node1", "obj", "b"))
         assert segment is None
 
     def test__get_nested_attribute_non_dict(self) -> None:
         pool = VariablePool.empty()
-        obj = ["not", "a", "dict"]
-        segment = pool._get_nested_attribute(cast(Any, obj), "a")
+        pool.add(("node1", "obj"), ["not", "a", "dict"])
+        segment = pool.get(("node1", "obj", "a"))
         assert segment is None
 
     def test__get_nested_attribute_with_none_value(self) -> None:
         pool = VariablePool.empty()
-        obj = {"a": None}
-        segment = pool._get_nested_attribute(obj, "a")
+        pool.add(("node1", "obj"), {"a": None})
+        segment = pool.get(("node1", "obj", "a"))
         assert segment is not None
         assert isinstance(segment, NoneSegment)
 
     def test__get_nested_attribute_with_empty_string(self) -> None:
         pool = VariablePool.empty()
-        obj = {"a": ""}
-        segment = pool._get_nested_attribute(obj, "a")
+        pool.add(("node1", "obj"), {"a": ""})
+        segment = pool.get(("node1", "obj", "a"))
         assert segment is not None
         assert isinstance(segment, StringSegment)
         assert not segment.value


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #32

## Summary

- removes remaining `SLF001` private member access across production code and tests
- adds narrow public seams where behavior needs stable reuse or observability
- moves tests from private internals to public contracts or explicit initialization helpers
- removes `SLF001` from the Ruff ignore list now that the repository is clean
- validation used for this change:
  - `ruff check .`
  - targeted `pytest` runs covering runtime, graph traversal, model runtime, http, document extraction, parameter extractor, code, tool, iteration, and loop paths

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
