### PR TITLE
fix(if-else): stop legacy fallback on case miss

### DIFF
--- a/src/graphon/nodes/if_else/entities.py
+++ b/src/graphon/nodes/if_else/entities.py
@@ -25,7 +25,7 @@ class IfElseNodeData(BaseNodeData):
     cases: list[Case] | None = None
 
     def iter_cases(self) -> list[Case]:
-        if self.cases:
+        if self.cases is not None:
             return list(self.cases)
         legacy_conditions = self.__dict__.get("conditions") or []
         return [

--- a/src/graphon/nodes/if_else/if_else_node.py
+++ b/src/graphon/nodes/if_else/if_else_node.py
@@ -1,7 +1,5 @@
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal, override
-
-from typing_extensions import deprecated
+from typing import Any, override
 
 from graphon.enums import (
     BuiltinNodeTypes,
@@ -11,9 +9,7 @@ from graphon.enums import (
 from graphon.node_events.base import NodeRunResult
 from graphon.nodes.base.node import Node
 from graphon.nodes.if_else.entities import IfElseNodeData
-from graphon.runtime.variable_pool import VariablePool
-from graphon.utils.condition.entities import Condition
-from graphon.utils.condition.processor import ConditionCheckResult, ConditionProcessor
+from graphon.utils.condition.processor import ConditionProcessor
 
 
 class IfElseNode(Node[IfElseNodeData]):
@@ -37,7 +33,7 @@ class IfElseNode(Node[IfElseNodeData]):
         selected_case_id = "false"
         condition_processor = ConditionProcessor()
         try:
-            uses_legacy_shape = not self.node_data.cases
+            uses_legacy_shape = self.node_data.cases is None
             for case in self.node_data.iter_cases():
                 input_conditions, group_result, final_result = (
                     condition_processor.process_conditions(
@@ -58,25 +54,6 @@ class IfElseNode(Node[IfElseNodeData]):
                     selected_case_id = "true" if uses_legacy_shape else case.case_id
                     break
 
-            else:
-                # Keep the legacy fallback until all graph definitions use `cases`.
-                input_conditions, group_result, final_result = (
-                    _should_not_use_old_function(
-                        condition_processor=condition_processor,
-                        variable_pool=self.graph_runtime_state.variable_pool,
-                        conditions=self.node_data.conditions or [],
-                        operator=self.node_data.logical_operator or "and",
-                    )
-                )
-
-                selected_case_id = "true" if final_result else "false"
-
-                process_data["condition_results"].append({
-                    "group": "default",
-                    "results": group_result,
-                    "final_result": final_result,
-                })
-
             node_inputs["conditions"] = input_conditions
 
         except (TypeError, ValueError) as e:
@@ -93,7 +70,7 @@ class IfElseNode(Node[IfElseNodeData]):
             status=WorkflowNodeExecutionStatus.SUCCEEDED,
             inputs=node_inputs,
             process_data=process_data,
-            edge_source_handle=selected_case_id or "false",  # Use case ID or 'default'
+            edge_source_handle=selected_case_id or "false",
             outputs=outputs,
         )
 
@@ -114,18 +91,3 @@ class IfElseNode(Node[IfElseNodeData]):
                 var_mapping[key] = condition.variable_selector
 
         return var_mapping
-
-
-@deprecated("This function is deprecated. You should use the new cases structure.")
-def _should_not_use_old_function(
-    *,
-    condition_processor: ConditionProcessor,
-    variable_pool: VariablePool,
-    conditions: list[Condition],
-    operator: Literal["and", "or"],
-) -> ConditionCheckResult:
-    return condition_processor.process_conditions(
-        variable_pool=variable_pool,
-        conditions=conditions,
-        operator=operator,
-    )

--- a/tests/nodes/if_else/test_entities.py
+++ b/tests/nodes/if_else/test_entities.py
@@ -3,44 +3,98 @@ from graphon.nodes.if_else.if_else_node import IfElseNode
 from graphon.utils.condition.entities import Condition
 
 
-def test_iter_cases_normalizes_legacy_conditions() -> None:
-    condition = Condition(
-        variable_selector=["start", "flag"],
+def _condition(selector: list[str], value: str) -> Condition:
+    return Condition(
+        variable_selector=selector,
         comparison_operator="is",
-        value="yes",
-    )
-    node_data = IfElseNodeData(
-        logical_operator="or",
-        conditions=[condition],
+        value=value,
     )
 
-    cases = node_data.iter_cases()
 
-    assert len(cases) == 1
-    assert cases[0].case_id == "true"
-    assert cases[0].logical_operator == "or"
-    assert cases[0].conditions == [condition]
-
-
-def test_extract_variable_mapping_includes_legacy_conditions() -> None:
-    node_data = IfElseNodeData(
-        conditions=[
-            Condition(
-                variable_selector=["start", "flag"],
-                comparison_operator="is",
-                value="yes",
-            ),
-        ],
+def _extract_variable_mapping(node_data: IfElseNodeData) -> dict[str, list[str]]:
+    return dict(
+        IfElseNode.extract_variable_selector_to_variable_mapping(
+            graph_config={},
+            config={
+                "id": "if-node",
+                "data": node_data.model_dump(mode="json"),
+            },
+        )
     )
 
-    mapping = IfElseNode.extract_variable_selector_to_variable_mapping(
-        graph_config={},
-        config={
-            "id": "if-node",
-            "data": node_data.model_dump(mode="json"),
-        },
-    )
 
-    assert mapping == {
-        "if-node.#start.flag#": ["start", "flag"],
-    }
+class TestIfElseNodeDataIterCases:
+    def test_iter_cases_normalizes_legacy_conditions(self) -> None:
+        condition = _condition(["start", "flag"], "yes")
+        node_data = IfElseNodeData(
+            logical_operator="or",
+            conditions=[condition],
+        )
+
+        cases = node_data.iter_cases()
+
+        assert len(cases) == 1
+        assert cases[0].case_id == "true"
+        assert cases[0].logical_operator == "or"
+        assert cases[0].conditions == [condition]
+
+    def test_iter_cases_preserves_explicit_cases(self) -> None:
+        legacy_condition = _condition(["legacy", "flag"], "legacy")
+        case_condition = _condition(["cases", "flag"], "case")
+        explicit_case = IfElseNodeData.Case(
+            case_id="explicit",
+            logical_operator="and",
+            conditions=[case_condition],
+        )
+        node_data = IfElseNodeData(
+            logical_operator="or",
+            conditions=[legacy_condition],
+            cases=[explicit_case],
+        )
+
+        assert node_data.iter_cases() == [explicit_case]
+
+    def test_iter_cases_preserves_explicit_empty_cases(self) -> None:
+        node_data = IfElseNodeData(
+            conditions=[_condition(["legacy", "flag"], "legacy")],
+            cases=[],
+        )
+
+        assert node_data.iter_cases() == []
+
+
+class TestIfElseNodeVariableMapping:
+    def test_extract_variable_mapping_includes_legacy_conditions(self) -> None:
+        node_data = IfElseNodeData(
+            conditions=[_condition(["start", "flag"], "yes")],
+        )
+
+        assert _extract_variable_mapping(node_data) == {
+            "if-node.#start.flag#": ["start", "flag"],
+        }
+
+    def test_extract_variable_mapping_uses_cases_when_present(self) -> None:
+        node_data = IfElseNodeData(
+            conditions=[_condition(["legacy", "flag"], "legacy")],
+            cases=[
+                IfElseNodeData.Case(
+                    case_id="explicit",
+                    logical_operator="and",
+                    conditions=[_condition(["cases", "flag"], "case")],
+                )
+            ],
+        )
+
+        assert _extract_variable_mapping(node_data) == {
+            "if-node.#cases.flag#": ["cases", "flag"],
+        }
+
+    def test_extract_variable_mapping_ignores_legacy_conditions_for_empty_cases(
+        self,
+    ) -> None:
+        node_data = IfElseNodeData(
+            conditions=[_condition(["legacy", "flag"], "legacy")],
+            cases=[],
+        )
+
+        assert _extract_variable_mapping(node_data) == {}

--- a/tests/nodes/if_else/test_if_else_node.py
+++ b/tests/nodes/if_else/test_if_else_node.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Any
+
+import pytest
+
+from graphon.enums import WorkflowNodeExecutionStatus
+from graphon.graph_events.node import NodeRunSucceededEvent
+from graphon.node_events.base import NodeRunResult
+from graphon.nodes.if_else.if_else_node import IfElseNode
+from graphon.runtime.graph_runtime_state import GraphRuntimeState
+
+from ...helpers import build_graph_init_params, build_variable_pool
+
+
+def _condition(
+    *,
+    selector: tuple[str, ...] = ("start", "enabled"),
+    value: str = "true",
+) -> dict[str, Any]:
+    return {
+        "comparison_operator": "is",
+        "variable_selector": list(selector),
+        "value": value,
+    }
+
+
+def _case(
+    case_id: str,
+    *,
+    selector: tuple[str, ...] = ("start", "enabled"),
+    value: str = "true",
+    logical_operator: str = "and",
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "logical_operator": logical_operator,
+        "conditions": [_condition(selector=selector, value=value)],
+    }
+
+
+def _expected_input(
+    *,
+    actual_value: bool,
+    expected_value: bool,
+) -> dict[str, Any]:
+    return {
+        "actual_value": actual_value,
+        "expected_value": expected_value,
+        "comparison_operator": "is",
+    }
+
+
+def _expected_case_group(
+    case_id: str,
+    *,
+    selector: tuple[str, ...] = ("start", "enabled"),
+    value: str = "true",
+    logical_operator: str = "and",
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "logical_operator": logical_operator,
+        "conditions": [
+            {
+                "variable_selector": list(selector),
+                "comparison_operator": "is",
+                "value": value,
+                "sub_variable_condition": None,
+            }
+        ],
+    }
+
+
+def _expected_condition_result(
+    *,
+    group: str | dict[str, Any],
+    result: bool,
+) -> dict[str, Any]:
+    return {
+        "group": group,
+        "results": [result],
+        "final_result": result,
+    }
+
+
+@dataclass(frozen=True)
+class RunScenario:
+    name: str
+    data: dict[str, Any]
+    expected_outputs: dict[str, Any]
+    expected_edge_source_handle: str
+    expected_inputs: list[dict[str, Any]]
+    expected_condition_results: list[dict[str, Any]]
+    variables: tuple[tuple[tuple[str, ...], Any], ...] = field(
+        default_factory=lambda: ((("start", "enabled"), True),),
+    )
+
+
+def _run_scenarios() -> list[RunScenario]:
+    return [
+        RunScenario(
+            name="legacy_match",
+            data={
+                "type": "if-else",
+                "title": "If Else",
+                "logical_operator": "and",
+                "conditions": [_condition(value="true")],
+            },
+            expected_outputs={"result": True, "selected_case_id": "true"},
+            expected_edge_source_handle="true",
+            expected_inputs=[_expected_input(actual_value=True, expected_value=True)],
+            expected_condition_results=[
+                _expected_condition_result(group="default", result=True)
+            ],
+        ),
+        RunScenario(
+            name="legacy_miss_does_not_duplicate_results",
+            data={
+                "type": "if-else",
+                "title": "If Else",
+                "logical_operator": "and",
+                "conditions": [_condition(value="false")],
+            },
+            expected_outputs={"result": False, "selected_case_id": "false"},
+            expected_edge_source_handle="false",
+            expected_inputs=[_expected_input(actual_value=True, expected_value=False)],
+            expected_condition_results=[
+                _expected_condition_result(group="default", result=False)
+            ],
+        ),
+        RunScenario(
+            name="cases_match_after_initial_miss_short_circuits",
+            data={
+                "type": "if-else",
+                "title": "If Else",
+                "logical_operator": "and",
+                "conditions": [_condition(value="false")],
+                "cases": [
+                    _case("first", value="false"),
+                    _case("second", value="true"),
+                    _case("unreachable", selector=("missing", "flag"), value="true"),
+                ],
+            },
+            expected_outputs={"result": True, "selected_case_id": "second"},
+            expected_edge_source_handle="second",
+            expected_inputs=[_expected_input(actual_value=True, expected_value=True)],
+            expected_condition_results=[
+                _expected_condition_result(
+                    group=_expected_case_group("first", value="false"),
+                    result=False,
+                ),
+                _expected_condition_result(
+                    group=_expected_case_group("second", value="true"),
+                    result=True,
+                ),
+            ],
+        ),
+        RunScenario(
+            name="cases_miss_ignores_legacy_conditions",
+            data={
+                "type": "if-else",
+                "title": "If Else",
+                "logical_operator": "and",
+                "conditions": [_condition(value="true")],
+                "cases": [_case("true", value="false")],
+            },
+            expected_outputs={"result": False, "selected_case_id": "false"},
+            expected_edge_source_handle="false",
+            expected_inputs=[_expected_input(actual_value=True, expected_value=False)],
+            expected_condition_results=[
+                _expected_condition_result(
+                    group=_expected_case_group("true", value="false"),
+                    result=False,
+                )
+            ],
+        ),
+        RunScenario(
+            name="explicit_empty_cases_do_not_fallback_to_legacy_conditions",
+            data={
+                "type": "if-else",
+                "title": "If Else",
+                "logical_operator": "and",
+                "conditions": [_condition(value="true")],
+                "cases": [],
+            },
+            expected_outputs={"result": False, "selected_case_id": "false"},
+            expected_edge_source_handle="false",
+            expected_inputs=[],
+            expected_condition_results=[],
+        ),
+    ]
+
+
+RUN_SCENARIOS = _run_scenarios()
+
+
+def _run_if_else_node(
+    *,
+    data: dict[str, Any],
+    variables: tuple[tuple[tuple[str, ...], Any], ...],
+) -> tuple[NodeRunResult, list[warnings.WarningMessage]]:
+    runtime_state = GraphRuntimeState(
+        variable_pool=build_variable_pool(variables=variables),
+        start_at=perf_counter(),
+    )
+    node = IfElseNode(
+        node_id="if-node",
+        config=data,
+        graph_init_params=build_graph_init_params(
+            graph_config={"nodes": [], "edges": []},
+        ),
+        graph_runtime_state=runtime_state,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        events = list(node.run())
+
+    result_event = next(
+        event for event in events if isinstance(event, NodeRunSucceededEvent)
+    )
+    return result_event.node_run_result, caught
+
+
+def _assert_no_deprecation_warnings(
+    caught: list[warnings.WarningMessage],
+) -> None:
+    assert not any(isinstance(w.message, DeprecationWarning) for w in caught)
+
+
+class TestIfElseNodeRun:
+    @pytest.mark.parametrize(
+        "scenario",
+        RUN_SCENARIOS,
+        ids=[scenario.name for scenario in RUN_SCENARIOS],
+    )
+    def test_run_scenarios(self, scenario: RunScenario) -> None:
+        result, caught = _run_if_else_node(
+            data=scenario.data,
+            variables=scenario.variables,
+        )
+
+        assert result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+        assert result.outputs == scenario.expected_outputs
+        assert result.edge_source_handle == scenario.expected_edge_source_handle
+        assert result.inputs == {"conditions": scenario.expected_inputs}
+        assert (
+            result.process_data["condition_results"]
+            == scenario.expected_condition_results
+        )
+        _assert_no_deprecation_warnings(caught)


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #43

## Summary

- stop falling back to deprecated top-level `conditions` when `cases` are present but none match
- treat `cases=[]` as an explicit new-shape configuration instead of a legacy signal
- restructure the `if_else` tests around runtime behavior, shape priority, short-circuiting, warnings, and variable mapping

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
