### PR TITLE
refactor(nodes)!: rename typed constructor config to data

### DIFF
--- a/examples/graphon_openai_slim/workflow.py
+++ b/examples/graphon_openai_slim/workflow.py
@@ -255,7 +255,7 @@ def build_graph(
 ) -> Graph:
     start_node = StartNode(
         node_id="start",
-        config=StartNodeData(
+        data=StartNodeData(
             title="Start",
             variables=[
                 VariableEntity(
@@ -272,7 +272,7 @@ def build_graph(
 
     llm_node = LLMNode(
         node_id="llm",
-        config=LLMNodeData(
+        data=LLMNodeData(
             title="LLM",
             model=ModelConfig(
                 provider=provider,
@@ -300,7 +300,7 @@ def build_graph(
 
     output_node = AnswerNode(
         node_id="output",
-        config=AnswerNodeData(
+        data=AnswerNodeData(
             title="Output",
             answer="{{#llm.text#}}",
         ),

--- a/src/graphon/nodes/base/node.py
+++ b/src/graphon/nodes/base/node.py
@@ -183,7 +183,7 @@ class _NodeDataModelMixin[NodeDataT: BaseNodeData]:
 
         This convenience wrapper keeps direct node construction ergonomic for
         callers that naturally start from plain dictionaries while preserving the
-        stricter `Node.__init__(..., config=NodeDataT, ...)` contract.
+        stricter `Node.__init__(..., data=NodeDataT, ...)` contract.
 
         Returns:
             The validated node data instance for the concrete node subclass.
@@ -552,7 +552,7 @@ class Node[NodeDataT: BaseNodeData](
     def __init__(
         self,
         node_id: str,
-        config: NodeDataT,
+        data: NodeDataT,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -574,7 +574,7 @@ class Node[NodeDataT: BaseNodeData](
         self._node_execution_id: str = ""
         self._start_at = datetime.now(UTC).replace(tzinfo=None)
 
-        self._node_data = self.validate_node_data(config)
+        self._node_data = self.validate_node_data(data)
 
         self.post_init()
 

--- a/src/graphon/nodes/code/code_node.py
+++ b/src/graphon/nodes/code/code_node.py
@@ -82,7 +82,7 @@ class CodeNode(Node[CodeNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: CodeNodeData,
+        data: CodeNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -91,7 +91,7 @@ class CodeNode(Node[CodeNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -249,7 +249,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: DocumentExtractorNodeData,
+        data: DocumentExtractorNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -258,7 +258,7 @@ class DocumentExtractorNode(Node[DocumentExtractorNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/http_request/node.py
+++ b/src/graphon/nodes/http_request/node.py
@@ -55,7 +55,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: HttpRequestNodeData,
+        data: HttpRequestNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -68,7 +68,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -65,7 +65,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: HumanInputNodeData,
+        data: HumanInputNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -77,7 +77,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -128,7 +128,7 @@ class LLMNode(Node[LLMNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: LLMNodeData,
+        data: LLMNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -145,7 +145,7 @@ class LLMNode(Node[LLMNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -179,7 +179,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: ParameterExtractorNodeData,
+        data: ParameterExtractorNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -192,7 +192,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -147,7 +147,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: ParameterExtractorNodeData,
+        data: ParameterExtractorNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -163,7 +163,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: ParameterExtractorNodeData,
+        data: ParameterExtractorNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,

--- a/src/graphon/nodes/question_classifier/question_classifier_node.py
+++ b/src/graphon/nodes/question_classifier/question_classifier_node.py
@@ -105,7 +105,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: QuestionClassifierNodeData,
+        data: QuestionClassifierNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -121,7 +121,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/template_transform/template_transform_node.py
+++ b/src/graphon/nodes/template_transform/template_transform_node.py
@@ -37,7 +37,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: TemplateTransformNodeData,
+        data: TemplateTransformNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -46,7 +46,7 @@ class TemplateTransformNode(Node[TemplateTransformNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/tool/tool_node.py
+++ b/src/graphon/nodes/tool/tool_node.py
@@ -60,7 +60,7 @@ class ToolNode(Node[ToolNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: ToolNodeData,
+        data: ToolNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
@@ -72,7 +72,7 @@ class ToolNode(Node[ToolNodeData]):
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/variable_assigner/v1/node.py
+++ b/src/graphon/nodes/variable_assigner/v1/node.py
@@ -37,14 +37,14 @@ class VariableAssignerNode(Node[VariableAssignerData]):
     def __init__(
         self,
         node_id: str,
-        config: VariableAssignerData,
+        data: VariableAssignerData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/src/graphon/nodes/variable_assigner/v2/node.py
+++ b/src/graphon/nodes/variable_assigner/v2/node.py
@@ -79,14 +79,14 @@ class VariableAssignerNode(Node[VariableAssignerNodeData]):
     def __init__(
         self,
         node_id: str,
-        config: VariableAssignerNodeData,
+        data: VariableAssignerNodeData,
         *,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )

--- a/tests/graph/test_graph_validation.py
+++ b/tests/graph/test_graph_validation.py
@@ -37,13 +37,13 @@ class _TestNode(Node[_TestNodeData]):
         self,
         *,
         node_id: str,
-        config: _TestNodeData,
+        data: _TestNodeData,
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
     ) -> None:
         super().__init__(
             node_id=node_id,
-            config=config,
+            data=data,
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
@@ -78,7 +78,7 @@ class _SimpleNodeFactory:
     def create_node(self, node_config: NodeConfigDict) -> _TestNode:
         return _TestNode(
             node_id=str(node_config["id"]),
-            config=_TestNode.validate_node_data(node_config["data"]),
+            data=_TestNode.validate_node_data(node_config["data"]),
             graph_init_params=self.graph_init_params,
             graph_runtime_state=self.graph_runtime_state,
         )

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -261,7 +261,7 @@ def test_http_request_node_rejects_mixed_dependency_inputs() -> None:
     ):
         HttpRequestNode(
             node_id="http",
-            config=HttpRequestNodeData(
+            data=HttpRequestNodeData(
                 title="HTTP Request",
                 method="get",
                 url="https://example.com",
@@ -286,7 +286,7 @@ def test_http_request_node_uses_configured_default_http_client() -> None:
 
     node = HttpRequestNode(
         node_id="http",
-        config=HttpRequestNodeData(
+        data=HttpRequestNodeData(
             title="HTTP Request",
             method="get",
             url="https://example.com",
@@ -330,7 +330,7 @@ def test_document_extractor_node_uses_configured_default_http_client() -> None:
 
     node = DocumentExtractorNode(
         node_id="extractor",
-        config=DocumentExtractorNodeData(
+        data=DocumentExtractorNodeData(
             title="Document Extractor",
             variable_selector=["inputs", "file"],
         ),

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -234,7 +234,7 @@ def test_set_http_client_updates_process_default() -> None:
 def test_http_request_node_accepts_public_dependency_bundle() -> None:
     node = HttpRequestNode(
         node_id="http",
-        config=HttpRequestNodeData(
+        data=HttpRequestNodeData(
             title="HTTP Request",
             method="get",
             url="https://example.com",
@@ -311,7 +311,7 @@ def test_http_request_node_uses_configured_default_http_client() -> None:
 def test_document_extractor_node_uses_default_http_client_when_not_injected() -> None:
     node = DocumentExtractorNode(
         node_id="extractor",
-        config=DocumentExtractorNodeData(
+        data=DocumentExtractorNodeData(
             title="Document Extractor",
             variable_selector=["inputs", "file"],
         ),

--- a/tests/nodes/human_input/test_human_input_node.py
+++ b/tests/nodes/human_input/test_human_input_node.py
@@ -80,7 +80,7 @@ def _build_node(*, form: _FakeForm) -> HumanInputNode:
     )
     return HumanInputNode(
         node_id="human_input_node",
-        config=node_data,
+        data=node_data,
         graph_init_params=_build_graph_init_params(),
         graph_runtime_state=GraphRuntimeState(
             variable_pool=VariablePool(),

--- a/tests/nodes/if_else/test_if_else_node.py
+++ b/tests/nodes/if_else/test_if_else_node.py
@@ -209,7 +209,7 @@ def _run_if_else_node(
     )
     node = IfElseNode(
         node_id="if-node",
-        config=IfElseNode.validate_node_data(data),
+        data=data,
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),

--- a/tests/nodes/if_else/test_if_else_node.py
+++ b/tests/nodes/if_else/test_if_else_node.py
@@ -209,7 +209,7 @@ def _run_if_else_node(
     )
     node = IfElseNode(
         node_id="if-node",
-        data=data,
+        data=IfElseNode.validate_node_data(data),
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -13,7 +13,7 @@ from ...helpers import build_graph_init_params, build_variable_pool
 def _build_llm_node() -> LLMNode:
     return LLMNode(
         node_id="llm",
-        config=LLMNodeData.model_validate({
+        data=LLMNodeData.model_validate({
             "title": "LLM",
             "model": {
                 "provider": "openai",

--- a/tests/nodes/parameter_extractor/test_prompts.py
+++ b/tests/nodes/parameter_extractor/test_prompts.py
@@ -60,7 +60,7 @@ def _build_parameter_extractor_node() -> tuple[ParameterExtractorNode, VariableP
         ParameterExtractorNode,
         _call_parameter_extractor_constructor(
             node_id="extractor",
-            config=ParameterExtractorNodeData(
+            data=ParameterExtractorNodeData(
                 title="Parameter Extractor",
                 model=ModelConfig(
                     provider="test",
@@ -232,7 +232,7 @@ def test_parameter_extractor_accepts_dependency_bundle() -> None:
         ParameterExtractorNode,
         _call_parameter_extractor_constructor(
             node_id="extractor",
-            config=ParameterExtractorNodeData(
+            data=ParameterExtractorNodeData(
                 title="Parameter Extractor",
                 model=ModelConfig(
                     provider="test",
@@ -260,7 +260,7 @@ def test_parameter_extractor_rejects_mixed_dependency_styles() -> None:
     with pytest.raises(TypeError, match="Pass either dependencies="):
         _call_parameter_extractor_constructor(
             node_id="extractor",
-            config=ParameterExtractorNodeData(
+            data=ParameterExtractorNodeData(
                 title="Parameter Extractor",
                 model=ModelConfig(
                     provider="test",
@@ -300,7 +300,7 @@ def test_parameter_extractor_legacy_dependency_keywords_still_work() -> None:
 
     node = ParameterExtractorNode(
         node_id="extractor",
-        config=ParameterExtractorNodeData(
+        data=ParameterExtractorNodeData(
             title="Parameter Extractor",
             model=ModelConfig(
                 provider="test",

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -74,7 +74,7 @@ def _build_question_classifier_node(
 ) -> QuestionClassifierNode:
     return QuestionClassifierNode(
         node_id="classifier",
-        config=node_data,
+        data=node_data,
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),
@@ -136,7 +136,7 @@ def test_question_classifier_constructor_accepts_dependency_bundle(
     )
     node = QuestionClassifierNode(
         node_id="classifier",
-        config=node_data,
+        data=node_data,
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),
@@ -206,7 +206,7 @@ def test_question_classifier_constructor_rejects_mixed_dependency_inputs() -> No
     with pytest.raises(TypeError, match="runtime collaborators twice"):
         QuestionClassifierNode(
             node_id="classifier",
-            config=node_data,
+            data=node_data,
             graph_init_params=build_graph_init_params(
                 graph_config={"nodes": [], "edges": []},
             ),

--- a/tests/nodes/test_human_input_runtime_binding.py
+++ b/tests/nodes/test_human_input_runtime_binding.py
@@ -144,7 +144,7 @@ def _build_human_input_node(
 ) -> HumanInputNode:
     return HumanInputNode(
         node_id="human-input-node",
-        config=HumanInputNodeData(title="Human Input"),
+        data=HumanInputNodeData(title="Human Input"),
         graph_init_params=build_graph_init_params(
             graph_config={"nodes": [], "edges": []},
         ),

--- a/tests/nodes/variable_assigner/test_v1_node.py
+++ b/tests/nodes/variable_assigner/test_v1_node.py
@@ -33,7 +33,7 @@ def _build_node(
         node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
-        config=VariableAssignerData(
+        data=VariableAssignerData(
             title="Variable Assigner",
             assigned_variable_selector=assigned_selector,
             write_mode=write_mode,

--- a/tests/nodes/variable_assigner/test_v2_node.py
+++ b/tests/nodes/variable_assigner/test_v2_node.py
@@ -39,7 +39,7 @@ def _build_node(
         node_id="assigner",
         graph_init_params=init_params,
         graph_runtime_state=runtime_state,
-        config=VariableAssignerNodeData(
+        data=VariableAssignerNodeData(
             title="Variable Assigner",
             version="2",
             items=items,


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #47

## Summary

This follow-up to #38 / #39 renames the typed node-constructor keyword from `config` to `data` now that direct instantiation accepts concrete `*NodeData` payloads instead of raw `{id, data}` config objects.

What changed:
- renamed `Node.__init__(..., config=...)` to `Node.__init__(..., data=...)`
- updated concrete node subclasses to forward `data=` instead of `config=`
- updated direct instantiation call sites in examples and tests
- left raw graph boundary types such as `NodeConfigDict` unchanged

Why it changed:
- `config` still refers to the outer graph payload in this codebase
- the constructor now receives the inner typed node data payload
- nodes that already depend on real `*_config` collaborators read more clearly after the rename

Developer impact:
- direct keyword construction now uses `data=` instead of `config=`
- raw graph parsing code that still works with `NodeConfigDict` is unchanged

Validation:
- `make check`
- `uv run pytest tests/graph/test_graph_validation.py tests/http/test_client.py tests/nodes/parameter_extractor/test_prompts.py tests/nodes/variable_assigner/test_v1_node.py tests/nodes/variable_assigner/test_v2_node.py`

CLA Assistant has not prompted on this pull request yet.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
