### PR TITLE
feat: question classifier labels graphon

### DIFF
--- a/src/graphon/nodes/question_classifier/entities.py
+++ b/src/graphon/nodes/question_classifier/entities.py
@@ -10,8 +10,23 @@ from graphon.prompt_entities import MemoryConfig
 
 
 class ClassConfig(BaseModel):
-    id: str
-    name: str
+    """Question Classifier branch configuration."""
+
+    id: str = Field(
+        description="Stable branch identifier used for routing and edge handles.",
+    )
+    name: str = Field(
+        description=(
+            "Classifier-facing category description used in prompts "
+            "and returned as class_name."
+        ),
+    )
+    label: str | None = Field(
+        default=None,
+        description=(
+            "Optional user-facing branch label exposed separately as class_label."
+        ),
+    )
 
 
 class QuestionClassifierNodeData(BaseNodeData):

--- a/src/graphon/nodes/question_classifier/entities.py
+++ b/src/graphon/nodes/question_classifier/entities.py
@@ -21,8 +21,8 @@ class ClassConfig(BaseModel):
             "and returned as class_name."
         ),
     )
-    label: str | None = Field(
-        default=None,
+    label: str = Field(
+        default="",
         description=(
             "Optional user-facing branch label exposed separately as class_label."
         ),

--- a/src/graphon/nodes/question_classifier/question_classifier_node.py
+++ b/src/graphon/nodes/question_classifier/question_classifier_node.py
@@ -131,6 +131,10 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
     def version(cls) -> str:
         return "1"
 
+    @staticmethod
+    def _default_class_label(index: int) -> str:
+        return f"CLASS {index}"
+
     @override
     def _run(self) -> NodeRunResult:
         run_context = self._prepare_run_context()
@@ -140,7 +144,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             result_text, usage, finish_reason = self._invoke_classifier(
                 run_context=run_context,
             )
-            category_name, category_id = self._resolve_category(
+            category_name, category_id, category_label = self._resolve_category(
                 rendered_classes=run_context.rendered_classes,
                 result_text=result_text,
             )
@@ -149,6 +153,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
                 usage=usage,
                 finish_reason=finish_reason,
                 category_name=category_name,
+                category_label=category_label,
                 category_id=category_id,
             )
         except ValueError as e:
@@ -277,22 +282,35 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         *,
         rendered_classes: Sequence[Any],
         result_text: str,
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, str]:
         category_name = rendered_classes[0].name
         category_id = rendered_classes[0].id
+        category_label = rendered_classes[
+            0
+        ].label or QuestionClassifierNode._default_class_label(1)
         cleaned_result_text = QuestionClassifierNode._strip_think_tags(result_text)
         result_text_json = parse_and_check_json_markdown(cleaned_result_text, [])
         if (
             "category_name" not in result_text_json
             or "category_id" not in result_text_json
         ):
-            return category_name, category_id
+            return category_name, category_id, category_label
 
         category_id_result = result_text_json["category_id"]
-        classes_map = {class_.id: class_.name for class_ in rendered_classes}
+        classes_map = {
+            class_.id: {
+                "name": class_.name,
+                "label": (
+                    class_.label
+                    or QuestionClassifierNode._default_class_label(index + 1)
+                ),
+            }
+            for index, class_ in enumerate(rendered_classes)
+        }
         if category_id_result in classes_map:
-            return classes_map[category_id_result], category_id_result
-        return category_name, category_id
+            category = classes_map[category_id_result]
+            return category["name"], category_id_result, category["label"]
+        return category_name, category_id, category_label
 
     @staticmethod
     def _strip_think_tags(result_text: str) -> str:
@@ -312,6 +330,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         usage: LLMUsage,
         finish_reason: str | None,
         category_name: str,
+        category_label: str,
         category_id: str,
     ) -> NodeRunResult:
         process_data = {
@@ -327,6 +346,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         }
         outputs = {
             "class_name": category_name,
+            "class_label": category_label,
             "class_id": category_id,
             "usage": jsonable_encoder(usage),
         }

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -1,4 +1,18 @@
-from graphon.nodes.question_classifier import QuestionClassifierNodeData
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.node_events.node import ModelInvokeCompletedEvent
+from graphon.nodes.question_classifier import (
+    QuestionClassifierNode,
+    QuestionClassifierNodeData,
+)
+from graphon.nodes.question_classifier.question_classifier_node import llm_utils
+from graphon.runtime.graph_runtime_state import GraphRuntimeState
+
+from ...helpers import build_graph_init_params
 
 
 def test_question_classifier_node_data_accepts_optional_label() -> None:
@@ -41,3 +55,171 @@ def test_question_classifier_node_data_defaults_label_to_none() -> None:
     })
 
     assert node_data.classes[0].label is None
+
+
+def _build_question_classifier_node(
+    node_data: QuestionClassifierNodeData,
+    *,
+    variable_pool: MagicMock,
+    template_renderer: MagicMock,
+) -> QuestionClassifierNode:
+    return QuestionClassifierNode(
+        node_id="classifier",
+        config=node_data,
+        graph_init_params=build_graph_init_params(
+            graph_config={"nodes": [], "edges": []},
+        ),
+        graph_runtime_state=GraphRuntimeState(
+            variable_pool=variable_pool,
+            start_at=0.0,
+        ),
+        model_instance=MagicMock(
+            provider="openai",
+            model_name="gpt-4o",
+            stop=(),
+            parameters={},
+        ),
+        template_renderer=template_renderer,
+        llm_file_saver=MagicMock(),
+    )
+
+
+def test_question_classifier_run_returns_custom_class_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node_data = QuestionClassifierNodeData.model_validate({
+        "title": "Classifier",
+        "query_variable_selector": ["start", "sys.query"],
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "classes": [
+            {
+                "id": "billing",
+                "name": "Questions about invoices and charges",
+                "label": "Billing",
+            },
+            {
+                "id": "refund",
+                "name": "Questions about refunds",
+                "label": "Refund desk",
+            },
+        ],
+        "instruction": "Classify the query",
+    })
+    variable_pool = MagicMock()
+    variable_pool.get.return_value = SimpleNamespace(value="Where is my refund?")
+    variable_pool.convert_template.side_effect = lambda value: SimpleNamespace(
+        text=value
+    )
+    template_renderer = MagicMock()
+    node = _build_question_classifier_node(
+        node_data,
+        variable_pool=variable_pool,
+        template_renderer=template_renderer,
+    )
+
+    monkeypatch.setattr(
+        llm_utils,
+        "resolve_completion_params_variables",
+        lambda parameters, _: parameters,
+    )
+    monkeypatch.setattr(
+        llm_utils,
+        "fetch_prompt_messages",
+        MagicMock(return_value=([], None)),
+    )
+    monkeypatch.setattr(node, "_calculate_rest_token", MagicMock(return_value=1024))
+    monkeypatch.setattr(node, "_get_prompt_template", MagicMock(return_value=[]))
+    monkeypatch.setattr(
+        "graphon.nodes.question_classifier.question_classifier_node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text=(
+                    '{"category_id": "refund", '
+                    '"category_name": "Questions about refunds"}'
+                ),
+                usage=LLMUsage.empty_usage(),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    result = node._run()  # noqa: SLF001
+
+    assert result.outputs["class_name"] == "Questions about refunds"
+    assert result.outputs["class_label"] == "Refund desk"
+    assert result.outputs["class_id"] == "refund"
+
+
+def test_question_classifier_run_falls_back_to_canonical_class_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node_data = QuestionClassifierNodeData.model_validate({
+        "title": "Classifier",
+        "query_variable_selector": ["start", "sys.query"],
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "classes": [
+            {
+                "id": "billing",
+                "name": "Questions about invoices and charges",
+                "label": "Billing",
+            },
+            {
+                "id": "refund",
+                "name": "Questions about refunds",
+            },
+        ],
+        "instruction": "Classify the query",
+    })
+    variable_pool = MagicMock()
+    variable_pool.get.return_value = SimpleNamespace(value="Where is my refund?")
+    variable_pool.convert_template.side_effect = lambda value: SimpleNamespace(
+        text=value
+    )
+    template_renderer = MagicMock()
+    node = _build_question_classifier_node(
+        node_data,
+        variable_pool=variable_pool,
+        template_renderer=template_renderer,
+    )
+
+    monkeypatch.setattr(
+        llm_utils,
+        "resolve_completion_params_variables",
+        lambda parameters, _: parameters,
+    )
+    monkeypatch.setattr(
+        llm_utils,
+        "fetch_prompt_messages",
+        MagicMock(return_value=([], None)),
+    )
+    monkeypatch.setattr(node, "_calculate_rest_token", MagicMock(return_value=1024))
+    monkeypatch.setattr(node, "_get_prompt_template", MagicMock(return_value=[]))
+    monkeypatch.setattr(
+        "graphon.nodes.question_classifier.question_classifier_node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text=(
+                    '{"category_id": "refund", '
+                    '"category_name": "Questions about refunds"}'
+                ),
+                usage=LLMUsage.empty_usage(),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    result = node._run()  # noqa: SLF001
+
+    assert result.outputs["class_name"] == "Questions about refunds"
+    assert result.outputs["class_label"] == "CLASS 2"
+    assert result.outputs["class_id"] == "refund"

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -1,0 +1,43 @@
+from graphon.nodes.question_classifier import QuestionClassifierNodeData
+
+
+def test_question_classifier_node_data_accepts_optional_label() -> None:
+    node_data = QuestionClassifierNodeData.model_validate({
+        "title": "Classifier",
+        "query_variable_selector": ["start", "sys.query"],
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "classes": [
+            {
+                "id": "billing",
+                "name": "Questions about invoices and charges",
+                "label": "Billing",
+            }
+        ],
+        "instruction": "Classify the query",
+    })
+
+    assert node_data.classes[0].id == "billing"
+    assert node_data.classes[0].name == "Questions about invoices and charges"
+    assert node_data.classes[0].label == "Billing"
+
+
+def test_question_classifier_node_data_defaults_label_to_none() -> None:
+    node_data = QuestionClassifierNodeData.model_validate({
+        "title": "Classifier",
+        "query_variable_selector": ["start", "sys.query"],
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "classes": [{"id": "billing", "name": "Questions about invoices and charges"}],
+        "instruction": "Classify the query",
+    })
+
+    assert node_data.classes[0].label is None

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -40,7 +40,7 @@ def test_question_classifier_node_data_accepts_optional_label() -> None:
     assert node_data.classes[0].label == "Billing"
 
 
-def test_question_classifier_node_data_defaults_label_to_none() -> None:
+def test_question_classifier_node_data_defaults_label_to_empty_string() -> None:
     node_data = QuestionClassifierNodeData.model_validate({
         "title": "Classifier",
         "query_variable_selector": ["start", "sys.query"],
@@ -54,7 +54,7 @@ def test_question_classifier_node_data_defaults_label_to_none() -> None:
         "instruction": "Classify the query",
     })
 
-    assert node_data.classes[0].label is None
+    assert not node_data.classes[0].label
 
 
 def _build_question_classifier_node(


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #63

Refs langgenius/dify#33806  
Refs langgenius/dify#35429  
Supersedes runtime portion of langgenius/dify#34075  
Companion issue: langgenius/dify#35429  
Companion PR: langgenius/dify#35430

## Summary

<img width="1497" height="831" alt="568930390-9e754181-e731-4700-aca8-c5399a02b7e7" src="https://github.com/user-attachments/assets/47112ceb-de96-48c5-a353-e42b4b861294" />

This adds runtime support for editable Question Classifier labels after the workflow engine moved from Dify into Graphon.

The change makes the field semantics explicit:

- `id`: stable branch identifier used for routing and handles
- `name`: classifier-facing category description used in prompt construction and returned as `class_name`
- `label`: user-facing branch title returned as `class_label`

Included changes:

- adds optional `label` to `ClassConfig`
- documents the distinction between `id`, `name`, and `label`
- emits `class_label` from the Question Classifier node result
- falls back to canonical `CLASS N` labels when none is provided
- adds runtime tests covering custom labels and fallback behavior

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
