### PR TITLE
refactor(document-extractor): centralize text extractor dispatch

### DIFF
--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -8,6 +8,7 @@ import pathlib
 import tempfile
 import zipfile
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, override
 
 import charset_normalizer
@@ -51,32 +52,6 @@ _MIME_PLAIN_TEXT_TYPES = frozenset((
     "text/markdown",
     "text/xml",
 ))
-_MIME_DIRECT_EXTRACTOR_NAMES: dict[str, str] = {
-    "application/pdf": "_extract_text_from_pdf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
-        "_extract_text_from_docx"
-    ),
-    "text/csv": "_extract_text_from_csv",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
-        "_extract_text_from_excel"
-    ),
-    "application/vnd.ms-excel": "_extract_text_from_excel",
-    "message/rfc822": "_extract_text_from_eml",
-    "application/vnd.ms-outlook": "_extract_text_from_msg",
-    "application/json": "_extract_text_from_json",
-    "application/x-yaml": "_extract_text_from_yaml",
-    "text/yaml": "_extract_text_from_yaml",
-    "text/vtt": "_extract_text_from_vtt",
-    "text/properties": "_extract_text_from_properties",
-}
-_MIME_UNSTRUCTURED_EXTRACTOR_NAMES: dict[str, str] = {
-    "application/msword": "_extract_text_from_doc",
-    "application/vnd.ms-powerpoint": "_extract_text_from_ppt",
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation": (
-        "_extract_text_from_pptx"
-    ),
-    "application/epub+zip": "_extract_text_from_epub",
-}
 _EXTENSION_PLAIN_TEXT_TYPES = frozenset((
     ".txt",
     ".markdown",
@@ -129,25 +104,107 @@ _EXTENSION_PLAIN_TEXT_TYPES = frozenset((
     ".log",
     ".vtt",
 ))
-_EXTENSION_DIRECT_EXTRACTOR_NAMES: dict[str, str] = {
-    ".json": "_extract_text_from_json",
-    ".yaml": "_extract_text_from_yaml",
-    ".yml": "_extract_text_from_yaml",
-    ".pdf": "_extract_text_from_pdf",
-    ".docx": "_extract_text_from_docx",
-    ".csv": "_extract_text_from_csv",
-    ".xls": "_extract_text_from_excel",
-    ".xlsx": "_extract_text_from_excel",
-    ".eml": "_extract_text_from_eml",
-    ".msg": "_extract_text_from_msg",
-    ".properties": "_extract_text_from_properties",
-}
-_EXTENSION_UNSTRUCTURED_EXTRACTOR_NAMES: dict[str, str] = {
-    ".doc": "_extract_text_from_doc",
-    ".ppt": "_extract_text_from_ppt",
-    ".pptx": "_extract_text_from_pptx",
-    ".epub": "_extract_text_from_epub",
-}
+
+
+@dataclass(frozen=True)
+class _ExtractorRegistration:
+    name: str
+    extractor: Callable[..., str]
+    mime_types: frozenset[str] = frozenset()
+    file_extensions: frozenset[str] = frozenset()
+    requires_unstructured_config: bool = False
+
+    def extract(
+        self,
+        *,
+        file_content: bytes,
+        unstructured_api_config: UnstructuredApiConfig,
+    ) -> str:
+        if self.requires_unstructured_config:
+            return self.extractor(
+                file_content,
+                unstructured_api_config=unstructured_api_config,
+            )
+        return self.extractor(file_content)
+
+
+class _TextExtractorRegistry:
+    def __init__(self, registrations: Sequence[_ExtractorRegistration]) -> None:
+        self._mime_type_extractors = self._build_lookup(
+            registrations,
+            kind_selector=lambda registration: registration.mime_types,
+        )
+        self._file_extension_extractors = self._build_lookup(
+            registrations,
+            kind_selector=lambda registration: registration.file_extensions,
+        )
+
+    def extract_by_mime_type(
+        self,
+        *,
+        file_content: bytes,
+        mime_type: str,
+        unstructured_api_config: UnstructuredApiConfig,
+    ) -> str:
+        return self._extract(
+            extractor_lookup=self._mime_type_extractors,
+            file_content=file_content,
+            file_kind=mime_type,
+            unstructured_api_config=unstructured_api_config,
+            error_label="Unsupported MIME type",
+        )
+
+    def extract_by_file_extension(
+        self,
+        *,
+        file_content: bytes,
+        file_extension: str,
+        unstructured_api_config: UnstructuredApiConfig,
+    ) -> str:
+        return self._extract(
+            extractor_lookup=self._file_extension_extractors,
+            file_content=file_content,
+            file_kind=file_extension,
+            unstructured_api_config=unstructured_api_config,
+            error_label="Unsupported Extension Type",
+        )
+
+    @staticmethod
+    def _build_lookup(
+        registrations: Sequence[_ExtractorRegistration],
+        *,
+        kind_selector: Callable[[_ExtractorRegistration], frozenset[str]],
+    ) -> dict[str, _ExtractorRegistration]:
+        lookup: dict[str, _ExtractorRegistration] = {}
+        for registration in registrations:
+            for kind in kind_selector(registration):
+                if kind in lookup:
+                    current_registration = lookup[kind]
+                    msg = (
+                        f"Duplicate extractor registration for {kind!r}: "
+                        f"{current_registration.name} and {registration.name}"
+                    )
+                    raise ValueError(msg)
+                lookup[kind] = registration
+        return lookup
+
+    @staticmethod
+    def _extract(
+        *,
+        extractor_lookup: Mapping[str, _ExtractorRegistration],
+        file_content: bytes,
+        file_kind: str,
+        unstructured_api_config: UnstructuredApiConfig,
+        error_label: str,
+    ) -> str:
+        registration = extractor_lookup.get(file_kind)
+        if registration is None:
+            msg = f"{error_label}: {file_kind}"
+            raise UnsupportedFileTypeError(msg)
+        return registration.extract(
+            file_content=file_content,
+            unstructured_api_config=unstructured_api_config,
+        )
 
 
 def _partition_file_via_unstructured_api(
@@ -318,14 +375,10 @@ def _extract_text_by_mime_type(
     unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
     """Extract text from a file based on its MIME type."""
-    return _dispatch_text_extractor(
+    return _TEXT_EXTRACTOR_REGISTRY.extract_by_mime_type(
         file_content=file_content,
-        file_kind=mime_type,
-        plain_text_types=_MIME_PLAIN_TEXT_TYPES,
-        direct_extractor_names=_MIME_DIRECT_EXTRACTOR_NAMES,
-        unstructured_extractor_names=_MIME_UNSTRUCTURED_EXTRACTOR_NAMES,
+        mime_type=mime_type,
         unstructured_api_config=unstructured_api_config,
-        error_label="Unsupported MIME type",
     )
 
 
@@ -336,45 +389,11 @@ def _extract_text_by_file_extension(
     unstructured_api_config: UnstructuredApiConfig,
 ) -> str:
     """Extract text from a file based on its file extension."""
-    return _dispatch_text_extractor(
+    return _TEXT_EXTRACTOR_REGISTRY.extract_by_file_extension(
         file_content=file_content,
-        file_kind=file_extension,
-        plain_text_types=_EXTENSION_PLAIN_TEXT_TYPES,
-        direct_extractor_names=_EXTENSION_DIRECT_EXTRACTOR_NAMES,
-        unstructured_extractor_names=_EXTENSION_UNSTRUCTURED_EXTRACTOR_NAMES,
+        file_extension=file_extension,
         unstructured_api_config=unstructured_api_config,
-        error_label="Unsupported Extension Type",
     )
-
-
-def _dispatch_text_extractor(
-    *,
-    file_content: bytes,
-    file_kind: str,
-    plain_text_types: frozenset[str],
-    direct_extractor_names: Mapping[str, str],
-    unstructured_extractor_names: Mapping[str, str],
-    unstructured_api_config: UnstructuredApiConfig,
-    error_label: str,
-) -> str:
-    if file_kind in plain_text_types:
-        return _extract_text_from_plain_text(file_content)
-
-    extractor_name = direct_extractor_names.get(file_kind)
-    if extractor_name is not None:
-        extractor: Callable[[bytes], str] = globals()[extractor_name]
-        return extractor(file_content)
-
-    extractor_name = unstructured_extractor_names.get(file_kind)
-    if extractor_name is not None:
-        extractor: Callable[..., str] = globals()[extractor_name]
-        return extractor(
-            file_content,
-            unstructured_api_config=unstructured_api_config,
-        )
-
-    msg = f"{error_label}: {file_kind}"
-    raise UnsupportedFileTypeError(msg)
 
 
 def _extract_text_from_plain_text(file_content: bytes) -> str:
@@ -941,3 +960,111 @@ def _extract_text_from_properties(file_content: bytes) -> str:
     except Exception as e:
         msg = f"Failed to extract text from properties file: {e!s}"
         raise TextExtractionError(msg) from e
+
+
+def _build_text_extractor_registry() -> _TextExtractorRegistry:
+    return _TextExtractorRegistry((
+        _ExtractorRegistration(
+            name="plain_text",
+            extractor=_extract_text_from_plain_text,
+            mime_types=_MIME_PLAIN_TEXT_TYPES,
+            file_extensions=_EXTENSION_PLAIN_TEXT_TYPES,
+        ),
+        _ExtractorRegistration(
+            name="json",
+            extractor=_extract_text_from_json,
+            mime_types=frozenset({"application/json"}),
+            file_extensions=frozenset({".json"}),
+        ),
+        _ExtractorRegistration(
+            name="yaml",
+            extractor=_extract_text_from_yaml,
+            mime_types=frozenset({"application/x-yaml", "text/yaml"}),
+            file_extensions=frozenset({".yaml", ".yml"}),
+        ),
+        _ExtractorRegistration(
+            name="pdf",
+            extractor=_extract_text_from_pdf,
+            mime_types=frozenset({"application/pdf"}),
+            file_extensions=frozenset({".pdf"}),
+        ),
+        _ExtractorRegistration(
+            name="doc",
+            extractor=_extract_text_from_doc,
+            mime_types=frozenset({"application/msword"}),
+            file_extensions=frozenset({".doc"}),
+            requires_unstructured_config=True,
+        ),
+        _ExtractorRegistration(
+            name="docx",
+            extractor=_extract_text_from_docx,
+            mime_types=frozenset({
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            }),
+            file_extensions=frozenset({".docx"}),
+        ),
+        _ExtractorRegistration(
+            name="csv",
+            extractor=_extract_text_from_csv,
+            mime_types=frozenset({"text/csv"}),
+            file_extensions=frozenset({".csv"}),
+        ),
+        _ExtractorRegistration(
+            name="excel",
+            extractor=_extract_text_from_excel,
+            mime_types=frozenset({
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "application/vnd.ms-excel",
+            }),
+            file_extensions=frozenset({".xls", ".xlsx"}),
+        ),
+        _ExtractorRegistration(
+            name="ppt",
+            extractor=_extract_text_from_ppt,
+            mime_types=frozenset({"application/vnd.ms-powerpoint"}),
+            file_extensions=frozenset({".ppt"}),
+            requires_unstructured_config=True,
+        ),
+        _ExtractorRegistration(
+            name="pptx",
+            extractor=_extract_text_from_pptx,
+            mime_types=frozenset({
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            }),
+            file_extensions=frozenset({".pptx"}),
+            requires_unstructured_config=True,
+        ),
+        _ExtractorRegistration(
+            name="epub",
+            extractor=_extract_text_from_epub,
+            mime_types=frozenset({"application/epub+zip"}),
+            file_extensions=frozenset({".epub"}),
+            requires_unstructured_config=True,
+        ),
+        _ExtractorRegistration(
+            name="eml",
+            extractor=_extract_text_from_eml,
+            mime_types=frozenset({"message/rfc822"}),
+            file_extensions=frozenset({".eml"}),
+        ),
+        _ExtractorRegistration(
+            name="msg",
+            extractor=_extract_text_from_msg,
+            mime_types=frozenset({"application/vnd.ms-outlook"}),
+            file_extensions=frozenset({".msg"}),
+        ),
+        _ExtractorRegistration(
+            name="vtt",
+            extractor=_extract_text_from_vtt,
+            mime_types=frozenset({"text/vtt"}),
+        ),
+        _ExtractorRegistration(
+            name="properties",
+            extractor=_extract_text_from_properties,
+            mime_types=frozenset({"text/properties"}),
+            file_extensions=frozenset({".properties"}),
+        ),
+    ))
+
+
+_TEXT_EXTRACTOR_REGISTRY = _build_text_extractor_registry()

--- a/tests/nodes/document_extractor/test_dispatch.py
+++ b/tests/nodes/document_extractor/test_dispatch.py
@@ -1,0 +1,66 @@
+# ruff: noqa: SLF001
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.nodes.document_extractor import node as document_extractor_node
+from graphon.nodes.document_extractor.entities import UnstructuredApiConfig
+from graphon.nodes.document_extractor.exc import UnsupportedFileTypeError
+
+
+def test_extract_text_by_file_extension_routes_registered_extractor() -> None:
+    payload = {"name": "graphon", "nested": {"value": 1}}
+
+    extracted = document_extractor_node._extract_text_by_file_extension(
+        file_content=json.dumps(payload).encode(),
+        file_extension=".json",
+        unstructured_api_config=UnstructuredApiConfig(),
+    )
+
+    assert extracted == json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def test_extract_text_by_mime_type_routes_registered_extractor() -> None:
+    extracted = document_extractor_node._extract_text_by_mime_type(
+        file_content=b"# comment\nfoo=bar\n",
+        mime_type="text/properties",
+        unstructured_api_config=UnstructuredApiConfig(),
+    )
+
+    assert extracted == "# comment\nfoo: bar"
+
+
+def test_extract_text_from_file_prefers_extension_over_mime_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file = MagicMock()
+    file.extension = ".json"
+    file.mime_type = "text/plain"
+
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_download_file_content",
+        lambda _http_client, _file: b'{"name":"graphon"}',
+    )
+
+    extracted = document_extractor_node._extract_text_from_file(
+        MagicMock(),
+        file,
+        unstructured_api_config=UnstructuredApiConfig(),
+    )
+
+    assert extracted == '{\n  "name": "graphon"\n}'
+
+
+def test_extract_text_by_file_extension_rejects_unknown_type() -> None:
+    with pytest.raises(
+        UnsupportedFileTypeError,
+        match=r"Unsupported Extension Type: \.unknown",
+    ):
+        document_extractor_node._extract_text_by_file_extension(
+            file_content=b"data",
+            file_extension=".unknown",
+            unstructured_api_config=UnstructuredApiConfig(),
+        )


### PR DESCRIPTION
## Related Issue

Closes #64

## Summary

- replace the document extractor's string-based MIME and extension dispatch tables with an explicit extractor registry
- keep each extractor's aliases and configuration requirements together so adding a new format changes one place instead of several
- preserve the existing public entrypoints and extension-over-MIME selection behavior while removing `globals()` lookup from routing

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
