### PR TITLE
refactor(human-input): make runtime binding explicit

### DIFF
--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -24,8 +24,8 @@ from graphon.nodes.base.node import Node
 from graphon.nodes.runtime import (
     HumanInputFormStateProtocol,
     HumanInputNodeRuntimeProtocol,
-    HumanInputRuntimeLike,
-    normalize_human_input_runtime,
+    _HumanInputRuntimeLike,
+    _normalize_human_input_runtime,
 )
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.workflow_type_encoder import WorkflowRuntimeTypeConverter
@@ -71,7 +71,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
         # TODO @-LAN: See https://github.com/langgenius/graphon/issues/new/choose.  # noqa: FIX002
         # Make `runtime` optional once Graphon provides a default human-input
         # runtime adapter instead of requiring an embedding-specific implementation.
-        runtime: HumanInputRuntimeLike,
+        runtime: _HumanInputRuntimeLike,
         form_repository: object | None = None,
     ) -> None:
         super().__init__(
@@ -80,7 +80,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
-        self._runtime: HumanInputNodeRuntimeProtocol = normalize_human_input_runtime(
+        self._runtime: HumanInputNodeRuntimeProtocol = _normalize_human_input_runtime(
             runtime,
             form_repository=form_repository,
         )

--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -24,6 +24,8 @@ from graphon.nodes.base.node import Node
 from graphon.nodes.runtime import (
     HumanInputFormStateProtocol,
     HumanInputNodeRuntimeProtocol,
+    HumanInputRuntimeLike,
+    normalize_human_input_runtime,
 )
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.workflow_type_encoder import WorkflowRuntimeTypeConverter
@@ -69,7 +71,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
         # TODO @-LAN: See https://github.com/langgenius/graphon/issues/new/choose.  # noqa: FIX002
         # Make `runtime` optional once Graphon provides a default human-input
         # runtime adapter instead of requiring an embedding-specific implementation.
-        runtime: HumanInputNodeRuntimeProtocol,
+        runtime: HumanInputRuntimeLike,
         form_repository: object | None = None,
     ) -> None:
         super().__init__(
@@ -78,19 +80,10 @@ class HumanInputNode(Node[HumanInputNodeData]):
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
-        if form_repository is not None:
-            with_form_repository = getattr(
-                runtime,
-                "with_form_repository",
-                None,
-            )
-            if callable(with_form_repository):
-                updated_runtime = with_form_repository(form_repository)
-                if not isinstance(updated_runtime, HumanInputNodeRuntimeProtocol):
-                    msg = "with_form_repository() must return a HumanInput runtime"
-                    raise TypeError(msg)
-                runtime = updated_runtime
-        self._runtime: HumanInputNodeRuntimeProtocol = runtime
+        self._runtime: HumanInputNodeRuntimeProtocol = normalize_human_input_runtime(
+            runtime,
+            form_repository=form_repository,
+        )
 
     @classmethod
     @override

--- a/src/graphon/nodes/runtime.py
+++ b/src/graphon/nodes/runtime.py
@@ -77,6 +77,53 @@ class HumanInputNodeRuntimeProtocol(Protocol):
     ) -> HumanInputFormStateProtocol: ...
 
 
+@runtime_checkable
+class HumanInputFormRepositoryBindableRuntimeProtocol(Protocol):
+    """Optional capability for runtimes that require explicit repository binding."""
+
+    def with_form_repository(
+        self,
+        form_repository: object,
+    ) -> HumanInputNodeRuntimeProtocol: ...
+
+
+HumanInputRuntimeLike = (
+    HumanInputNodeRuntimeProtocol | HumanInputFormRepositoryBindableRuntimeProtocol
+)
+
+
+def normalize_human_input_runtime(
+    runtime: HumanInputRuntimeLike,
+    *,
+    form_repository: object | None = None,
+) -> HumanInputNodeRuntimeProtocol:
+    """Return a runnable human-input runtime, binding a repository when needed."""
+    if form_repository is not None and isinstance(
+        runtime, HumanInputFormRepositoryBindableRuntimeProtocol
+    ):
+        bound_runtime = runtime.with_form_repository(form_repository)
+        if not isinstance(bound_runtime, HumanInputNodeRuntimeProtocol):
+            msg = "with_form_repository() must return a HumanInput runtime"
+            raise TypeError(msg)
+        return bound_runtime
+
+    if isinstance(runtime, HumanInputNodeRuntimeProtocol):
+        return runtime
+
+    if isinstance(runtime, HumanInputFormRepositoryBindableRuntimeProtocol):
+        msg = (
+            "form_repository is required when runtime only supports "
+            "with_form_repository()"
+        )
+        raise TypeError(msg)
+
+    msg = (
+        "runtime must implement HumanInputNodeRuntimeProtocol or "
+        "HumanInputFormRepositoryBindableRuntimeProtocol"
+    )
+    raise TypeError(msg)
+
+
 class HumanInputFormStateProtocol(Protocol):
     @property
     def id(self) -> str: ...

--- a/src/graphon/nodes/runtime.py
+++ b/src/graphon/nodes/runtime.py
@@ -87,13 +87,13 @@ class HumanInputFormRepositoryBindableRuntimeProtocol(Protocol):
     ) -> HumanInputNodeRuntimeProtocol: ...
 
 
-HumanInputRuntimeLike = (
+_HumanInputRuntimeLike = (
     HumanInputNodeRuntimeProtocol | HumanInputFormRepositoryBindableRuntimeProtocol
 )
 
 
-def normalize_human_input_runtime(
-    runtime: HumanInputRuntimeLike,
+def _normalize_human_input_runtime(
+    runtime: _HumanInputRuntimeLike,
     *,
     form_repository: object | None = None,
 ) -> HumanInputNodeRuntimeProtocol:

--- a/tests/nodes/test_human_input_runtime_binding.py
+++ b/tests/nodes/test_human_input_runtime_binding.py
@@ -11,10 +11,9 @@ from graphon.nodes.human_input.entities import HumanInputNodeData
 from graphon.nodes.human_input.enums import HumanInputFormStatus
 from graphon.nodes.human_input.human_input_node import HumanInputNode
 from graphon.nodes.runtime import (
+    HumanInputFormRepositoryBindableRuntimeProtocol,
     HumanInputFormStateProtocol,
     HumanInputNodeRuntimeProtocol,
-    HumanInputRuntimeLike,
-    normalize_human_input_runtime,
 )
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
@@ -138,7 +137,9 @@ class _InvalidBindableHumanInputRuntime:
 
 def _build_human_input_node(
     *,
-    runtime: HumanInputRuntimeLike,
+    runtime: (
+        HumanInputNodeRuntimeProtocol | HumanInputFormRepositoryBindableRuntimeProtocol
+    ),
     form_repository: object | None = None,
 ) -> HumanInputNode:
     return HumanInputNode(
@@ -156,46 +157,32 @@ def _build_human_input_node(
     )
 
 
-def test_normalize_human_input_runtime_returns_ready_runtime_unchanged() -> None:
-    runtime = _StubHumanInputRuntime()
+def test_human_input_node_accepts_ready_runtime_without_repository() -> None:
+    runtime = _RunnableHumanInputRuntime()
 
-    normalized_runtime = normalize_human_input_runtime(runtime)
+    node = _build_human_input_node(runtime=runtime)
 
-    assert normalized_runtime is runtime
+    list(node.run())
 
-
-def test_normalize_human_input_runtime_binds_repository_explicitly() -> None:
-    repository = object()
-    runtime = _BindableHumanInputRuntime()
-
-    normalized_runtime = normalize_human_input_runtime(
-        runtime,
-        form_repository=repository,
-    )
-
-    assert normalized_runtime is runtime.bound_runtime
-    assert runtime.bound_repositories == [repository]
+    assert runtime.get_form_calls == ["human-input-node"]
+    assert runtime.create_form_calls == ["human-input-node"]
 
 
-def test_normalize_human_input_runtime_requires_repository_for_bindable_runtime() -> (
-    None
-):
-    runtime = _BindableHumanInputRuntime()
-
+def test_human_input_node_requires_repository_for_bindable_runtime() -> None:
     with pytest.raises(
         TypeError,
         match="form_repository is required when runtime only supports",
     ):
-        normalize_human_input_runtime(runtime)
+        _build_human_input_node(runtime=_BindableHumanInputRuntime())
 
 
-def test_normalize_human_input_runtime_rejects_invalid_bound_runtime() -> None:
+def test_human_input_node_rejects_invalid_bound_runtime() -> None:
     with pytest.raises(
         TypeError,
         match="with_form_repository\\(\\) must return a HumanInput runtime",
     ):
-        normalize_human_input_runtime(
-            _InvalidBindableHumanInputRuntime(),
+        _build_human_input_node(
+            runtime=_InvalidBindableHumanInputRuntime(),
             form_repository=object(),
         )
 

--- a/tests/nodes/test_human_input_runtime_binding.py
+++ b/tests/nodes/test_human_input_runtime_binding.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from time import perf_counter
+from typing import Any, cast
+
+import pytest
+
+from graphon.nodes.human_input.entities import HumanInputNodeData
+from graphon.nodes.human_input.enums import HumanInputFormStatus
+from graphon.nodes.human_input.human_input_node import HumanInputNode
+from graphon.nodes.runtime import (
+    HumanInputFormStateProtocol,
+    HumanInputNodeRuntimeProtocol,
+    HumanInputRuntimeLike,
+    normalize_human_input_runtime,
+)
+from graphon.runtime.graph_runtime_state import GraphRuntimeState
+
+from ..helpers import build_graph_init_params, build_variable_pool
+
+
+class _StubHumanInputRuntime:
+    def get_form(self, *, node_id: str) -> HumanInputFormStateProtocol | None:
+        _ = node_id
+        msg = "not used in this test"
+        raise AssertionError(msg)
+
+    def create_form(
+        self,
+        *,
+        node_id: str,
+        node_data: HumanInputNodeData,
+        rendered_content: str,
+        resolved_default_values: Mapping[str, Any],
+    ) -> HumanInputFormStateProtocol:
+        _ = (node_id, node_data, rendered_content, resolved_default_values)
+        msg = "not used in this test"
+        raise AssertionError(msg)
+
+
+class _StubFormState:
+    def __init__(self) -> None:
+        self._id = "form-1"
+        self._rendered_content = "Rendered form"
+        self._expiration_time = datetime.now(UTC).replace(tzinfo=None)
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def rendered_content(self) -> str:
+        return self._rendered_content
+
+    @property
+    def selected_action_id(self) -> str | None:
+        return None
+
+    @property
+    def submitted_data(self) -> Mapping[str, Any] | None:
+        return None
+
+    @property
+    def submitted(self) -> bool:
+        return False
+
+    @property
+    def status(self) -> HumanInputFormStatus:
+        return HumanInputFormStatus.WAITING
+
+    @property
+    def expiration_time(self) -> datetime:
+        return self._expiration_time
+
+
+class _RunnableHumanInputRuntime(_StubHumanInputRuntime):
+    def __init__(self) -> None:
+        self.get_form_calls: list[str] = []
+        self.create_form_calls: list[str] = []
+
+    def get_form(self, *, node_id: str) -> HumanInputFormStateProtocol | None:
+        self.get_form_calls.append(node_id)
+        return None
+
+    def create_form(
+        self,
+        *,
+        node_id: str,
+        node_data: HumanInputNodeData,
+        rendered_content: str,
+        resolved_default_values: Mapping[str, Any],
+    ) -> HumanInputFormStateProtocol:
+        _ = (node_data, rendered_content, resolved_default_values)
+        self.create_form_calls.append(node_id)
+        return _StubFormState()
+
+
+class _BindableHumanInputRuntime:
+    def __init__(
+        self,
+        *,
+        bound_runtime: HumanInputNodeRuntimeProtocol | None = None,
+    ) -> None:
+        self.bound_runtime = bound_runtime or _StubHumanInputRuntime()
+        self.bound_repositories: list[object] = []
+
+    def with_form_repository(
+        self,
+        form_repository: object,
+    ) -> HumanInputNodeRuntimeProtocol:
+        self.bound_repositories.append(form_repository)
+        return self.bound_runtime
+
+
+class _RebindableHumanInputRuntime(_StubHumanInputRuntime):
+    def __init__(self, rebound_runtime: HumanInputNodeRuntimeProtocol) -> None:
+        self.rebound_runtime = rebound_runtime
+        self.bound_repositories: list[object] = []
+
+    def with_form_repository(
+        self,
+        form_repository: object,
+    ) -> HumanInputNodeRuntimeProtocol:
+        self.bound_repositories.append(form_repository)
+        return self.rebound_runtime
+
+
+class _InvalidBindableHumanInputRuntime:
+    def with_form_repository(
+        self,
+        form_repository: object,
+    ) -> HumanInputNodeRuntimeProtocol:
+        _ = form_repository
+        return cast(HumanInputNodeRuntimeProtocol, object())
+
+
+def _build_human_input_node(
+    *,
+    runtime: HumanInputRuntimeLike,
+    form_repository: object | None = None,
+) -> HumanInputNode:
+    return HumanInputNode(
+        node_id="human-input-node",
+        config=HumanInputNodeData(title="Human Input"),
+        graph_init_params=build_graph_init_params(
+            graph_config={"nodes": [], "edges": []},
+        ),
+        graph_runtime_state=GraphRuntimeState(
+            variable_pool=build_variable_pool(),
+            start_at=perf_counter(),
+        ),
+        runtime=runtime,
+        form_repository=form_repository,
+    )
+
+
+def test_normalize_human_input_runtime_returns_ready_runtime_unchanged() -> None:
+    runtime = _StubHumanInputRuntime()
+
+    normalized_runtime = normalize_human_input_runtime(runtime)
+
+    assert normalized_runtime is runtime
+
+
+def test_normalize_human_input_runtime_binds_repository_explicitly() -> None:
+    repository = object()
+    runtime = _BindableHumanInputRuntime()
+
+    normalized_runtime = normalize_human_input_runtime(
+        runtime,
+        form_repository=repository,
+    )
+
+    assert normalized_runtime is runtime.bound_runtime
+    assert runtime.bound_repositories == [repository]
+
+
+def test_normalize_human_input_runtime_requires_repository_for_bindable_runtime() -> (
+    None
+):
+    runtime = _BindableHumanInputRuntime()
+
+    with pytest.raises(
+        TypeError,
+        match="form_repository is required when runtime only supports",
+    ):
+        normalize_human_input_runtime(runtime)
+
+
+def test_normalize_human_input_runtime_rejects_invalid_bound_runtime() -> None:
+    with pytest.raises(
+        TypeError,
+        match="with_form_repository\\(\\) must return a HumanInput runtime",
+    ):
+        normalize_human_input_runtime(
+            _InvalidBindableHumanInputRuntime(),
+            form_repository=object(),
+        )
+
+
+def test_human_input_node_prefers_explicit_runtime_binding() -> None:
+    repository = object()
+    rebound_runtime = _RunnableHumanInputRuntime()
+    runtime = _RebindableHumanInputRuntime(rebound_runtime)
+
+    node = _build_human_input_node(runtime=runtime, form_repository=repository)
+
+    list(node.run())
+
+    assert rebound_runtime.get_form_calls == ["human-input-node"]
+    assert rebound_runtime.create_form_calls == ["human-input-node"]
+    assert runtime.bound_repositories == [repository]


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Refs #66

## Summary

- add an explicit protocol and helper for binding human-input runtimes with a form repository
- route `HumanInputNode` through the normalization helper instead of ad-hoc `getattr(...)` probing
- cover runtime normalization and node binding behavior with focused tests

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
