### PR TITLE
refactor(variable-pool)!: make bootstrap construction explicit

### DIFF
--- a/src/graphon/runtime/variable_pool.py
+++ b/src/graphon/runtime/variable_pool.py
@@ -4,9 +4,9 @@ import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from graphon.file import file_manager
 from graphon.file.enums import FileAttribute
@@ -36,6 +36,7 @@ class VariablePool(BaseModel):
     _ENVIRONMENT_VARIABLE_NODE_ID = "env"
     _CONVERSATION_VARIABLE_NODE_ID = "conversation"
     _RAG_PIPELINE_VARIABLE_NODE_ID = "rag"
+    model_config = ConfigDict(extra="forbid")
 
     # Variable dictionary is a dictionary for looking up variables by their selector.
     # The first element of the selector is the node id.
@@ -49,52 +50,89 @@ class VariablePool(BaseModel):
         description="Variables mapping",
         default_factory=_default_variable_dictionary,
     )
-    system_variables: Sequence[Variable] = Field(default_factory=tuple, exclude=True)
-    environment_variables: Sequence[Variable] = Field(
-        default_factory=tuple,
-        exclude=True,
-    )
-    conversation_variables: Sequence[Variable] = Field(
-        default_factory=tuple,
-        exclude=True,
-    )
-    rag_pipeline_variables: Sequence[RAGPipelineVariableInput] = Field(
-        default_factory=tuple,
-        exclude=True,
-    )
-    user_inputs: Mapping[str, Any] = Field(default_factory=dict, exclude=True)
 
-    @model_validator(mode="after")
-    def _load_legacy_bootstrap_inputs(self) -> VariablePool:
-        """Accept legacy constructor kwargs that still appear throughout the workflow
-        layer while keeping serialized state focused on `variable_dictionary`.
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_constructor_kwargs(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        legacy_keys = sorted(
+            {
+                "system_variables",
+                "environment_variables",
+                "conversation_variables",
+                "rag_pipeline_variables",
+                "user_inputs",
+            }.intersection(value),
+        )
+        if not legacy_keys:
+            return value
+
+        joined_keys = ", ".join(legacy_keys)
+        msg = (
+            "VariablePool() no longer accepts legacy bootstrap inputs "
+            f"({joined_keys}); use VariablePool.from_bootstrap(...) or "
+            "VariablePool.from_legacy_bootstrap(...)."
+        )
+        raise ValueError(msg)
+
+    @classmethod
+    def from_bootstrap(
+        cls,
+        *,
+        system_variables: Sequence[Variable] = (),
+        environment_variables: Sequence[Variable] = (),
+        conversation_variables: Sequence[Variable] = (),
+        rag_pipeline_variables: Sequence[RAGPipelineVariableInput] = (),
+        user_inputs: Mapping[str, Any] | None = None,
+    ) -> Self:
+        """Build a pool from workflow bootstrap inputs.
+
+        The default constructor remains focused on the normalized
+        `variable_dictionary` payload. `user_inputs` is accepted for
+        compatibility with older workflow bootstrap code but is not stored on the
+        pool.
 
         Returns:
-            The normalized `VariablePool` instance after ingesting legacy inputs.
-
+            A normalized variable pool populated from the provided bootstrap inputs.
         """
-        self._ingest_legacy_variables(
-            self.system_variables,
-            node_id=self._SYSTEM_VARIABLE_NODE_ID,
-        )
-        self._ingest_legacy_variables(
-            self.environment_variables,
-            node_id=self._ENVIRONMENT_VARIABLE_NODE_ID,
-        )
-        self._ingest_legacy_variables(
-            self.conversation_variables,
-            node_id=self._CONVERSATION_VARIABLE_NODE_ID,
-        )
-        self._ingest_legacy_rag_variables(self.rag_pipeline_variables)
+        del user_inputs
 
-        # These kwargs are accepted for compatibility but should not affect the
-        # stable serialized form or model equality.
-        self.system_variables = ()
-        self.environment_variables = ()
-        self.conversation_variables = ()
-        self.rag_pipeline_variables = ()
-        self.user_inputs = {}
-        return self
+        pool = cls()
+        pool._ingest_legacy_variables(
+            system_variables,
+            node_id=pool._SYSTEM_VARIABLE_NODE_ID,
+        )
+        pool._ingest_legacy_variables(
+            environment_variables,
+            node_id=pool._ENVIRONMENT_VARIABLE_NODE_ID,
+        )
+        pool._ingest_legacy_variables(
+            conversation_variables,
+            node_id=pool._CONVERSATION_VARIABLE_NODE_ID,
+        )
+        pool._ingest_legacy_rag_variables(rag_pipeline_variables)
+        return pool
+
+    @classmethod
+    def from_legacy_bootstrap(
+        cls,
+        *,
+        system_variables: Sequence[Variable] = (),
+        environment_variables: Sequence[Variable] = (),
+        conversation_variables: Sequence[Variable] = (),
+        rag_pipeline_variables: Sequence[RAGPipelineVariableInput] = (),
+        user_inputs: Mapping[str, Any] | None = None,
+    ) -> Self:
+        """Compatibility entrypoint for older constructor-style bootstrap call sites."""
+        return cls.from_bootstrap(
+            system_variables=system_variables,
+            environment_variables=environment_variables,
+            conversation_variables=conversation_variables,
+            rag_pipeline_variables=rag_pipeline_variables,
+            user_inputs=user_inputs,
+        )
 
     def _ingest_legacy_variables(
         self,

--- a/tests/helpers/builders.py
+++ b/tests/helpers/builders.py
@@ -44,7 +44,7 @@ def build_variable_pool(
     conversation_variables: Sequence[Variable] = (),
     variables: Sequence[tuple[Sequence[str], Any]] = (),
 ) -> VariablePool:
-    variable_pool = VariablePool(
+    variable_pool = VariablePool.from_bootstrap(
         system_variables=system_variables,
         conversation_variables=conversation_variables,
     )

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -311,7 +311,7 @@ class TestGraphRuntimeState:
         assert new_stub.state == "configured"
 
     def test_snapshot_restore_preserves_updated_conversation_variable(self) -> None:
-        variable_pool = VariablePool(
+        variable_pool = VariablePool.from_bootstrap(
             conversation_variables=[
                 StringVariable(name="session_name", value="before"),
             ],

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import (
     BooleanSegment,
@@ -6,7 +9,72 @@ from graphon.variables.segments import (
     ObjectSegment,
     StringSegment,
 )
-from graphon.variables.variables import StringVariable
+from graphon.variables.variables import (
+    RAGPipelineVariable,
+    RAGPipelineVariableInput,
+    StringVariable,
+)
+
+
+class TestVariablePoolConstruction:
+    def test_default_constructor_starts_empty(self) -> None:
+        assert VariablePool().flatten() == {}
+
+    def test_from_bootstrap_loads_legacy_inputs(self) -> None:
+        system_variable = StringVariable(
+            name="system_name",
+            value="sys-value",
+            selector=["wrong", "system_name"],
+        )
+        conversation_variable = StringVariable(
+            name="session_name",
+            value="before",
+        )
+        rag_variable = RAGPipelineVariableInput(
+            variable=RAGPipelineVariable(
+                belong_to_node_id="retriever",
+                type="text-input",
+                label="Question",
+                variable="query",
+            ),
+            value="answer",
+        )
+
+        pool = VariablePool.from_bootstrap(
+            system_variables=[system_variable],
+            conversation_variables=[conversation_variable],
+            rag_pipeline_variables=[rag_variable],
+            user_inputs={"query": "ignored"},
+        )
+
+        normalized_system_variable = pool.get_variable(("sys", "system_name"))
+        assert normalized_system_variable is not None
+        assert tuple(normalized_system_variable.selector) == ("sys", "system_name")
+
+        conversation_segment = pool.get(("conversation", "session_name"))
+        assert conversation_segment is not None
+        assert conversation_segment.value == "before"
+
+        rag_segment = pool.get(("rag", "retriever"))
+        assert rag_segment is not None
+        assert rag_segment.value == {"query": "answer"}
+
+    def test_constructor_rejects_legacy_bootstrap_kwargs(self) -> None:
+        with pytest.raises(ValidationError, match="from_bootstrap"):
+            VariablePool.model_validate({
+                "conversation_variables": [
+                    StringVariable(name="session", value="x"),
+                ],
+            })
+
+    def test_from_legacy_bootstrap_preserves_compatibility(self) -> None:
+        pool = VariablePool.from_legacy_bootstrap(
+            conversation_variables=[StringVariable(name="session_name", value="value")],
+        )
+
+        segment = pool.get(("conversation", "session_name"))
+        assert segment is not None
+        assert segment.value == "value"
 
 
 class TestVariablePoolGetAndNestedAttribute:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Refs #66

## Summary

- move legacy/bootstrap variable-pool assembly into explicit classmethod constructors
- keep `VariablePool()` focused on normalized state and reject legacy bootstrap kwargs with a clear migration path
- update focused helpers and runtime tests to use the new construction entrypoint

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
