### PR TITLE
refactor(llm): bundle file saver dependencies

### DIFF
--- a/src/graphon/nodes/llm/file_saver.py
+++ b/src/graphon/nodes/llm/file_saver.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 import mimetypes
 import typing as tp
+from dataclasses import dataclass
+from typing import cast
 
 from graphon.file.constants import DEFAULT_EXTENSION, DEFAULT_MIME_TYPE
 from graphon.file.enums import (
@@ -68,20 +72,114 @@ class LLMFileSaver(tp.Protocol):
         raise NotImplementedError
 
 
+@dataclass(frozen=True, slots=True)
+class FileSaverDependencies:
+    """Runtime collaborators required by FileSaverImpl."""
+
+    tool_file_manager: ToolFileManagerProtocol
+    file_reference_factory: FileReferenceFactoryProtocol
+    http_client: HttpClientProtocol | None = None
+
+
 class FileSaverImpl(LLMFileSaver):
     _tool_file_manager: ToolFileManagerProtocol
     _file_reference_factory: FileReferenceFactoryProtocol
 
+    @tp.overload
     def __init__(
         self,
         *,
+        dependencies: FileSaverDependencies,
+        tool_file_manager: None = None,
+        file_reference_factory: None = None,
+        http_client: None = None,
+    ) -> None: ...
+
+    @tp.overload
+    def __init__(
+        self,
+        *,
+        dependencies: None = None,
         tool_file_manager: ToolFileManagerProtocol,
         file_reference_factory: FileReferenceFactoryProtocol,
         http_client: HttpClientProtocol | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        dependencies: FileSaverDependencies | None = None,
+        tool_file_manager: ToolFileManagerProtocol | None = None,
+        file_reference_factory: FileReferenceFactoryProtocol | None = None,
+        http_client: HttpClientProtocol | None = None,
     ) -> None:
-        self._tool_file_manager = tool_file_manager
-        self._file_reference_factory = file_reference_factory
-        self._http_client = http_client or get_http_client()
+        resolved_dependencies = self._resolve_dependencies(
+            dependencies=dependencies,
+            tool_file_manager=tool_file_manager,
+            file_reference_factory=file_reference_factory,
+            http_client=http_client,
+        )
+        self._tool_file_manager = resolved_dependencies.tool_file_manager
+        self._file_reference_factory = resolved_dependencies.file_reference_factory
+        self._http_client = (
+            resolved_dependencies.http_client
+            if resolved_dependencies.http_client is not None
+            else get_http_client()
+        )
+
+    @staticmethod
+    def _resolve_dependencies(
+        *,
+        dependencies: FileSaverDependencies | None,
+        tool_file_manager: ToolFileManagerProtocol | None,
+        file_reference_factory: FileReferenceFactoryProtocol | None,
+        http_client: HttpClientProtocol | None,
+    ) -> FileSaverDependencies:
+        if dependencies is not None:
+            duplicate_arguments = [
+                argument_name
+                for argument_name, argument_value in (
+                    ("tool_file_manager", tool_file_manager),
+                    ("file_reference_factory", file_reference_factory),
+                    ("http_client", http_client),
+                )
+                if argument_value is not None
+            ]
+            if duplicate_arguments:
+                duplicate_arguments_str = ", ".join(sorted(duplicate_arguments))
+                msg = (
+                    "FileSaverImpl received runtime collaborators twice. "
+                    "Use either 'dependencies' or the legacy keyword arguments, "
+                    f"not both: {duplicate_arguments_str}."
+                )
+                raise TypeError(msg)
+            return dependencies
+
+        missing_arguments = [
+            argument_name
+            for argument_name, argument_value in (
+                ("tool_file_manager", tool_file_manager),
+                ("file_reference_factory", file_reference_factory),
+            )
+            if argument_value is None
+        ]
+        if missing_arguments:
+            missing_arguments_str = ", ".join(sorted(missing_arguments))
+            msg = (
+                "FileSaverImpl requires either "
+                "'dependencies=FileSaverDependencies(...)' or the legacy "
+                f"keyword arguments: {missing_arguments_str}."
+            )
+            raise TypeError(msg)
+
+        return FileSaverDependencies(
+            tool_file_manager=cast(ToolFileManagerProtocol, tool_file_manager),
+            file_reference_factory=cast(
+                FileReferenceFactoryProtocol,
+                file_reference_factory,
+            ),
+            http_client=http_client,
+        )
 
     @property
     def http_client(self) -> HttpClientProtocol:

--- a/src/graphon/nodes/llm/file_saver.py
+++ b/src/graphon/nodes/llm/file_saver.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import mimetypes
 import typing as tp
-from dataclasses import dataclass
-from typing import cast
 
 from graphon.file.constants import DEFAULT_EXTENSION, DEFAULT_MIME_TYPE
 from graphon.file.enums import (
@@ -72,112 +70,35 @@ class LLMFileSaver(tp.Protocol):
         raise NotImplementedError
 
 
-@dataclass(frozen=True, slots=True)
-class FileSaverDependencies:
-    """Runtime collaborators required by FileSaverImpl."""
-
-    tool_file_manager: ToolFileManagerProtocol
-    file_reference_factory: FileReferenceFactoryProtocol
-    http_client: HttpClientProtocol | None = None
-
-
 class FileSaverImpl(LLMFileSaver):
     _tool_file_manager: ToolFileManagerProtocol
     _file_reference_factory: FileReferenceFactoryProtocol
 
-    @tp.overload
     def __init__(
         self,
         *,
-        dependencies: FileSaverDependencies,
-        tool_file_manager: None = None,
-        file_reference_factory: None = None,
-        http_client: None = None,
-    ) -> None: ...
-
-    @tp.overload
-    def __init__(
-        self,
-        *,
-        dependencies: None = None,
         tool_file_manager: ToolFileManagerProtocol,
         file_reference_factory: FileReferenceFactoryProtocol,
         http_client: HttpClientProtocol | None = None,
-    ) -> None: ...
-
-    def __init__(
-        self,
-        *,
-        dependencies: FileSaverDependencies | None = None,
-        tool_file_manager: ToolFileManagerProtocol | None = None,
-        file_reference_factory: FileReferenceFactoryProtocol | None = None,
-        http_client: HttpClientProtocol | None = None,
     ) -> None:
-        resolved_dependencies = self._resolve_dependencies(
-            dependencies=dependencies,
+        self._tool_file_manager = tool_file_manager
+        self._file_reference_factory = file_reference_factory
+        self._http_client = (
+            http_client if http_client is not None else get_http_client()
+        )
+
+    @classmethod
+    def with_runtime(
+        cls,
+        *,
+        tool_file_manager: ToolFileManagerProtocol,
+        file_reference_factory: FileReferenceFactoryProtocol,
+        http_client: HttpClientProtocol | None = None,
+    ) -> FileSaverImpl:
+        """Build a file saver from the runtime collaborators it needs."""
+        return cls(
             tool_file_manager=tool_file_manager,
             file_reference_factory=file_reference_factory,
-            http_client=http_client,
-        )
-        self._tool_file_manager = resolved_dependencies.tool_file_manager
-        self._file_reference_factory = resolved_dependencies.file_reference_factory
-        self._http_client = (
-            resolved_dependencies.http_client
-            if resolved_dependencies.http_client is not None
-            else get_http_client()
-        )
-
-    @staticmethod
-    def _resolve_dependencies(
-        *,
-        dependencies: FileSaverDependencies | None,
-        tool_file_manager: ToolFileManagerProtocol | None,
-        file_reference_factory: FileReferenceFactoryProtocol | None,
-        http_client: HttpClientProtocol | None,
-    ) -> FileSaverDependencies:
-        if dependencies is not None:
-            duplicate_arguments = [
-                argument_name
-                for argument_name, argument_value in (
-                    ("tool_file_manager", tool_file_manager),
-                    ("file_reference_factory", file_reference_factory),
-                    ("http_client", http_client),
-                )
-                if argument_value is not None
-            ]
-            if duplicate_arguments:
-                duplicate_arguments_str = ", ".join(sorted(duplicate_arguments))
-                msg = (
-                    "FileSaverImpl received runtime collaborators twice. "
-                    "Use either 'dependencies' or the legacy keyword arguments, "
-                    f"not both: {duplicate_arguments_str}."
-                )
-                raise TypeError(msg)
-            return dependencies
-
-        missing_arguments = [
-            argument_name
-            for argument_name, argument_value in (
-                ("tool_file_manager", tool_file_manager),
-                ("file_reference_factory", file_reference_factory),
-            )
-            if argument_value is None
-        ]
-        if missing_arguments:
-            missing_arguments_str = ", ".join(sorted(missing_arguments))
-            msg = (
-                "FileSaverImpl requires either "
-                "'dependencies=FileSaverDependencies(...)' or the legacy "
-                f"keyword arguments: {missing_arguments_str}."
-            )
-            raise TypeError(msg)
-
-        return FileSaverDependencies(
-            tool_file_manager=cast(ToolFileManagerProtocol, tool_file_manager),
-            file_reference_factory=cast(
-                FileReferenceFactoryProtocol,
-                file_reference_factory,
-            ),
             http_client=http_client,
         )
 

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -27,7 +27,7 @@ from graphon.nodes.http_request.entities import (
     HttpRequestNodeAuthorization,
     HttpRequestNodeBody,
 )
-from graphon.nodes.llm.file_saver import FileSaverDependencies, FileSaverImpl
+from graphon.nodes.llm.file_saver import FileSaverImpl
 from graphon.nodes.llm.node import LLMNode
 from graphon.nodes.question_classifier.question_classifier_node import (
     QuestionClassifierNode,
@@ -204,11 +204,9 @@ def test_document_extractor_node_uses_default_http_client_when_not_injected() ->
 
 
 def test_file_saver_impl_uses_default_http_client_when_not_injected() -> None:
-    file_saver = FileSaverImpl(
-        dependencies=FileSaverDependencies(
-            tool_file_manager=_ToolFileManager(),
-            file_reference_factory=_FileReferenceFactory(),
-        ),
+    file_saver = FileSaverImpl.with_runtime(
+        tool_file_manager=_ToolFileManager(),
+        file_reference_factory=_FileReferenceFactory(),
     )
 
     assert file_saver.http_client is get_http_client()

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -27,7 +27,7 @@ from graphon.nodes.http_request.entities import (
     HttpRequestNodeAuthorization,
     HttpRequestNodeBody,
 )
-from graphon.nodes.llm.file_saver import FileSaverImpl
+from graphon.nodes.llm.file_saver import FileSaverDependencies, FileSaverImpl
 from graphon.nodes.llm.node import LLMNode
 from graphon.nodes.question_classifier.question_classifier_node import (
     QuestionClassifierNode,
@@ -205,8 +205,10 @@ def test_document_extractor_node_uses_default_http_client_when_not_injected() ->
 
 def test_file_saver_impl_uses_default_http_client_when_not_injected() -> None:
     file_saver = FileSaverImpl(
-        tool_file_manager=_ToolFileManager(),
-        file_reference_factory=_FileReferenceFactory(),
+        dependencies=FileSaverDependencies(
+            tool_file_manager=_ToolFileManager(),
+            file_reference_factory=_FileReferenceFactory(),
+        ),
     )
 
     assert file_saver.http_client is get_http_client()

--- a/tests/nodes/llm/test_file_saver.py
+++ b/tests/nodes/llm/test_file_saver.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+from typing import Any, cast
+
+import pytest
+
+from graphon.file.models import File
+from graphon.http import HttpResponse, HttpxHttpClient, get_http_client
+from graphon.nodes.llm.file_saver import FileSaverDependencies, FileSaverImpl
+
+
+class _ToolFileManager:
+    def create_file_by_raw(
+        self,
+        *,
+        file_binary: bytes,
+        mimetype: str,
+        filename: str | None = None,
+    ) -> object:
+        _ = file_binary, mimetype, filename
+        raise NotImplementedError
+
+    def get_file_generator_by_tool_file_id(
+        self,
+        tool_file_id: str,
+    ) -> tuple[Generator[bytes, None, None] | None, File | None]:
+        _ = tool_file_id
+        raise NotImplementedError
+
+
+class _FileReferenceFactory:
+    def build_from_mapping(
+        self,
+        *,
+        mapping: Mapping[str, Any],
+    ) -> File:
+        return File.model_validate(mapping)
+
+
+class _FalseyHttpClient:
+    @property
+    def max_retries_exceeded_error(self) -> type[Exception]:
+        return RuntimeError
+
+    @property
+    def request_error(self) -> type[Exception]:
+        return RuntimeError
+
+    def __bool__(self) -> bool:
+        return False
+
+    def get(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+    def head(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+    def post(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+    def put(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+    def delete(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+    def patch(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        _ = url, max_retries, kwargs
+        raise NotImplementedError
+
+
+def test_file_saver_impl_accepts_dependency_bundle() -> None:
+    http_client = HttpxHttpClient()
+
+    file_saver = FileSaverImpl(
+        dependencies=FileSaverDependencies(
+            tool_file_manager=_ToolFileManager(),
+            file_reference_factory=_FileReferenceFactory(),
+            http_client=http_client,
+        ),
+    )
+
+    assert file_saver.http_client is http_client
+
+
+def test_file_saver_impl_uses_default_http_client_for_dependency_bundle() -> None:
+    file_saver = FileSaverImpl(
+        dependencies=FileSaverDependencies(
+            tool_file_manager=_ToolFileManager(),
+            file_reference_factory=_FileReferenceFactory(),
+        ),
+    )
+
+    assert file_saver.http_client is get_http_client()
+
+
+def test_file_saver_impl_preserves_explicit_falsey_http_client() -> None:
+    http_client = _FalseyHttpClient()
+
+    file_saver = FileSaverImpl(
+        dependencies=FileSaverDependencies(
+            tool_file_manager=_ToolFileManager(),
+            file_reference_factory=_FileReferenceFactory(),
+            http_client=http_client,
+        ),
+    )
+
+    assert file_saver.http_client is http_client
+
+
+def test_file_saver_impl_rejects_mixed_dependency_styles() -> None:
+    dependencies = FileSaverDependencies(
+        tool_file_manager=_ToolFileManager(),
+        file_reference_factory=_FileReferenceFactory(),
+    )
+    constructor = cast(Any, FileSaverImpl)
+
+    with pytest.raises(
+        TypeError,
+        match="Use either 'dependencies' or the legacy keyword arguments",
+    ):
+        constructor(
+            dependencies=dependencies,
+            tool_file_manager=_ToolFileManager(),
+        )
+
+
+def test_file_saver_impl_requires_complete_legacy_arguments() -> None:
+    constructor = cast(Any, FileSaverImpl)
+
+    with pytest.raises(
+        TypeError,
+        match="requires either 'dependencies=FileSaverDependencies",
+    ):
+        constructor(
+            file_reference_factory=_FileReferenceFactory(),
+        )

--- a/tests/nodes/llm/test_file_saver.py
+++ b/tests/nodes/llm/test_file_saver.py
@@ -7,7 +7,7 @@ import pytest
 
 from graphon.file.models import File
 from graphon.http import HttpResponse, HttpxHttpClient, get_http_client
-from graphon.nodes.llm.file_saver import FileSaverDependencies, FileSaverImpl
+from graphon.nodes.llm.file_saver import FileSaverImpl
 
 
 class _ToolFileManager:
@@ -75,68 +75,57 @@ class _FalseyHttpClient:
         raise NotImplementedError
 
 
-def test_file_saver_impl_accepts_dependency_bundle() -> None:
+def test_file_saver_impl_with_runtime_accepts_explicit_http_client() -> None:
     http_client = HttpxHttpClient()
 
-    file_saver = FileSaverImpl(
-        dependencies=FileSaverDependencies(
-            tool_file_manager=_ToolFileManager(),
-            file_reference_factory=_FileReferenceFactory(),
-            http_client=http_client,
-        ),
+    file_saver = FileSaverImpl.with_runtime(
+        tool_file_manager=_ToolFileManager(),
+        file_reference_factory=_FileReferenceFactory(),
+        http_client=http_client,
     )
 
     assert file_saver.http_client is http_client
 
 
-def test_file_saver_impl_uses_default_http_client_for_dependency_bundle() -> None:
-    file_saver = FileSaverImpl(
-        dependencies=FileSaverDependencies(
-            tool_file_manager=_ToolFileManager(),
-            file_reference_factory=_FileReferenceFactory(),
-        ),
+def test_file_saver_impl_with_runtime_uses_default_http_client() -> None:
+    file_saver = FileSaverImpl.with_runtime(
+        tool_file_manager=_ToolFileManager(),
+        file_reference_factory=_FileReferenceFactory(),
     )
 
     assert file_saver.http_client is get_http_client()
 
 
-def test_file_saver_impl_preserves_explicit_falsey_http_client() -> None:
+def test_file_saver_impl_with_runtime_preserves_falsey_http_client() -> None:
     http_client = _FalseyHttpClient()
 
-    file_saver = FileSaverImpl(
-        dependencies=FileSaverDependencies(
-            tool_file_manager=_ToolFileManager(),
-            file_reference_factory=_FileReferenceFactory(),
-            http_client=http_client,
-        ),
+    file_saver = FileSaverImpl.with_runtime(
+        tool_file_manager=_ToolFileManager(),
+        file_reference_factory=_FileReferenceFactory(),
+        http_client=http_client,
     )
 
     assert file_saver.http_client is http_client
 
 
-def test_file_saver_impl_rejects_mixed_dependency_styles() -> None:
-    dependencies = FileSaverDependencies(
+def test_file_saver_impl_constructor_still_accepts_legacy_arguments() -> None:
+    http_client = HttpxHttpClient()
+
+    file_saver = FileSaverImpl(
         tool_file_manager=_ToolFileManager(),
         file_reference_factory=_FileReferenceFactory(),
+        http_client=http_client,
     )
+
+    assert file_saver.http_client is http_client
+
+
+def test_file_saver_impl_constructor_requires_runtime_collaborators() -> None:
     constructor = cast(Any, FileSaverImpl)
 
     with pytest.raises(
         TypeError,
-        match="Use either 'dependencies' or the legacy keyword arguments",
-    ):
-        constructor(
-            dependencies=dependencies,
-            tool_file_manager=_ToolFileManager(),
-        )
-
-
-def test_file_saver_impl_requires_complete_legacy_arguments() -> None:
-    constructor = cast(Any, FileSaverImpl)
-
-    with pytest.raises(
-        TypeError,
-        match="requires either 'dependencies=FileSaverDependencies",
+        match="missing 1 required keyword-only argument",
     ):
         constructor(
             file_reference_factory=_FileReferenceFactory(),


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Refs #66

## Summary

- add `FileSaverDependencies` so callers can pass one explicit runtime bundle to `FileSaverImpl`
- keep the legacy keyword constructor path while rejecting mixed or incomplete construction
- add focused file-saver constructor coverage and switch the default-path HTTP client test to the new call site

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
