### PR TITLE
feat(human-input): expose selected action value output

### DIFF
--- a/src/graphon/nodes/human_input/entities.py
+++ b/src/graphon/nodes/human_input/entities.py
@@ -180,7 +180,17 @@ class HumanInputNodeData(BaseNodeData):
         return action_id
 
     def must_resolve_action_value(self, action_id: str) -> str:
-        """Resolve the selected action's workflow-facing value by id."""
+        """Resolve the selected action's workflow-facing value by id.
+
+        This method should only be called with action ids that have already been
+        validated against the node configuration.
+
+        Returns:
+            The configured workflow-facing value for the selected action id.
+
+        Raises:
+            AssertionError: If the action id is not present in the node config.
+        """
         for action in self.user_actions:
             if action.id == action_id:
                 return action.title

--- a/src/graphon/nodes/human_input/entities.py
+++ b/src/graphon/nodes/human_input/entities.py
@@ -73,7 +73,7 @@ class UserAction(BaseModel):
     #
     # The id must be a valid identifier (satisfy the _IDENTIFIER_PATTERN above.)
     id: str = Field(max_length=20)
-    title: str = Field(max_length=20)
+    title: str = Field(max_length=100)
     button_style: ButtonStyle = ButtonStyle.DEFAULT
 
     @field_validator("id")
@@ -178,6 +178,13 @@ class HumanInputNodeData(BaseNodeData):
             if action.id == action_id:
                 return action.title
         return action_id
+
+    def find_action_value(self, action_id: str) -> str:
+        """Resolve the selected action's workflow-facing value by id."""
+        for action in self.user_actions:
+            if action.id == action_id:
+                return action.title
+        return ""
 
 
 class FormDefinition(BaseModel):

--- a/src/graphon/nodes/human_input/entities.py
+++ b/src/graphon/nodes/human_input/entities.py
@@ -179,12 +179,13 @@ class HumanInputNodeData(BaseNodeData):
                 return action.title
         return action_id
 
-    def find_action_value(self, action_id: str) -> str:
+    def must_resolve_action_value(self, action_id: str) -> str:
         """Resolve the selected action's workflow-facing value by id."""
         for action in self.user_actions:
             if action.id == action_id:
                 return action.title
-        return ""
+        msg = f"Invalid action: {action_id}"
+        raise AssertionError(msg)
 
 
 class FormDefinition(BaseModel):

--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -266,8 +266,8 @@ class HumanInputNode(Node[HumanInputNodeData]):
         submitted_inputs = dict(form.submitted_data or {})
         outputs: dict[str, Any] = dict(submitted_inputs)
         outputs[self._OUTPUT_FIELD_ACTION_ID] = selected_action_id
-        outputs[self._OUTPUT_FIELD_ACTION_VALUE] = self._node_data.find_action_value(
-            selected_action_id,
+        outputs[self._OUTPUT_FIELD_ACTION_VALUE] = (
+            self._node_data.must_resolve_action_value(selected_action_id)
         )
         rendered_content = self.render_form_content_with_outputs(
             form.rendered_content,

--- a/src/graphon/nodes/human_input/human_input_node.py
+++ b/src/graphon/nodes/human_input/human_input_node.py
@@ -56,6 +56,7 @@ class HumanInputNode(Node[HumanInputNodeData]):
 
     _node_data: HumanInputNodeData
     _OUTPUT_FIELD_ACTION_ID = "__action_id"
+    _OUTPUT_FIELD_ACTION_VALUE = "__action_value"
     _OUTPUT_FIELD_RENDERED_CONTENT = "__rendered_content"
     _TIMEOUT_HANDLE = _TIMEOUT_ACTION_ID = "__timeout"
 
@@ -243,7 +244,10 @@ class HumanInputNode(Node[HumanInputNodeData]):
             yield StreamCompletedEvent(
                 node_run_result=NodeRunResult(
                     status=WorkflowNodeExecutionStatus.SUCCEEDED,
-                    outputs={self._OUTPUT_FIELD_ACTION_ID: ""},
+                    outputs={
+                        self._OUTPUT_FIELD_ACTION_ID: "",
+                        self._OUTPUT_FIELD_ACTION_VALUE: "",
+                    },
                     edge_source_handle=self._TIMEOUT_HANDLE,
                 ),
             )
@@ -263,6 +267,9 @@ class HumanInputNode(Node[HumanInputNodeData]):
         submitted_data = form.submitted_data or {}
         outputs: dict[str, Any] = dict(submitted_data)
         outputs[self._OUTPUT_FIELD_ACTION_ID] = selected_action_id
+        outputs[self._OUTPUT_FIELD_ACTION_VALUE] = self._node_data.find_action_value(
+            selected_action_id,
+        )
         rendered_content = self.render_form_content_with_outputs(
             form.rendered_content,
             outputs,

--- a/tests/nodes/human_input/test_human_input_node.py
+++ b/tests/nodes/human_input/test_human_input_node.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from time import time
+from typing import Any
 
 from graphon.entities.graph_init_params import GraphInitParams
 from graphon.node_events.node import HumanInputFormTimeoutEvent, StreamCompletedEvent
@@ -45,7 +47,7 @@ class _FakeHumanInputRuntime:
         node_id: str,
         node_data: HumanInputNodeData,
         rendered_content: str,
-        resolved_default_values: dict[str, object],
+        resolved_default_values: Mapping[str, Any],
     ) -> _FakeForm:
         _ = (node_id, node_data, rendered_content, resolved_default_values)
         msg = "create_form should not be called in these tests"

--- a/tests/nodes/human_input/test_human_input_node.py
+++ b/tests/nodes/human_input/test_human_input_node.py
@@ -124,10 +124,6 @@ def test_human_input_submission_emits_action_value_outputs() -> None:
         completed.node_run_result.outputs["__action_value"]
         == "card_visa_enterprise_001_long_value"
     )
-    assert (
-        completed.node_run_result.outputs["__rendered_content"]
-        == "Selected ticket: TICKET-1"
-    )
 
 
 def test_human_input_timeout_emits_empty_action_value() -> None:

--- a/tests/nodes/human_input/test_human_input_node.py
+++ b/tests/nodes/human_input/test_human_input_node.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from time import time
+
+from graphon.entities.graph_init_params import GraphInitParams
+from graphon.node_events.node import HumanInputFormTimeoutEvent, StreamCompletedEvent
+from graphon.nodes.human_input.entities import HumanInputNodeData, UserAction
+from graphon.nodes.human_input.enums import (
+    ButtonStyle,
+    HumanInputFormStatus,
+    TimeoutUnit,
+)
+from graphon.nodes.human_input.human_input_node import HumanInputNode
+from graphon.runtime.graph_runtime_state import GraphRuntimeState
+from graphon.runtime.variable_pool import VariablePool
+
+
+@dataclass
+class _FakeForm:
+    id: str
+    rendered_content: str
+    expiration_time: datetime
+    status: HumanInputFormStatus
+    selected_action_id: str | None = None
+    submitted_data: dict[str, str] | None = None
+
+    @property
+    def submitted(self) -> bool:
+        return self.status == HumanInputFormStatus.SUBMITTED
+
+
+class _FakeHumanInputRuntime:
+    def __init__(self, form: _FakeForm) -> None:
+        self._form = form
+
+    def get_form(self, *, node_id: str) -> _FakeForm | None:
+        assert node_id == "human_input_node"
+        return self._form
+
+    def create_form(
+        self,
+        *,
+        node_id: str,
+        node_data: HumanInputNodeData,
+        rendered_content: str,
+        resolved_default_values: dict[str, object],
+    ) -> _FakeForm:
+        _ = (node_id, node_data, rendered_content, resolved_default_values)
+        msg = "create_form should not be called in these tests"
+        raise AssertionError(msg)
+
+
+def _build_graph_init_params() -> GraphInitParams:
+    return GraphInitParams(
+        workflow_id="workflow",
+        graph_config={},
+        run_context={},
+        call_depth=0,
+    )
+
+
+def _build_node(*, form: _FakeForm) -> HumanInputNode:
+    node_data = HumanInputNodeData(
+        title="Approval",
+        type="human-input",
+        form_content="Selected ticket: {{#$output.ticket#}}",
+        user_actions=[
+            UserAction(
+                id="approve",
+                title="card_visa_enterprise_001_long_value",
+                button_style=ButtonStyle.DEFAULT,
+            ),
+        ],
+        timeout=3,
+        timeout_unit=TimeoutUnit.DAY,
+    )
+    return HumanInputNode(
+        node_id="human_input_node",
+        config=node_data,
+        graph_init_params=_build_graph_init_params(),
+        graph_runtime_state=GraphRuntimeState(
+            variable_pool=VariablePool(),
+            start_at=time(),
+        ),
+        runtime=_FakeHumanInputRuntime(form),
+    )
+
+
+def _run_node_events(form: _FakeForm) -> list[object]:
+    return list(_build_node(form=form)._run())  # noqa: SLF001
+
+
+def test_user_action_title_accepts_long_business_value() -> None:
+    action = UserAction(
+        id="approve",
+        title="card_visa_enterprise_001_long_value",
+        button_style=ButtonStyle.DEFAULT,
+    )
+
+    assert action.title == "card_visa_enterprise_001_long_value"
+
+
+def test_human_input_submission_emits_action_value_outputs() -> None:
+    form = _FakeForm(
+        id="form-1",
+        rendered_content="Selected ticket: {{#$output.ticket#}}",
+        expiration_time=datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=1),
+        status=HumanInputFormStatus.SUBMITTED,
+        selected_action_id="approve",
+        submitted_data={"ticket": "TICKET-1"},
+    )
+
+    events = _run_node_events(form)
+    completed = next(
+        event for event in events if isinstance(event, StreamCompletedEvent)
+    )
+
+    assert completed.node_run_result.outputs["__action_id"] == "approve"
+    assert (
+        completed.node_run_result.outputs["__action_value"]
+        == "card_visa_enterprise_001_long_value"
+    )
+    assert (
+        completed.node_run_result.outputs["__rendered_content"]
+        == "Selected ticket: TICKET-1"
+    )
+
+
+def test_human_input_timeout_emits_empty_action_value() -> None:
+    form = _FakeForm(
+        id="form-2",
+        rendered_content="Selected ticket: {{#$output.ticket#}}",
+        expiration_time=datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=1),
+        status=HumanInputFormStatus.TIMEOUT,
+    )
+
+    events = _run_node_events(form)
+
+    assert any(isinstance(event, HumanInputFormTimeoutEvent) for event in events)
+    completed = next(
+        event for event in events if isinstance(event, StreamCompletedEvent)
+    )
+    assert not completed.node_run_result.outputs["__action_id"]
+    assert not completed.node_run_result.outputs["__action_value"]


### PR DESCRIPTION
## Summary

This Graphon-side companion PR implements the runtime/schema portion of [langgenius/dify#34597](https://github.com/langgenius/dify/issues/34597).

It adds `__action_value` for `Human Input` actions and raises the right-hand action value limit from 20 to 100.

## Changes

- raise `UserAction.title` max length from 20 to 100
- add `HumanInputNodeData.find_action_value()`
- emit `__action_value` from `HumanInputNode` submissions
- emit an empty `__action_value` on timeout for a stable output shape
- add focused tests for submit and timeout behavior

Closes #77.

<img width="2606" height="1358" alt="image" src="https://github.com/user-attachments/assets/6ab08a01-1ab2-46d9-9878-91810f5f4f83" />


## Cross References

- Companion Dify issue: [langgenius/dify#34597](https://github.com/langgenius/dify/issues/34597)
- Companion Dify PR: [langgenius/dify#35451](https://github.com/langgenius/dify/pull/35451)

## Verification

```bash
uv run pytest -o addopts='' tests/nodes/human_input/test_human_input_node.py -q
```
