### PR TITLE
fix(http-request): export dependency bundle

### DIFF
--- a/src/graphon/nodes/http_request/__init__.py
+++ b/src/graphon/nodes/http_request/__init__.py
@@ -7,7 +7,7 @@ from .entities import (
     HttpRequestNodeConfig,
     HttpRequestNodeData,
 )
-from .node import HttpRequestNode
+from .node import HttpRequestNode, HttpRequestNodeDependencies
 
 __all__ = [
     "HTTP_REQUEST_CONFIG_FILTER_KEY",
@@ -17,6 +17,7 @@ __all__ = [
     "HttpRequestNodeBody",
     "HttpRequestNodeConfig",
     "HttpRequestNodeData",
+    "HttpRequestNodeDependencies",
     "build_http_request_config",
     "resolve_http_request_config",
 ]

--- a/src/graphon/nodes/http_request/node.py
+++ b/src/graphon/nodes/http_request/node.py
@@ -39,7 +39,9 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
-class _HttpRequestNodeDependencies:
+class HttpRequestNodeDependencies:
+    """Runtime collaborators required by ``HttpRequestNode``."""
+
     tool_file_manager_factory: Callable[[], ToolFileManagerProtocol]
     file_manager: FileManagerProtocol
     file_reference_factory: FileReferenceFactoryProtocol
@@ -58,7 +60,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
         graph_init_params: GraphInitParams,
         graph_runtime_state: GraphRuntimeState,
         http_request_config: HttpRequestNodeConfig,
-        dependencies: _HttpRequestNodeDependencies | None = None,
+        dependencies: HttpRequestNodeDependencies | None = None,
         http_client: HttpClientProtocol | None = None,
         tool_file_manager_factory: Callable[[], ToolFileManagerProtocol] | None = None,
         file_manager: FileManagerProtocol | None = None,
@@ -70,7 +72,6 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
-
         resolved_dependencies = self._resolve_dependencies(
             dependencies=dependencies,
             http_client=http_client,
@@ -89,12 +90,12 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
     @staticmethod
     def _resolve_dependencies(
         *,
-        dependencies: _HttpRequestNodeDependencies | None,
+        dependencies: HttpRequestNodeDependencies | None,
         http_client: HttpClientProtocol | None,
         tool_file_manager_factory: Callable[[], ToolFileManagerProtocol] | None,
         file_manager: FileManagerProtocol | None,
         file_reference_factory: FileReferenceFactoryProtocol | None,
-    ) -> _HttpRequestNodeDependencies:
+    ) -> HttpRequestNodeDependencies:
         legacy_dependencies = {
             "http_client": http_client,
             "tool_file_manager_factory": tool_file_manager_factory,
@@ -125,7 +126,7 @@ class HttpRequestNode(Node[HttpRequestNodeData]):
             )
             raise TypeError(msg)
 
-        return _HttpRequestNodeDependencies(
+        return HttpRequestNodeDependencies(
             tool_file_manager_factory=cast(
                 Callable[[], ToolFileManagerProtocol],
                 tool_file_manager_factory,

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -2,7 +2,6 @@ import inspect
 import time
 from collections.abc import Callable, Generator, Mapping
 from http import HTTPStatus
-from importlib import import_module
 from typing import Any
 
 import httpx
@@ -23,6 +22,7 @@ from graphon.nodes.document_extractor.node import DocumentExtractorNode
 from graphon.nodes.http_request import (
     HttpRequestNode,
     HttpRequestNodeData,
+    HttpRequestNodeDependencies,
     build_http_request_config,
 )
 from graphon.nodes.http_request.entities import (
@@ -37,9 +37,6 @@ from graphon.nodes.question_classifier.question_classifier_node import (
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
 from ..helpers import build_graph_init_params, build_variable_pool
-
-_http_request_node_module = import_module("graphon.nodes.http_request.node")
-_internal_dependencies_name = "_HttpRequestNodeDependencies"
 
 
 class _ToolFileManager:
@@ -80,12 +77,11 @@ def _build_runtime_state() -> GraphRuntimeState:
     )
 
 
-def _build_internal_dependencies(
+def _build_dependencies(
     *,
     http_client: HttpClientProtocol | None = None,
-) -> Any:
-    dependencies_cls = getattr(_http_request_node_module, _internal_dependencies_name)
-    return dependencies_cls(
+) -> HttpRequestNodeDependencies:
+    return HttpRequestNodeDependencies(
         tool_file_manager_factory=_ToolFileManager,
         file_manager=_FileManager(),
         file_reference_factory=_FileReferenceFactory(),
@@ -205,7 +201,7 @@ def test_http_request_node_uses_default_http_client_when_not_injected() -> None:
     assert node.http_client is get_http_client()
 
 
-def test_http_request_node_accepts_internal_dependency_bundle() -> None:
+def test_http_request_node_accepts_public_dependency_bundle() -> None:
     node = HttpRequestNode(
         node_id="http",
         config=HttpRequestNodeData(
@@ -222,7 +218,7 @@ def test_http_request_node_accepts_internal_dependency_bundle() -> None:
         ),
         graph_runtime_state=_build_runtime_state(),
         http_request_config=build_http_request_config(),
-        dependencies=_build_internal_dependencies(),
+        dependencies=_build_dependencies(),
     )
 
     assert node.http_client is get_http_client()
@@ -249,7 +245,7 @@ def test_http_request_node_rejects_mixed_dependency_inputs() -> None:
             ),
             graph_runtime_state=_build_runtime_state(),
             http_request_config=build_http_request_config(),
-            dependencies=_build_internal_dependencies(),
+            dependencies=_build_dependencies(),
             file_manager=_FileManager(),
         )
 
@@ -296,3 +292,10 @@ def test_http_client_injection_is_optional(
     parameter = inspect.signature(callable_obj).parameters[parameter_name]
 
     assert parameter.default is None
+
+
+def test_http_request_node_signature_exposes_public_dependencies() -> None:
+    parameters = inspect.signature(HttpRequestNode.__init__).parameters
+
+    assert "dependencies" in parameters
+    assert parameters["dependencies"].default is None


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Refs #66

## Summary

- Export `HttpRequestNodeDependencies` as a public type so the `dependencies=` constructor path is usable through the package API.
- Keep the mixed-input validation and legacy keyword path intact.
- Replace the test-only private-module lookup with direct construction through the public import surface.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
