### PR TITLE
fix(prek): run make tc as a repository hook

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -26,6 +26,11 @@ hooks = [
 
 [[repos]]
 repo = 'local'
-hooks = [
-    {id = 'make-tc', name = 'make tc', entry = 'make tc', language = 'system'},
-]
+
+[[repos.hooks]]
+id = 'make-tc'
+name = 'make tc'
+entry = 'make tc'
+language = 'system'
+always_run = true
+pass_filenames = false


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #82

## Summary

- configure the local `make tc` hook as a repository-level `prek` hook with `always_run = true`
- disable filename passing for `make tc` with `pass_filenames = false` so `make` does not receive changed paths as extra targets
- keep the hook behavior consistent for file-driven invocations and empty file selections
- validation: `make test`, `make check`

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
