### PR TITLE
ci: improve GitHub Actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr-title:
     name: Validate PR title
@@ -20,7 +24,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title against CONTRIBUTING.md
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -44,10 +48,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python and uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Run checks
         run: make check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,13 @@ jobs:
       version: ${{ steps.verify.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python and uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - id: verify
         name: Verify tag matches pyproject.toml and main
@@ -68,18 +69,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Install uv and Python 3.12
-        uses: astral-sh/setup-uv@v7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          python-version: "3.12"
+          persist-credentials: false
+
+      - name: Setup Python and uv
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Build distributions
         run: make build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package-distributions
           path: dist/*
@@ -95,13 +96,13 @@ jobs:
       contents: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist
 
       - name: Create or update GitHub draft release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.verify-tag.outputs.tag }}
           name: ${{ needs.verify-tag.outputs.tag }}
@@ -129,13 +130,13 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -155,16 +156,16 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-package-distributions
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
       - name: Publish GitHub draft release
-        uses: ncipollo/release-action@v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.verify-tag.outputs.tag }}
           allowUpdates: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,15 @@ jobs:
           - "3.13"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup uv and Python
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
+          cache-dependency-glob: uv.lock
           python-version: ${{ matrix.python-version }}
 
       - name: Run tests
-        run: make test
+        run: uv run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Use these commands for normal development:
 - `make format`: run `uv run ruff format`
 - `make lint`: run `make format`, then `uv run ruff check --fix`
 - `make tc`: run `make lint`, then `uv run ty check`
-- `make check`: run `uv run ruff format --check && uv run ruff check && uv run ty check`
+- `make check`: run `uv lock --check && uv run ruff format --check && uv run ruff check && uv run ty check`
 - `make test`: run `make tc`, then `uv run pytest`
 - `make build`: build the package distributions
 - `make clean`: remove build artifacts and caches
@@ -87,8 +87,8 @@ Notes:
   formatting and lint fixes first.
 - `make test` is the progressive local full-chain target. It formats, applies
   lint fixes, runs `ty check`, and then runs the test suite.
-- `make check` aggregates the same non-mutating lint and type-check commands
-  used by CI.
+- `make check` aggregates the same non-mutating lockfile, lint, and type-check
+  commands used by CI.
 - `pytest` is configured with `-n auto` and `testpaths = ['tests']`, so the
   test suite runs in parallel by default.
 - If you change dependencies, refresh and commit `uv.lock` before opening a
@@ -109,8 +109,8 @@ make check
 Pull requests targeting `main` currently run three kinds of checks:
 
 1. PR title validation with `amannn/action-semantic-pull-request`
-2. `make check`
-3. `make test` on Python 3.12 and 3.13
+2. `make check` including `uv.lock` freshness validation
+3. `uv run pytest` on Python 3.12 and 3.13
 
 Keep local workflow aligned with those checks. A green local `make test` plus
 `make check` is useful, but it is not a complete substitute for the exact CI

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test: tc
 
 .PHONY: check
 check:
+	uv lock --check
 	uv run ruff format --check
 	uv run ruff check
 	uv run ty check

--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ construction, input seeding, and streamed output handling.
 Contributor setup, tooling details, CLA notes, and commit/PR conventions live
 in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-CI currently validates pull request titles, runs `make check`, and runs
-`make test` on Python 3.12 and 3.13. Python 3.14 is currently excluded because
-`unstructured` does not yet support it.
+CI currently validates pull request titles, runs `make check` including
+`uv.lock` freshness validation, and runs `uv run pytest` on Python 3.12 and
+3.13. Python 3.14 is currently excluded because `unstructured` does not yet
+support it.
 
 ## License
 


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #85

## Summary

- add PR workflow concurrency with `cancel-in-progress: true`
- pin GitHub Actions and release-related actions to explicit SHAs
- disable credential persistence for read-only checkout steps
- keep `uv.lock` validation in `make check` and let the Python matrix run `uv run pytest`
- add Dependabot updates for `uv` and `github-actions`
- update contributor documentation to match the current CI flow

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
