### PR TITLE
chore: Bump package version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'graphon'
-version = "0.2.2"
+version = "0.3.0"
 description = 'Graph execution engine for agentic AI workflows.'
 readme = 'README.md'
 license = 'Apache-2.0'

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "graphon"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary
- Bump the project and lockfile version to `0.3.0`.
- Prepare the repository for the next release tag.

## Testing
- Not included.