### PR TITLE
fix(http): honor content-type charset before encoding detection

### DIFF
--- a/src/graphon/http/response.py
+++ b/src/graphon/http/response.py
@@ -84,10 +84,10 @@ class HttpResponse:
         if self._cached_text is not None:
             return self._cached_text
 
-        detected_encoding = charset_normalizer.from_bytes(self.content).best()
-        if detected_encoding and detected_encoding.encoding:
+        charset = self._extract_charset_from_content_type()
+        if charset:
             try:
-                self._cached_text = self.content.decode(detected_encoding.encoding)
+                self._cached_text = self.content.decode(charset)
             except (UnicodeDecodeError, TypeError, LookupError):
                 pass
             else:
@@ -97,8 +97,29 @@ class HttpResponse:
             self._cached_text = self._fallback_text
             return self._cached_text
 
+        detected_encoding = charset_normalizer.from_bytes(self.content).best()
+        if detected_encoding and detected_encoding.encoding:
+            try:
+                self._cached_text = self.content.decode(detected_encoding.encoding)
+            except (UnicodeDecodeError, TypeError, LookupError):
+                pass
+            else:
+                return self._cached_text
+
         self._cached_text = self.content.decode("utf-8", errors="replace")
         return self._cached_text
+
+    def _extract_charset_from_content_type(self) -> str | None:
+        content_type = self.headers.get("content-type", "")
+        if not content_type:
+            return None
+
+        for param in content_type.split(";")[1:]:
+            key, sep, value = param.partition("=")
+            if sep and key.strip().lower() == "charset":
+                charset = value.strip().strip("\"'")
+                return charset or None
+        return None
 
     def raise_for_status(self) -> None:
         if not self.is_success:

--- a/src/graphon/http/response.py
+++ b/src/graphon/http/response.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import email.message
 from collections.abc import Iterator, Mapping
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
@@ -87,8 +88,8 @@ class HttpResponse:
         charset = self._extract_charset_from_content_type()
         if charset:
             try:
-                self._cached_text = self.content.decode(charset)
-            except (UnicodeDecodeError, TypeError, LookupError):
+                self._cached_text = self.content.decode(charset, errors="replace")
+            except (TypeError, LookupError):
                 pass
             else:
                 return self._cached_text
@@ -114,12 +115,9 @@ class HttpResponse:
         if not content_type:
             return None
 
-        for param in content_type.split(";")[1:]:
-            key, sep, value = param.partition("=")
-            if sep and key.strip().lower() == "charset":
-                charset = value.strip().strip("\"'")
-                return charset or None
-        return None
+        message = email.message.Message()
+        message["content-type"] = content_type
+        return message.get_content_charset(failobj=None)
 
     def raise_for_status(self) -> None:
         if not self.is_success:

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -190,6 +190,44 @@ def test_http_response_raise_for_status_uses_library_error() -> None:
         response.raise_for_status()
 
 
+def test_http_response_text_prefers_charset_from_content_type(
+    mocker: MockerFixture,
+) -> None:
+    detected_mock = mocker.patch("graphon.http.response.charset_normalizer.from_bytes")
+    response = HttpResponse(
+        status_code=HTTPStatus.OK,
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        content=b"\xe4\xb8\xad\xe6\x96\x87",
+    )
+
+    assert response.text == "\u4e2d\u6587"
+    detected_mock.assert_not_called()
+
+
+def test_http_response_text_prefers_fallback_text_over_detection(
+    mocker: MockerFixture,
+) -> None:
+    class _DetectedEncoding:
+        encoding = "latin-1"
+
+    class _DetectedMatches:
+        def best(self) -> _DetectedEncoding:
+            return _DetectedEncoding()
+
+    detected_mock = mocker.patch(
+        "graphon.http.response.charset_normalizer.from_bytes",
+        return_value=_DetectedMatches(),
+    )
+    response = HttpResponse(
+        status_code=HTTPStatus.OK,
+        content=b"\xe4\xb8\xad\xe6\x96\x87",
+        fallback_text="\u4e2d\u6587",
+    )
+
+    assert response.text == "\u4e2d\u6587"
+    detected_mock.assert_not_called()
+
+
 def test_httpx_http_client_raises_max_retries_exceeded_after_last_retry(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -228,6 +228,69 @@ def test_http_response_text_prefers_fallback_text_over_detection(
     detected_mock.assert_not_called()
 
 
+def test_http_response_from_httpx_preserves_httpx_text_without_charset_header(
+    mocker: MockerFixture,
+) -> None:
+    detected_mock = mocker.patch("graphon.http.response.charset_normalizer.from_bytes")
+    request = httpx.Request("GET", "https://example.com")
+    raw_response = httpx.Response(
+        HTTPStatus.OK,
+        request=request,
+        content="日本語の本文です".encode("shift_jis"),
+    )
+
+    response = HttpResponse.from_httpx(raw_response)
+
+    assert response.text == raw_response.text
+    detected_mock.assert_not_called()
+
+
+def test_http_response_from_httpx_preserves_custom_default_encoding(
+    mocker: MockerFixture,
+) -> None:
+    detected_mock = mocker.patch("graphon.http.response.charset_normalizer.from_bytes")
+    request = httpx.Request("GET", "https://example.com")
+    raw_response = httpx.Response(
+        HTTPStatus.OK,
+        request=request,
+        content="Привет".encode("cp1251"),
+        default_encoding="cp1251",
+    )
+
+    response = HttpResponse.from_httpx(raw_response)
+
+    assert response.text == raw_response.text
+    detected_mock.assert_not_called()
+
+
+def test_http_response_text_ignores_charset_fragments_inside_quoted_parameters(
+    mocker: MockerFixture,
+) -> None:
+    detected_mock = mocker.patch("graphon.http.response.charset_normalizer.from_bytes")
+    response = HttpResponse(
+        status_code=HTTPStatus.OK,
+        headers={"Content-Type": 'text/plain; foo="a; charset=latin-1"; charset=utf-8'},
+        content=b"\xe4\xb8\xad\xe6\x96\x87",
+    )
+
+    assert response.text == "\u4e2d\u6587"
+    detected_mock.assert_not_called()
+
+
+def test_http_response_text_uses_declared_charset_with_replacement(
+    mocker: MockerFixture,
+) -> None:
+    detected_mock = mocker.patch("graphon.http.response.charset_normalizer.from_bytes")
+    response = HttpResponse(
+        status_code=HTTPStatus.OK,
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+        content=b"\xffabc",
+    )
+
+    assert response.text == "\ufffdabc"
+    detected_mock.assert_not_called()
+
+
 def test_httpx_http_client_raises_max_retries_exceeded_after_last_retry(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

  This PR fixes text decoding in the HTTP response wrapper to prevent garbled Chinese (and other non-ASCII text) on some servers.

## Related Issue

* https://github.com/langgenius/dify/issues/31695
* https://github.com/langgenius/dify/issues/19202


  ### What changed

  - Updated `HttpResponse.text` decode priority:
  1. Use charset from `Content-Type` header first (if present)
  2. Fallback to `httpx` decoded text (`fallback_text`)
  3. Then use `charset_normalizer` detection
  4. Finally fallback to `utf-8` with replacement

  - Added charset parsing from `Content-Type` parameters.

  - Added regression tests:
  1. `Content-Type: ...; charset=utf-8` is respected directly
  2. `fallback_text` is preferred over encoding detection

  ### Why

  Some endpoints explicitly return `Content-Type: application/json; charset=utf-8`, but previous logic attempted heuristic detection first, which could decode incorrectly for certain payloads.

  ## Checklist

  - [x] This pull request links the issue it resolves or advances
  - [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
  - [x] If CLA Assistant prompted me, I signed [CLA.md](https://github.com/langgenius/graphon/CLA.md) in the pull request conversation