### PR TITLE
chore(ci): migrate runners to depot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: CLA Assistant
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   validate-pr-title:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       pull-requests: read
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   verify-tag:
     name: Verify release tag
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -61,7 +61,7 @@ jobs:
 
   build:
     name: Build release distributions
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs:
       - verify-tag
       - test
@@ -88,7 +88,7 @@ jobs:
 
   publish-github-draft:
     name: Create GitHub draft release
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs:
       - verify-tag
       - build
@@ -118,7 +118,7 @@ jobs:
 
   publish-testpypi:
     name: Publish package distributions to TestPyPI
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs:
       - verify-tag
       - build
@@ -143,7 +143,7 @@ jobs:
 
   publish-pypi:
     name: Publish package distributions to PyPI
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs:
       - verify-tag
       - build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #111

## Summary

This pull request migrates GitHub Actions jobs in `.github/workflows/cla.yml`, `.github/workflows/pr.yml`, `.github/workflows/release.yml`, and `.github/workflows/test.yml` from `ubuntu-latest` to `depot-ubuntu-24.04`.

The workflow triggers, permissions, Python matrix, and pinned action versions are unchanged. The change is limited to the runner label so CLA, PR validation, test, and release automation execute on the Depot runner pool.

The branch commit has been re-authored as `WH-2099 <wh2099@pm.me>` so CLA validation is tied to the local maintainer author instead of the original contributor who cannot sign the CLA.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
