### PR TITLE
fix: ensure previously serialized `File` object could be properly deserialized.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ ignore-one-line-docstrings = true
 'tests/**/*.py' = [
     'S101',    # Assert statements used for pytest.
     'PLR2004', # Magic value used in test cases.
+    'PLC2701', # Allow import private members from graphon module.
 ]
 
 [tool.ty.environment]

--- a/src/graphon/file/models.py
+++ b/src/graphon/file/models.py
@@ -16,6 +16,10 @@ from .enums import FileTransferMethod, FileType
 _FILE_REFERENCE_PREFIX = "dify-file-ref:"
 
 
+class _FileConstructorConflictError(ValueError):
+    """Raised when multiple constructor inputs disagree on file identity."""
+
+
 def sign_tool_file(
     *,
     tool_file_id: str,
@@ -113,7 +117,7 @@ class File(BaseModel):
         *,
         file_id: str | None = None,
         tenant_id: str | None = None,
-        file_type: FileType,
+        file_type: FileType | None = None,
         transfer_method: FileTransferMethod,
         remote_url: str | None = None,
         reference: str | None = None,
@@ -129,18 +133,39 @@ class File(BaseModel):
         tool_file_id: str | None = None,
         upload_file_id: str | None = None,
         datasource_file_id: str | None = None,
+        **legacy_kwargs: Any,
     ) -> None:
+        legacy_id = legacy_kwargs.pop("id", None)
+        legacy_type = legacy_kwargs.pop("type", None)
+        if legacy_kwargs:
+            unexpected_keys = ", ".join(sorted(legacy_kwargs))
+            msg = f"Unexpected keyword arguments: {unexpected_keys}"
+            raise TypeError(msg)
+
         legacy_record_id = (
             related_id or tool_file_id or upload_file_id or datasource_file_id
         )
+        if legacy_id is not None and file_id is not None and legacy_id != file_id:
+            msg = "Conflicting file identifiers"
+            raise _FileConstructorConflictError(msg)
+        if (
+            legacy_type is not None
+            and file_type is not None
+            and legacy_type != file_type
+        ):
+            msg = "Conflicting file types"
+            raise _FileConstructorConflictError(msg)
+
         normalized_reference = reference
         if normalized_reference is None and legacy_record_id is not None:
             normalized_reference = str(legacy_record_id)
         _, parsed_storage_key = _parse_reference(normalized_reference)
+        normalized_file_id = file_id if file_id is not None else legacy_id
+        normalized_file_type = file_type if file_type is not None else legacy_type
 
         super().__init__(
-            id=file_id,
-            type=file_type,
+            id=normalized_file_id,
+            type=normalized_file_type,
             transfer_method=transfer_method,
             remote_url=remote_url,
             reference=normalized_reference,

--- a/src/graphon/file/models.py
+++ b/src/graphon/file/models.py
@@ -16,7 +16,7 @@ from .enums import FileTransferMethod, FileType
 _FILE_REFERENCE_PREFIX = "dify-file-ref:"
 
 
-class _FileConstructorConflictError(ValueError):
+class _FileConstructorConflictError(Exception):
     """Raised when multiple constructor inputs disagree on file identity."""
 
 

--- a/tests/file/test_models.py
+++ b/tests/file/test_models.py
@@ -5,12 +5,11 @@ from graphon.file.enums import (
     FileTransferMethod,
     FileType,
 )
-from graphon.file.models import File
+from graphon.file.models import File, _FileConstructorConflictError
 
 from ..helpers import build_file_reference
 
-_HISTORICAL_FILE_JSON_FROM_749751D_PARENT = (
-    """{
+_HISTORICAL_FILE_JSON_FROM_749751D_PARENT = """{
   "dify_model_identity": "__dify__file__",
   "id": "message-file-id",
   "type": "document",
@@ -22,7 +21,6 @@ _HISTORICAL_FILE_JSON_FROM_749751D_PARENT = (
   "mime_type": "application/pdf",
   "size": 128
 }"""
-)
 
 
 def _build_local_file(*, reference: str, storage_key: str | None = None) -> File:
@@ -106,7 +104,9 @@ def test_file_model_validate_accepts_historical_payload_from_749751d_parent() ->
 
 
 def test_file_constructor_rejects_conflicting_identity_kwargs() -> None:
-    with pytest.raises(ValueError, match="Conflicting file identifiers") as exc_info:
+    with pytest.raises(
+        _FileConstructorConflictError, match="Conflicting file identifiers"
+    ):
         File(
             id="message-file-id",
             file_id="other-file-id",
@@ -114,5 +114,3 @@ def test_file_constructor_rejects_conflicting_identity_kwargs() -> None:
             transfer_method=FileTransferMethod.LOCAL_FILE,
             reference="upload-file-id",
         )
-
-    assert exc_info.type.__name__ == "_FileConstructorConflictError"

--- a/tests/file/test_models.py
+++ b/tests/file/test_models.py
@@ -9,6 +9,21 @@ from graphon.file.models import File
 
 from ..helpers import build_file_reference
 
+_HISTORICAL_FILE_JSON_FROM_749751D_PARENT = (
+    """{
+  "dify_model_identity": "__dify__file__",
+  "id": "message-file-id",
+  "type": "document",
+  "transfer_method": "local_file",
+  "remote_url": null,
+  "reference": "upload-file-id",
+  "filename": "report.pdf",
+  "extension": ".pdf",
+  "mime_type": "application/pdf",
+  "size": 128
+}"""
+)
+
 
 def _build_local_file(*, reference: str, storage_key: str | None = None) -> File:
     return File(
@@ -80,3 +95,24 @@ def test_file_related_id_setter_updates_reference_alias() -> None:
 
     assert file.reference == "replacement-upload-id"
     assert file.related_id == "replacement-upload-id"
+
+
+def test_file_model_validate_accepts_historical_payload_from_749751d_parent() -> None:
+    restored = File.model_validate_json(_HISTORICAL_FILE_JSON_FROM_749751D_PARENT)
+
+    assert restored.id == "message-file-id"
+    assert restored.type == FileType.DOCUMENT
+    assert restored.reference == "upload-file-id"
+
+
+def test_file_constructor_rejects_conflicting_identity_kwargs() -> None:
+    with pytest.raises(ValueError, match="Conflicting file identifiers") as exc_info:
+        File(
+            id="message-file-id",
+            file_id="other-file-id",
+            type=FileType.DOCUMENT,
+            transfer_method=FileTransferMethod.LOCAL_FILE,
+            reference="upload-file-id",
+        )
+
+    assert exc_info.type.__name__ == "_FileConstructorConflictError"

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -14,6 +14,72 @@ from graphon.variables.variables import StringVariable
 
 CONVERSATION_VARIABLE_NODE_ID = "conversation"
 
+_HISTORICAL_FILE_SNAPSHOT_JSON_FROM_749751D_PARENT = (
+    """{
+  "version": "1.0",
+  "start_at": 123.0,
+  "total_tokens": 0,
+  "node_run_steps": 0,
+  "llm_usage": {
+    "prompt_tokens": 0,
+    "prompt_unit_price": "0.0",
+    "prompt_price_unit": "0.0",
+    "prompt_price": "0.0",
+    "completion_tokens": 0,
+    "completion_unit_price": "0.0",
+    "completion_price_unit": "0.0",
+    "completion_price": "0.0",
+    "total_tokens": 0,
+    "total_price": "0.0",
+    "currency": "USD",
+    "latency": 0.0,
+    "time_to_first_token": null,
+    "time_to_generate": null
+  },
+  "outputs": {},
+  "variable_pool": {
+    "variable_dictionary": {
+      "node1": {
+        "attachment": {
+          "value_type": "file",
+          "value": {
+            "dify_model_identity": "__dify__file__",
+            "id": "message-file-id",
+            "type": "document",
+            "transfer_method": "local_file",
+            "remote_url": null,
+            "reference": "upload-file-id",
+            "filename": "report.pdf",
+            "extension": ".pdf",
+            "mime_type": "application/pdf",
+            "size": 128
+          },
+          "id": "0759bf04-6fe1-4871-82b0-bc59ce96d43a",
+          "name": "attachment",
+          "description": "",
+          "selector": [
+            "node1",
+            "attachment"
+          ]
+        }
+      }
+    }
+  },
+  "ready_queue": "{\\"type\\":\\"InMemoryReadyQueue\\",\\"version\\":\\"1.0\\","""
+    """\\"items\\":[]}",
+  "graph_execution": "{\\"type\\":\\"GraphExecution\\",\\"version\\":\\"1.0\\","""
+    """\\"workflow_id\\":\\"\\",\\"started\\":false,\\"completed\\":false,"""
+    """\\"aborted\\":false,\\"paused\\":false,\\"pause_reasons\\":[],"""
+    """\\"error\\":null,\\"exceptions_count\\":0,\\"node_executions\\":[]}",
+  "paused_nodes": [],
+  "deferred_nodes": [],
+  "graph_state": {
+    "nodes": {},
+    "edges": {}
+  }
+}"""
+)
+
 
 class StubCoordinator:
     def __init__(self) -> None:
@@ -328,3 +394,14 @@ class TestGraphRuntimeState:
         ))
         assert restored_value is not None
         assert restored_value.value == "after"
+
+    def test_snapshot_restore_preserves_file_variable_id(self) -> None:
+        restored = GraphRuntimeState.from_snapshot(
+            _HISTORICAL_FILE_SNAPSHOT_JSON_FROM_749751D_PARENT,
+        )
+
+        restored_segment = restored.variable_pool.get(("node1", "attachment"))
+        assert restored_segment is not None
+        assert restored_segment.value.id == "message-file-id"
+        assert restored_segment.value.type == "document"
+        assert restored_segment.value.reference == "upload-file-id"


### PR DESCRIPTION
This PR restores compatibility when deserializing historical `File` payloads produced before 749751d.

Changes:
- Updated `graphon.file.models.File` to accept historical normalized fields (`id` / `type`) during deserialization while preserving the current constructor surface.
- Introduced a private internal error for conflicting constructor inputs instead of raising a generic `ValueError`.
- Added regression coverage using JSON fixtures generated from `749751d^`:
  - direct `File` deserialization from historical JSON
  - `GraphRuntimeState.from_snapshot(...)` deserialization from a historical snapshot containing a file variable

Validation:
- Targeted file/runtime tests pass
- Full test suite passes (`324 passed`)

## Related Issue

Closes langgenius/dify#35703

## Summary

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
