### PR TITLE
refactor(runtime): remove legacy bootstrap entrypoint

### DIFF
--- a/src/graphon/runtime/variable_pool.py
+++ b/src/graphon/runtime/variable_pool.py
@@ -72,8 +72,7 @@ class VariablePool(BaseModel):
         joined_keys = ", ".join(legacy_keys)
         msg = (
             "VariablePool() no longer accepts legacy bootstrap inputs "
-            f"({joined_keys}); use VariablePool.from_bootstrap(...) or "
-            "VariablePool.from_legacy_bootstrap(...)."
+            f"({joined_keys}); use VariablePool.from_bootstrap(...)."
         )
         raise ValueError(msg)
 
@@ -114,25 +113,6 @@ class VariablePool(BaseModel):
         )
         pool._ingest_legacy_rag_variables(rag_pipeline_variables)
         return pool
-
-    @classmethod
-    def from_legacy_bootstrap(
-        cls,
-        *,
-        system_variables: Sequence[Variable] = (),
-        environment_variables: Sequence[Variable] = (),
-        conversation_variables: Sequence[Variable] = (),
-        rag_pipeline_variables: Sequence[RAGPipelineVariableInput] = (),
-        user_inputs: Mapping[str, Any] | None = None,
-    ) -> Self:
-        """Compatibility entrypoint for older constructor-style bootstrap call sites."""
-        return cls.from_bootstrap(
-            system_variables=system_variables,
-            environment_variables=environment_variables,
-            conversation_variables=conversation_variables,
-            rag_pipeline_variables=rag_pipeline_variables,
-            user_inputs=user_inputs,
-        )
 
     def _ingest_legacy_variables(
         self,

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -1,6 +1,3 @@
-import pytest
-from pydantic import ValidationError
-
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import (
     BooleanSegment,
@@ -58,23 +55,6 @@ class TestVariablePoolConstruction:
         rag_segment = pool.get(("rag", "retriever"))
         assert rag_segment is not None
         assert rag_segment.value == {"query": "answer"}
-
-    def test_constructor_rejects_legacy_bootstrap_kwargs(self) -> None:
-        with pytest.raises(ValidationError, match="from_bootstrap"):
-            VariablePool.model_validate({
-                "conversation_variables": [
-                    StringVariable(name="session", value="x"),
-                ],
-            })
-
-    def test_from_legacy_bootstrap_preserves_compatibility(self) -> None:
-        pool = VariablePool.from_legacy_bootstrap(
-            conversation_variables=[StringVariable(name="session_name", value="value")],
-        )
-
-        segment = pool.get(("conversation", "session_name"))
-        assert segment is not None
-        assert segment.value == "value"
 
 
 class TestVariablePoolGetAndNestedAttribute:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #121

## Summary

Removes the unused `VariablePool` legacy bootstrap compatibility entrypoint and deletes its compatibility tests.

Updates legacy constructor guidance to point only to `from_bootstrap`.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
