### PR TITLE
feat(dsl): add partial Dify workflow node import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ See [examples/slim_llm/dsl.py](examples/slim_llm/dsl.py) for the DSL import
 version and [examples/slim_llm/code.py](examples/slim_llm/code.py) for the
 Python graph construction version.
 
+Default DSL import currently supports `start`, `end`, `answer`, `if-else`,
+`template-transform`, `code`, `llm`, `tool`, `http-request`,
+`variable-aggregator`, `assigner`, `list-operator`, `question-classifier`, and
+`parameter-extractor`. HTTP request import covers text request bodies and text
+responses; file request bodies still require application-level file adapters.
+
 For direct Python graph construction, use `graphon.dsl.slim.SlimLLM` as the
 standard Slim-backed LLM runtime. Integrations that need to replace model
 execution, routing, credential injection, or token counting can implement

--- a/src/graphon/dsl/__init__.py
+++ b/src/graphon/dsl/__init__.py
@@ -5,6 +5,8 @@ from .entities import (
     DslDocument,
     DslImportPlan,
     DslKind,
+    DslRuntimeVariable,
+    DslRuntimeVariables,
     LoadStatus,
     PluginDependencyType,
 )
@@ -20,6 +22,8 @@ __all__ = [
     "DslError",
     "DslImportPlan",
     "DslKind",
+    "DslRuntimeVariable",
+    "DslRuntimeVariables",
     "LoadStatus",
     "PluginDependencyType",
     "SandboxCodeExecutionError",

--- a/src/graphon/dsl/entities.py
+++ b/src/graphon/dsl/entities.py
@@ -28,11 +28,27 @@ class PluginDependencyType(StrEnum):
     PACKAGE = auto()
 
 
+class DslRuntimeVariable(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    value: Any = None
+    source: Mapping[str, Any] = Field(default_factory=dict)
+
+
+class DslRuntimeVariables(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    environment_variables: list[DslRuntimeVariable] = Field(default_factory=list)
+    conversation_variables: list[DslRuntimeVariable] = Field(default_factory=list)
+
+
 class DslDocument(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     kind: DslKind
     graph_config: Mapping[str, Any] | None = None
+    runtime_variables: DslRuntimeVariables = Field(default_factory=DslRuntimeVariables)
 
 
 class DslDependency(BaseModel):

--- a/src/graphon/dsl/importer.py
+++ b/src/graphon/dsl/importer.py
@@ -26,6 +26,8 @@ from .entities import (
     DslDocument,
     DslImportPlan,
     DslKind,
+    DslRuntimeVariable,
+    DslRuntimeVariables,
     LoadStatus,
     PluginDependencyType,
 )
@@ -58,6 +60,12 @@ _SUPPORTED_DEFAULT_FACTORY_NODES = frozenset((
     BuiltinNodeTypes.CODE,
     BuiltinNodeTypes.LLM,
     BuiltinNodeTypes.TOOL,
+    BuiltinNodeTypes.HTTP_REQUEST,
+    BuiltinNodeTypes.VARIABLE_AGGREGATOR,
+    BuiltinNodeTypes.VARIABLE_ASSIGNER,
+    BuiltinNodeTypes.LIST_OPERATOR,
+    BuiltinNodeTypes.QUESTION_CLASSIFIER,
+    BuiltinNodeTypes.PARAMETER_EXTRACTOR,
 ))
 
 
@@ -129,6 +137,7 @@ def loads(
     root_id = root_node_id or _select_root_node_id(graph_config)
     workflow_id = workflow_id if workflow_id is not None else str(uuid4())
     variable_pool = _build_variable_pool(
+        runtime_variables=plan.document.runtime_variables,
         root_node_id=root_id,
         run_context=run_context or {},
         start_inputs=start_inputs or {},
@@ -144,6 +153,7 @@ def loads(
         start_at=time.time(),
     )
     parsed_credentials = _parse_credentials(credentials)
+    engine_config = config or GraphEngineConfig()
     node_factory = SlimDslNodeFactory(
         graph_config=graph_config,
         graph_init_params=graph_init_params,
@@ -179,7 +189,7 @@ def loads(
         graph=graph,
         graph_runtime_state=graph_runtime_state,
         command_channel=command_channel or InMemoryChannel(),
-        config=config or GraphEngineConfig(),
+        config=engine_config,
     )
 
 
@@ -339,6 +349,7 @@ def _build_dify_app_plan(payload: Mapping[str, Any]) -> DslImportPlan:
         kind=DslKind.APP,
         graph_config=graph,
         dependencies=dependencies,
+        runtime_variables=_extract_app_runtime_variables(workflow),
     )
 
 
@@ -361,6 +372,7 @@ def _build_graph_plan(
     kind: DslKind,
     graph_config: Mapping[str, Any],
     dependencies: list[DslDependency],
+    runtime_variables: DslRuntimeVariables | None = None,
 ) -> DslImportPlan:
     normalized_graph = _normalize_graph_config(graph_config, kind=kind)
     node_types = _node_types(normalized_graph)
@@ -369,16 +381,21 @@ def _build_graph_plan(
         for node_type in node_types
         if node_type not in _SUPPORTED_DEFAULT_FACTORY_NODES
     )
+    unsupported_node_reasons = _unsupported_node_reasons(normalized_graph)
     load_status: LoadStatus = LoadStatus.LOADABLE
-    load_reason: str | None = None
+    load_reasons: list[str] = []
     if unsupported:
+        load_reasons.append(f"Unsupported node types: {', '.join(unsupported)}")
+    load_reasons.extend(unsupported_node_reasons)
+    load_reason: str | None = "; ".join(load_reasons) or None
+    if load_reasons:
         load_status = LoadStatus.UNSUPPORTED
-        load_reason = f"Unsupported node types: {', '.join(unsupported)}"
 
     return DslImportPlan(
         document=DslDocument(
             kind=kind,
             graph_config=normalized_graph,
+            runtime_variables=runtime_variables or DslRuntimeVariables(),
         ),
         load_status=load_status,
         dependencies=dependencies,
@@ -421,6 +438,110 @@ def _normalize_graph_config(
     normalized["nodes"] = nodes
     normalized["edges"] = edges
     return normalized
+
+
+def _extract_app_runtime_variables(
+    workflow: Mapping[str, Any],
+) -> DslRuntimeVariables:
+    return DslRuntimeVariables(
+        environment_variables=_normalize_runtime_variables(
+            workflow.get("environment_variables"),
+            path="/workflow/environment_variables",
+        ),
+        conversation_variables=_normalize_runtime_variables(
+            workflow.get("conversation_variables"),
+            path="/workflow/conversation_variables",
+        ),
+    )
+
+
+def _normalize_runtime_variables(
+    raw_variables: object,
+    *,
+    path: str,
+) -> list[DslRuntimeVariable]:
+    if raw_variables is None:
+        return []
+    if not isinstance(raw_variables, list):
+        msg = "Runtime variables must be a list."
+        raise _dsl_error(
+            msg,
+            code="runtime_variables.invalid",
+            path=path,
+            kind=DslKind.APP,
+            details={"actual_type": type(raw_variables).__name__},
+        )
+
+    variables: list[DslRuntimeVariable] = []
+    for index, raw_variable in enumerate(raw_variables):
+        variable_path = f"{path}/{index}"
+        if not isinstance(raw_variable, Mapping):
+            msg = "Runtime variable must be a mapping."
+            raise _dsl_error(
+                msg,
+                code="runtime_variables.invalid_item",
+                path=variable_path,
+                kind=DslKind.APP,
+                details={"actual_type": type(raw_variable).__name__},
+            )
+        variable = cast(Mapping[str, Any], raw_variable)
+        name = variable.get("name")
+        if not isinstance(name, str) or not name:
+            msg = "Runtime variable name must be a non-empty string."
+            raise _dsl_error(
+                msg,
+                code="runtime_variables.invalid_name",
+                path=f"{variable_path}/name",
+                kind=DslKind.APP,
+                details={"actual_type": type(name).__name__},
+            )
+        variables.append(
+            DslRuntimeVariable(
+                name=name,
+                value=variable.get("value"),
+                source=dict(variable),
+            )
+        )
+    return variables
+
+
+def _unsupported_node_reasons(graph_config: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    for node in graph_config.get("nodes", []):
+        if not isinstance(node, Mapping) or not isinstance(node.get("data"), Mapping):
+            continue
+        data = cast(Mapping[str, Any], node["data"])
+        if data.get("type") != BuiltinNodeTypes.HTTP_REQUEST:
+            continue
+        reason = _unsupported_http_request_reason(data)
+        if reason is None:
+            continue
+        node_id = node.get("id")
+        prefix = (
+            f"HTTP request node {node_id!r}"
+            if isinstance(node_id, str)
+            else "HTTP request node"
+        )
+        reasons.append(f"{prefix} is unsupported: {reason}")
+    return reasons
+
+
+def _unsupported_http_request_reason(data: Mapping[str, Any]) -> str | None:
+    body = data.get("body")
+    if not isinstance(body, Mapping):
+        return None
+    body_type = body.get("type")
+    if body_type == "binary":
+        return "binary request bodies require file download support"
+    if body_type != "form-data":
+        return None
+    body_data = body.get("data") or []
+    if not isinstance(body_data, Sequence) or isinstance(body_data, str):
+        return None
+    for item in body_data:
+        if isinstance(item, Mapping) and item.get("type") == "file":
+            return "multipart file fields require file download support"
+    return None
 
 
 def _normalize_nodes(nodes: object, *, kind: DslKind) -> list[dict[str, Any]]:
@@ -493,7 +614,11 @@ def _normalize_nodes(nodes: object, *, kind: DslKind) -> list[dict[str, Any]]:
 
 
 def _normalize_node_data(data: dict[str, Any]) -> None:
-    if data.get("type") == BuiltinNodeTypes.LLM:
+    if data.get("type") in {
+        BuiltinNodeTypes.LLM,
+        BuiltinNodeTypes.QUESTION_CLASSIFIER,
+        BuiltinNodeTypes.PARAMETER_EXTRACTOR,
+    }:
         model = data.get("model")
         if isinstance(model, Mapping):
             normalized_model = dict(model)
@@ -690,11 +815,13 @@ def _select_root_node_id(graph_config: Mapping[str, Any]) -> str:
 
 def _build_variable_pool(
     *,
+    runtime_variables: DslRuntimeVariables,
     root_node_id: str,
     run_context: Mapping[str, Any],
     start_inputs: Mapping[str, Any],
 ) -> VariablePool:
     variable_pool = VariablePool()
+    _add_runtime_variables(variable_pool, runtime_variables=runtime_variables)
     for key, value in run_context.items():
         if isinstance(value, str | int | float | bool) or value is None:
             variable_pool.add(("sys", str(key)), value)
@@ -704,3 +831,16 @@ def _build_variable_pool(
         variable_pool.add((root_node_id, str(key)), value)
         variable_pool.add(("sys", str(key)), value)
     return variable_pool
+
+
+def _add_runtime_variables(
+    variable_pool: VariablePool,
+    *,
+    runtime_variables: DslRuntimeVariables,
+) -> None:
+    for namespace, variables in (
+        ("env", runtime_variables.environment_variables),
+        ("conversation", runtime_variables.conversation_variables),
+    ):
+        for variable in variables:
+            variable_pool.add((namespace, variable.name), variable.value)

--- a/src/graphon/dsl/importer.py
+++ b/src/graphon/dsl/importer.py
@@ -32,7 +32,7 @@ from .entities import (
     PluginDependencyType,
 )
 from .errors import DslError
-from .node_factory import SlimDslNodeFactory
+from .node_factory import SUPPORTED_DEFAULT_FACTORY_NODE_TYPES, SlimDslNodeFactory
 
 
 class _DslKey(StrEnum):
@@ -50,22 +50,6 @@ _CONFIG_ONLY_DIFY_APP_MODES = frozenset((
     "chat",
     "agent-chat",
     "channel",
-))
-_SUPPORTED_DEFAULT_FACTORY_NODES = frozenset((
-    BuiltinNodeTypes.START,
-    BuiltinNodeTypes.END,
-    BuiltinNodeTypes.ANSWER,
-    BuiltinNodeTypes.IF_ELSE,
-    BuiltinNodeTypes.TEMPLATE_TRANSFORM,
-    BuiltinNodeTypes.CODE,
-    BuiltinNodeTypes.LLM,
-    BuiltinNodeTypes.TOOL,
-    BuiltinNodeTypes.HTTP_REQUEST,
-    BuiltinNodeTypes.VARIABLE_AGGREGATOR,
-    BuiltinNodeTypes.VARIABLE_ASSIGNER,
-    BuiltinNodeTypes.LIST_OPERATOR,
-    BuiltinNodeTypes.QUESTION_CLASSIFIER,
-    BuiltinNodeTypes.PARAMETER_EXTRACTOR,
 ))
 
 
@@ -379,17 +363,13 @@ def _build_graph_plan(
     unsupported = sorted(
         node_type
         for node_type in node_types
-        if node_type not in _SUPPORTED_DEFAULT_FACTORY_NODES
+        if node_type not in SUPPORTED_DEFAULT_FACTORY_NODE_TYPES
     )
     unsupported_node_reasons = _unsupported_node_reasons(normalized_graph)
-    load_status: LoadStatus = LoadStatus.LOADABLE
     load_reasons: list[str] = []
     if unsupported:
         load_reasons.append(f"Unsupported node types: {', '.join(unsupported)}")
     load_reasons.extend(unsupported_node_reasons)
-    load_reason: str | None = "; ".join(load_reasons) or None
-    if load_reasons:
-        load_status = LoadStatus.UNSUPPORTED
 
     return DslImportPlan(
         document=DslDocument(
@@ -397,9 +377,9 @@ def _build_graph_plan(
             graph_config=normalized_graph,
             runtime_variables=runtime_variables or DslRuntimeVariables(),
         ),
-        load_status=load_status,
+        load_status=LoadStatus.UNSUPPORTED if load_reasons else LoadStatus.LOADABLE,
         dependencies=dependencies,
-        load_reason=load_reason,
+        load_reason="; ".join(load_reasons) or None,
     )
 
 

--- a/src/graphon/dsl/node_factory.py
+++ b/src/graphon/dsl/node_factory.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.entities.graph_config import NodeConfigDict
@@ -406,6 +406,9 @@ class _NodeBuildRequest:
     node_type: Any
 
 
+type _NodeBuilder = Callable[[Any, _NodeBuildRequest], Node]
+
+
 @dataclass(slots=True)
 class SlimDslNodeFactory:
     graph_config: Mapping[str, Any]
@@ -434,10 +437,10 @@ class SlimDslNodeFactory:
 
     def create_node(self, node_config: NodeConfigDict) -> Node:
         request = self._node_request(node_config)
-        builder = self._node_builders().get(request.node_type)
+        builder = self.NODE_BUILDERS.get(request.node_type)
         if builder is None:
             raise self._unsupported_node_error(request)
-        return builder(request)
+        return builder(self, request)
 
     def _node_request(
         self,
@@ -452,24 +455,6 @@ class SlimDslNodeFactory:
             data_payload=data_payload,
             node_type=data_payload["type"],
         )
-
-    def _node_builders(self) -> Mapping[Any, Callable[[_NodeBuildRequest], Node]]:
-        return {
-            BuiltinNodeTypes.START: self._create_start_node,
-            BuiltinNodeTypes.END: self._create_end_node,
-            BuiltinNodeTypes.ANSWER: self._create_answer_node,
-            BuiltinNodeTypes.IF_ELSE: self._create_if_else_node,
-            BuiltinNodeTypes.TEMPLATE_TRANSFORM: self._create_template_transform_node,
-            BuiltinNodeTypes.CODE: self._create_code_node,
-            BuiltinNodeTypes.LLM: self._create_llm_node,
-            BuiltinNodeTypes.TOOL: self._create_tool_node,
-            BuiltinNodeTypes.HTTP_REQUEST: self._create_http_request_node,
-            BuiltinNodeTypes.VARIABLE_AGGREGATOR: self._create_variable_aggregator_node,
-            BuiltinNodeTypes.VARIABLE_ASSIGNER: self._create_variable_assigner_node,
-            BuiltinNodeTypes.LIST_OPERATOR: self._create_list_operator_node,
-            BuiltinNodeTypes.QUESTION_CLASSIFIER: self._create_question_classifier_node,
-            BuiltinNodeTypes.PARAMETER_EXTRACTOR: self._create_parameter_extractor_node,
-        }
 
     def _create_start_node(self, request: _NodeBuildRequest) -> StartNode:
         return StartNode(
@@ -794,3 +779,23 @@ class SlimDslNodeFactory:
             credentials=tool_credential.values,
             credential_type=tool_credential.credential_type,
         )
+
+    NODE_BUILDERS: ClassVar[Mapping[Any, _NodeBuilder]] = {
+        BuiltinNodeTypes.START: _create_start_node,
+        BuiltinNodeTypes.END: _create_end_node,
+        BuiltinNodeTypes.ANSWER: _create_answer_node,
+        BuiltinNodeTypes.IF_ELSE: _create_if_else_node,
+        BuiltinNodeTypes.TEMPLATE_TRANSFORM: _create_template_transform_node,
+        BuiltinNodeTypes.CODE: _create_code_node,
+        BuiltinNodeTypes.LLM: _create_llm_node,
+        BuiltinNodeTypes.TOOL: _create_tool_node,
+        BuiltinNodeTypes.HTTP_REQUEST: _create_http_request_node,
+        BuiltinNodeTypes.VARIABLE_AGGREGATOR: _create_variable_aggregator_node,
+        BuiltinNodeTypes.VARIABLE_ASSIGNER: _create_variable_assigner_node,
+        BuiltinNodeTypes.LIST_OPERATOR: _create_list_operator_node,
+        BuiltinNodeTypes.QUESTION_CLASSIFIER: _create_question_classifier_node,
+        BuiltinNodeTypes.PARAMETER_EXTRACTOR: _create_parameter_extractor_node,
+    }
+
+
+SUPPORTED_DEFAULT_FACTORY_NODE_TYPES = frozenset(SlimDslNodeFactory.NODE_BUILDERS)

--- a/src/graphon/dsl/node_factory.py
+++ b/src/graphon/dsl/node_factory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -21,8 +21,27 @@ from graphon.nodes.code.code_node import CodeNode
 from graphon.nodes.code.entities import CodeNodeData
 from graphon.nodes.code.limits import CodeNodeLimits
 from graphon.nodes.end.end_node import EndNode
+from graphon.nodes.http_request.config import build_http_request_config
+from graphon.nodes.http_request.entities import HttpRequestNodeData
+from graphon.nodes.http_request.exc import FileFetchError, HttpRequestNodeError
+from graphon.nodes.http_request.node import (
+    HttpRequestNode,
+    HttpRequestNodeDependencies,
+)
 from graphon.nodes.if_else.if_else_node import IfElseNode
+from graphon.nodes.list_operator.entities import ListOperatorNodeData
+from graphon.nodes.list_operator.node import ListOperatorNode
 from graphon.nodes.llm import LLMNode, LLMNodeData
+from graphon.nodes.llm.exc import LLMNodeError
+from graphon.nodes.parameter_extractor.entities import ParameterExtractorNodeData
+from graphon.nodes.parameter_extractor.parameter_extractor_node import (
+    ParameterExtractorNode,
+)
+from graphon.nodes.question_classifier import (
+    QuestionClassifierNode,
+    QuestionClassifierNodeData,
+    QuestionClassifierNodeDependencies,
+)
 from graphon.nodes.start import StartNode
 from graphon.nodes.template_transform.entities import TemplateTransformNodeData
 from graphon.nodes.template_transform.template_transform_node import (
@@ -30,6 +49,18 @@ from graphon.nodes.template_transform.template_transform_node import (
 )
 from graphon.nodes.tool.entities import ToolNodeData
 from graphon.nodes.tool.tool_node import ToolNode
+from graphon.nodes.variable_aggregator.entities import VariableAggregatorNodeData
+from graphon.nodes.variable_aggregator.variable_aggregator_node import (
+    VariableAggregatorNode,
+)
+from graphon.nodes.variable_assigner.v1.node import (
+    VariableAssignerNode as VariableAssignerNodeV1,
+)
+from graphon.nodes.variable_assigner.v1.node_data import VariableAssignerData
+from graphon.nodes.variable_assigner.v2.entities import VariableAssignerNodeData
+from graphon.nodes.variable_assigner.v2.node import (
+    VariableAssignerNode as VariableAssignerNodeV2,
+)
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.template_rendering import Jinja2TemplateRenderer, TemplateRenderError
 
@@ -104,12 +135,12 @@ class _TextOnlyFileSaver:
     ) -> File:
         _ = data, mime_type, file_type, extension_override
         msg = "DSL import default LLM file saver only supports text responses."
-        raise RuntimeError(msg)
+        raise LLMNodeError(msg)
 
     def save_remote_url(self, url: str, file_type: FileType) -> File:
         _ = url, file_type
         msg = "DSL import default LLM file saver only supports text responses."
-        raise RuntimeError(msg)
+        raise LLMNodeError(msg)
 
 
 class _UnsupportedToolFileManager:
@@ -130,6 +161,40 @@ class _UnsupportedToolFileManager:
     ) -> tuple[None, None]:
         _ = tool_file_id
         return None, None
+
+
+class _UnsupportedHttpRequestFileManager:
+    def download(self, f: File, /) -> bytes:
+        _ = f
+        msg = "DSL import default HTTP request runtime only supports text requests."
+        raise FileFetchError(msg)
+
+
+class _TextOnlyHttpResponseFileManager:
+    def create_file_by_raw(
+        self,
+        *,
+        file_binary: bytes,
+        mimetype: str,
+        filename: str | None = None,
+    ) -> object:
+        _ = file_binary, mimetype, filename
+        msg = "DSL import default HTTP request runtime only supports text responses."
+        raise HttpRequestNodeError(msg)
+
+    def get_file_generator_by_tool_file_id(
+        self,
+        tool_file_id: str,
+    ) -> tuple[None, None]:
+        _ = tool_file_id
+        return None, None
+
+
+class _UnsupportedHttpFileReferenceFactory:
+    def build_from_mapping(self, *, mapping: Mapping[str, Any]) -> File:
+        _ = mapping
+        msg = "DSL import default HTTP request runtime only supports text responses."
+        raise HttpRequestNodeError(msg)
 
 
 class _DefaultJinja2TemplateRenderer(Jinja2TemplateRenderer):
@@ -334,6 +399,14 @@ def _node_data_payload(data: BaseNodeData | Mapping[str, Any]) -> dict[str, Any]
 
 
 @dataclass(slots=True)
+class _NodeBuildRequest:
+    node_id: str
+    data: BaseNodeData | Mapping[str, Any]
+    data_payload: dict[str, Any]
+    node_type: Any
+
+
+@dataclass(slots=True)
 class SlimDslNodeFactory:
     graph_config: Mapping[str, Any]
     graph_init_params: Any
@@ -359,97 +432,278 @@ class SlimDslNodeFactory:
             ignore_uv_lock=slim.ignore_uv_lock,
         )
 
-    def create_node(self, node_config: NodeConfigDict) -> Node:  # noqa: C901, PLR0911
+    def create_node(self, node_config: NodeConfigDict) -> Node:
+        request = self._node_request(node_config)
+        builder = self._node_builders().get(request.node_type)
+        if builder is None:
+            raise self._unsupported_node_error(request)
+        return builder(request)
+
+    def _node_request(
+        self,
+        node_config: NodeConfigDict,
+    ) -> _NodeBuildRequest:
         node_id = str(node_config["id"])
         data = node_config["data"]
         data_payload = _node_data_payload(data)
-        node_type = data_payload["type"]
+        return _NodeBuildRequest(
+            node_id=node_id,
+            data=data,
+            data_payload=data_payload,
+            node_type=data_payload["type"],
+        )
 
-        match node_type:
-            case BuiltinNodeTypes.START:
-                return StartNode(
-                    node_id=node_id,
-                    data=StartNode.validate_node_data(data),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                )
-            case BuiltinNodeTypes.END:
-                return EndNode(
-                    node_id=node_id,
-                    data=EndNode.validate_node_data(data),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                )
-            case BuiltinNodeTypes.ANSWER:
-                return AnswerNode(
-                    node_id=node_id,
-                    data=AnswerNode.validate_node_data(data),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                )
-            case BuiltinNodeTypes.IF_ELSE:
-                return IfElseNode(
-                    node_id=node_id,
-                    data=IfElseNode.validate_node_data(data),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                )
-            case BuiltinNodeTypes.TEMPLATE_TRANSFORM:
-                return TemplateTransformNode(
-                    node_id=node_id,
-                    data=TemplateTransformNodeData.model_validate(data_payload),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                    jinja2_template_renderer=_DefaultJinja2TemplateRenderer(),
-                )
-            case BuiltinNodeTypes.CODE:
-                return CodeNode(
-                    node_id=node_id,
-                    data=CodeNodeData.model_validate(data_payload),
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                    code_executor=SandboxCodeExecutor(self.credentials.code),
-                    code_limits=_code_limits(self.credentials.code),
-                )
-            case BuiltinNodeTypes.LLM:
-                return self._create_llm_node(node_id=node_id, data=data_payload)
-            case BuiltinNodeTypes.TOOL:
-                tool_data = ToolNodeData.model_validate(data_payload)
-                try:
-                    runtime = self._create_tool_runtime(tool_data)
-                except DslError:
-                    raise
-                except Exception as error:
-                    raise _dsl_error(
-                        str(error),
-                        code="runtime.slim_unavailable",
-                        path=f"/nodes/{node_id}/data",
-                        details={"node_id": node_id, "node_type": node_type},
-                    ) from error
-                return ToolNode(
-                    node_id=node_id,
-                    data=tool_data,
-                    graph_init_params=self.graph_init_params,
-                    graph_runtime_state=self.graph_runtime_state,
-                    tool_file_manager=_UnsupportedToolFileManager(),
-                    runtime=runtime,
-                )
-            case _:
-                msg = f"Unsupported DSL node type: {node_type}"
-                raise _dsl_error(
-                    msg,
-                    code="node.unsupported_type",
-                    path=f"/nodes/{node_id}",
-                    details={"node_id": node_id, "node_type": node_type},
-                )
+    def _node_builders(self) -> Mapping[Any, Callable[[_NodeBuildRequest], Node]]:
+        return {
+            BuiltinNodeTypes.START: self._create_start_node,
+            BuiltinNodeTypes.END: self._create_end_node,
+            BuiltinNodeTypes.ANSWER: self._create_answer_node,
+            BuiltinNodeTypes.IF_ELSE: self._create_if_else_node,
+            BuiltinNodeTypes.TEMPLATE_TRANSFORM: self._create_template_transform_node,
+            BuiltinNodeTypes.CODE: self._create_code_node,
+            BuiltinNodeTypes.LLM: self._create_llm_node,
+            BuiltinNodeTypes.TOOL: self._create_tool_node,
+            BuiltinNodeTypes.HTTP_REQUEST: self._create_http_request_node,
+            BuiltinNodeTypes.VARIABLE_AGGREGATOR: self._create_variable_aggregator_node,
+            BuiltinNodeTypes.VARIABLE_ASSIGNER: self._create_variable_assigner_node,
+            BuiltinNodeTypes.LIST_OPERATOR: self._create_list_operator_node,
+            BuiltinNodeTypes.QUESTION_CLASSIFIER: self._create_question_classifier_node,
+            BuiltinNodeTypes.PARAMETER_EXTRACTOR: self._create_parameter_extractor_node,
+        }
 
-    def _create_llm_node(self, *, node_id: str, data: Mapping[str, Any]) -> LLMNode:
+    def _create_start_node(self, request: _NodeBuildRequest) -> StartNode:
+        return StartNode(
+            node_id=request.node_id,
+            data=StartNode.validate_node_data(request.data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _create_end_node(self, request: _NodeBuildRequest) -> EndNode:
+        return EndNode(
+            node_id=request.node_id,
+            data=EndNode.validate_node_data(request.data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _create_answer_node(self, request: _NodeBuildRequest) -> AnswerNode:
+        return AnswerNode(
+            node_id=request.node_id,
+            data=AnswerNode.validate_node_data(request.data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _create_if_else_node(self, request: _NodeBuildRequest) -> IfElseNode:
+        return IfElseNode(
+            node_id=request.node_id,
+            data=IfElseNode.validate_node_data(request.data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _create_template_transform_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> TemplateTransformNode:
+        return TemplateTransformNode(
+            node_id=request.node_id,
+            data=TemplateTransformNodeData.model_validate(request.data_payload),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            jinja2_template_renderer=_DefaultJinja2TemplateRenderer(),
+        )
+
+    def _create_code_node(self, request: _NodeBuildRequest) -> CodeNode:
+        return CodeNode(
+            node_id=request.node_id,
+            data=CodeNodeData.model_validate(request.data_payload),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            code_executor=SandboxCodeExecutor(self.credentials.code),
+            code_limits=_code_limits(self.credentials.code),
+        )
+
+    def _create_tool_node(self, request: _NodeBuildRequest) -> ToolNode:
+        tool_data = ToolNodeData.model_validate(request.data_payload)
+        try:
+            runtime = self._create_tool_runtime(tool_data)
+        except DslError:
+            raise
+        except Exception as error:
+            raise _dsl_error(
+                str(error),
+                code="runtime.slim_unavailable",
+                path=f"/nodes/{request.node_id}/data",
+                details={
+                    "node_id": request.node_id,
+                    "node_type": BuiltinNodeTypes.TOOL,
+                },
+            ) from error
+        return ToolNode(
+            node_id=request.node_id,
+            data=tool_data,
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            tool_file_manager=_UnsupportedToolFileManager(),
+            runtime=runtime,
+        )
+
+    def _create_http_request_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> HttpRequestNode:
+        return HttpRequestNode(
+            node_id=request.node_id,
+            data=HttpRequestNodeData.model_validate(request.data_payload),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            http_request_config=build_http_request_config(),
+            dependencies=HttpRequestNodeDependencies(
+                tool_file_manager_factory=_TextOnlyHttpResponseFileManager,
+                file_manager=_UnsupportedHttpRequestFileManager(),
+                file_reference_factory=_UnsupportedHttpFileReferenceFactory(),
+            ),
+        )
+
+    def _create_variable_aggregator_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> VariableAggregatorNode:
+        return VariableAggregatorNode(
+            node_id=request.node_id,
+            data=VariableAggregatorNodeData.model_validate(request.data_payload),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _create_list_operator_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> ListOperatorNode:
+        return ListOperatorNode(
+            node_id=request.node_id,
+            data=ListOperatorNodeData.model_validate(request.data_payload),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+        )
+
+    def _unsupported_node_error(self, request: _NodeBuildRequest) -> DslError:
+        msg = f"Unsupported DSL node type: {request.node_type}"
+        return _dsl_error(
+            msg,
+            code="node.unsupported_type",
+            path=f"/nodes/{request.node_id}",
+            details={"node_id": request.node_id, "node_type": request.node_type},
+        )
+
+    def _create_variable_assigner_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> VariableAssignerNodeV1 | VariableAssignerNodeV2:
+        node_id = request.node_id
+        data = request.data_payload
+        version = str(data.get("version") or "")
+        if "items" in data or version == VariableAssignerNodeV2.version():
+            return VariableAssignerNodeV2(
+                node_id=node_id,
+                data=VariableAssignerNodeData.model_validate(data),
+                graph_init_params=self.graph_init_params,
+                graph_runtime_state=self.graph_runtime_state,
+            )
+
+        v1_fields = {
+            "assigned_variable_selector",
+            "write_mode",
+            "input_variable_selector",
+        }
+        if v1_fields.issubset(data):
+            return VariableAssignerNodeV1(
+                node_id=node_id,
+                data=VariableAssignerData.model_validate(data),
+                graph_init_params=self.graph_init_params,
+                graph_runtime_state=self.graph_runtime_state,
+            )
+
+        msg = "Variable assigner DSL node data is not recognized."
+        raise _dsl_error(
+            msg,
+            code="node.assigner_invalid_payload",
+            path=f"/nodes/{node_id}/data",
+            details={"node_id": node_id},
+        )
+
+    def _create_question_classifier_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> QuestionClassifierNode:
+        normalized_data, model_instance = self._create_slim_llm_runtime(
+            node_id=request.node_id,
+            data=request.data_payload,
+            node_type_label="Question classifier",
+        )
+        return QuestionClassifierNode(
+            node_id=request.node_id,
+            data=QuestionClassifierNodeData.model_validate(normalized_data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            dependencies=QuestionClassifierNodeDependencies(
+                model_instance=model_instance,
+                template_renderer=_DefaultJinja2TemplateRenderer(),
+                llm_file_saver=_TextOnlyFileSaver(),
+                prompt_message_serializer=_PassthroughPromptMessageSerializer(),
+            ),
+        )
+
+    def _create_parameter_extractor_node(
+        self,
+        request: _NodeBuildRequest,
+    ) -> ParameterExtractorNode:
+        normalized_data, model_instance = self._create_slim_llm_runtime(
+            node_id=request.node_id,
+            data=request.data_payload,
+            node_type_label="Parameter extractor",
+        )
+        return ParameterExtractorNode(
+            node_id=request.node_id,
+            data=ParameterExtractorNodeData.model_validate(normalized_data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            model_instance=model_instance,
+            prompt_message_serializer=_PassthroughPromptMessageSerializer(),
+        )
+
+    def _create_llm_node(self, request: _NodeBuildRequest) -> LLMNode:
+        normalized_data, model_instance = self._create_slim_llm_runtime(
+            node_id=request.node_id,
+            data=request.data_payload,
+            node_type_label="LLM",
+        )
+        return LLMNode(
+            node_id=request.node_id,
+            data=LLMNodeData.model_validate(normalized_data),
+            graph_init_params=self.graph_init_params,
+            graph_runtime_state=self.graph_runtime_state,
+            model_instance=model_instance,
+            llm_file_saver=_TextOnlyFileSaver(),
+            prompt_message_serializer=_PassthroughPromptMessageSerializer(),
+            default_query_selector=("sys", "query"),
+        )
+
+    def _create_slim_llm_runtime(
+        self,
+        *,
+        node_id: str,
+        data: Mapping[str, Any],
+        node_type_label: str,
+    ) -> tuple[dict[str, Any], SlimLLM]:
         normalized_data = dict(data)
         model = dict(normalized_data.get("model") or {})
         raw_provider = str(model.get("provider") or "")
         vendor = _canonical_vendor(raw_provider)
         if not vendor:
-            msg = "LLM node is missing model provider."
+            msg = f"{node_type_label} node is missing model provider."
             raise _dsl_error(
                 msg,
                 code="node.llm_missing_provider",
@@ -464,7 +718,7 @@ class SlimDslNodeFactory:
             dependencies=self.dependencies,
         )
         if plugin_id is None:
-            msg = "LLM node dependency could not be resolved."
+            msg = f"{node_type_label} node dependency could not be resolved."
             raise _dsl_error(
                 msg,
                 code="dependency.missing_plugin",
@@ -494,16 +748,7 @@ class SlimDslNodeFactory:
                 path=f"/nodes/{node_id}/data/model",
                 details={"node_id": node_id, "vendor": vendor},
             ) from error
-        return LLMNode(
-            node_id=node_id,
-            data=LLMNodeData.model_validate(normalized_data),
-            graph_init_params=self.graph_init_params,
-            graph_runtime_state=self.graph_runtime_state,
-            model_instance=model_instance,
-            llm_file_saver=_TextOnlyFileSaver(),
-            prompt_message_serializer=_PassthroughPromptMessageSerializer(),
-            default_query_selector=("sys", "query"),
-        )
+        return normalized_data, model_instance
 
     def _create_tool_runtime(self, node_data: ToolNodeData) -> SlimToolNodeRuntime:
         plugin_dependencies = [

--- a/src/graphon/dsl/slim/__init__.py
+++ b/src/graphon/dsl/slim/__init__.py
@@ -7,6 +7,7 @@ from .client import (
     SlimEvent,
     SlimMessageEvent,
     cached_slim_plugin_root,
+    parse_slim_event,
     resolve_slim_binary_path,
     slim_plugin_cache_path,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "SlimMessageEvent",
     "SlimStructuredOutputParseError",
     "cached_slim_plugin_root",
+    "parse_slim_event",
     "resolve_slim_binary_path",
     "slim_plugin_cache_path",
 ]

--- a/src/graphon/dsl/slim/client.py
+++ b/src/graphon/dsl/slim/client.py
@@ -31,6 +31,22 @@ _SLIM_BINARY_PATH_ENV = "SLIM_BINARY_PATH"
 class SlimClientError(RuntimeError):
     """Raised when the DSL slim client cannot run or parse Slim output."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | int | None = None,
+        stage: str | None = None,
+        data: Mapping[str, Any] | None = None,
+        return_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.stage = stage
+        self.data = dict(data or {})
+        self.return_code = return_code
+
 
 @dataclass(frozen=True, slots=True)
 class SlimMessageEvent:
@@ -259,9 +275,7 @@ class SlimClient:
             check=False,
         )
         if process.returncode != 0:
-            raise SlimClientError(
-                _slim_error_message(process.stderr, process.returncode)
-            )
+            raise _slim_process_error(process.stderr, process.returncode)
 
         try:
             payload = json.loads(process.stdout)
@@ -319,7 +333,14 @@ def _unwrap_remote_daemon_payload(payload: Any) -> Any:
     code = payload.get("code")
     if code != 0:
         msg = str(payload.get("message") or "Slim daemon returned an error.")
-        raise SlimClientError(msg)
+        data = payload.get("data")
+        stage = data.get("stage") if isinstance(data, Mapping) else payload.get("stage")
+        raise SlimClientError(
+            msg,
+            code=code if isinstance(code, str | int) else None,
+            stage=stage if isinstance(stage, str) else None,
+            data=payload,
+        )
     return payload.get("data")
 
 
@@ -363,13 +384,13 @@ def _iter_slim_events(stdout: Iterable[str]) -> Generator[SlimEvent, None, None]
     for line in stdout:
         if not line.strip():
             continue
-        event = _parse_slim_event(line)
+        event = parse_slim_event(line)
         yield event
         if isinstance(event, SlimDoneEvent):
             return
 
 
-def _parse_slim_event(line: str) -> SlimEvent:
+def parse_slim_event(line: str) -> SlimEvent:
     try:
         event = json.loads(line)
     except json.JSONDecodeError as error:
@@ -391,8 +412,15 @@ def _parse_slim_event(line: str) -> SlimEvent:
             error = event.get("data") or {}
             if isinstance(error, Mapping):
                 message = str(error.get("message") or "Slim error.")
-            else:
-                message = str(error or "Slim error.")
+                code = error.get("code") or error.get("error_code")
+                stage = error.get("stage")
+                raise SlimClientError(
+                    message,
+                    code=code if isinstance(code, str | int) else None,
+                    stage=stage if isinstance(stage, str) else None,
+                    data=error,
+                )
+            message = str(error or "Slim error.")
             raise SlimClientError(message)
         case _:
             msg = f"Unknown Slim event type: {event_type}"
@@ -421,19 +449,37 @@ def _check_slim_process_exit(
     stderr_text = stderr_file.read().strip()
     if return_code == 0:
         return
-    raise SlimClientError(_slim_error_message(stderr_text, return_code))
+    raise _slim_process_error(stderr_text, return_code)
 
 
-def _slim_error_message(stderr_text: str, return_code: int) -> str:
+def _slim_process_error(stderr_text: str, return_code: int) -> SlimClientError:
     if not stderr_text:
-        return f"Slim process exited with code {return_code}"
+        return SlimClientError(
+            f"Slim process exited with code {return_code}",
+            return_code=return_code,
+        )
     try:
         stderr_payload = json.loads(stderr_text.splitlines()[-1])
     except json.JSONDecodeError:
-        return f"Slim process exited with code {return_code}: {stderr_text}"
+        return SlimClientError(
+            f"Slim process exited with code {return_code}: {stderr_text}",
+            return_code=return_code,
+        )
     if isinstance(stderr_payload, Mapping):
-        return str(
+        message = str(
             stderr_payload.get("message")
             or f"Slim process exited with code {return_code}",
         )
-    return f"Slim process exited with code {return_code}: {stderr_text}"
+        code = stderr_payload.get("code") or stderr_payload.get("error_code")
+        stage = stderr_payload.get("stage")
+        return SlimClientError(
+            message,
+            code=code if isinstance(code, str | int) else None,
+            stage=stage if isinstance(stage, str) else None,
+            data=stderr_payload,
+            return_code=return_code,
+        )
+    return SlimClientError(
+        f"Slim process exited with code {return_code}: {stderr_text}",
+        return_code=return_code,
+    )

--- a/src/graphon/dsl/slim/llm.py
+++ b/src/graphon/dsl/slim/llm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, overload, override
@@ -32,6 +33,9 @@ from graphon.model_runtime.entities.model_entities import AIModelEntity
 from graphon.model_runtime.model_providers.base.large_language_model import (
     merge_tool_call_deltas,
 )
+from graphon.model_runtime.model_providers.base.tokenizers.gpt2_tokenizer import (
+    GPT2Tokenizer,
+)
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from graphon.nodes.llm.runtime_protocols import LLMProtocol
 
@@ -41,6 +45,10 @@ _MODEL_TYPE_LLM = "llm"
 _MISSING_STRUCTURED_OUTPUT_MESSAGE = (
     "Slim structured-output response is missing structured_output data"
 )
+_SLIM_TIMEOUT_ERROR_CODE = "killed_by_timeout"
+_SLIM_TIMEOUT_ERROR_MESSAGE = "killed by timeout"
+
+logger = logging.getLogger(__name__)
 
 _OPTIONAL_STR_ADAPTER = TypeAdapter(StrictStr | None)
 _STRUCTURED_OUTPUT_ADAPTER = TypeAdapter(dict[StrictStr, Any] | None)
@@ -161,17 +169,27 @@ class SlimLLM(LLMProtocol):
 
     @override
     def get_llm_num_tokens(self, prompt_messages: Sequence[PromptMessage]) -> int:
-        result = self._invoke_unary_action(
-            action=_ACTION_GET_LLM_NUM_TOKENS,
-            data={
-                "provider": self._provider,
-                "model_type": _MODEL_TYPE_LLM,
-                "model": self._model_name,
-                "credentials": self._credentials,
-                "prompt_messages": _serialize_prompt_messages(prompt_messages),
-                "tools": [],
-            },
-        )
+        try:
+            result = self._invoke_unary_action(
+                action=_ACTION_GET_LLM_NUM_TOKENS,
+                data={
+                    "provider": self._provider,
+                    "model_type": _MODEL_TYPE_LLM,
+                    "model": self._model_name,
+                    "credentials": self._credentials,
+                    "prompt_messages": _serialize_prompt_messages(prompt_messages),
+                    "tools": [],
+                },
+            )
+        except SlimClientError as error:
+            if not _is_token_count_timeout(error):
+                raise
+            logger.info(
+                "Slim token counting timed out for %s/%s; using local estimate",
+                self._provider,
+                self._model_name,
+            )
+            return _estimate_prompt_message_tokens(prompt_messages)
         return int(result["num_tokens"])
 
     @overload
@@ -398,14 +416,11 @@ class SlimLLM(LLMProtocol):
         action: str,
         data: Mapping[str, Any],
     ) -> Iterable[Any]:
-        try:
-            return self._client.invoke_chunks(
-                plugin_id=self._plugin_id,
-                action=action,
-                data=data,
-            )
-        except SlimClientError as error:
-            raise RuntimeError(str(error)) from error
+        return self._client.invoke_chunks(
+            plugin_id=self._plugin_id,
+            action=action,
+            data=data,
+        )
 
 
 @overload
@@ -641,6 +656,27 @@ def _serialize_prompt_messages(
     prompt_messages: Sequence[PromptMessage],
 ) -> list[dict[str, Any]]:
     return [jsonable_encoder(item) for item in prompt_messages]
+
+
+def _estimate_prompt_message_tokens(prompt_messages: Sequence[PromptMessage]) -> int:
+    # Fallback estimate only considers text content. Multimodal token accounting
+    # remains provider-specific and should use Slim token counting when available.
+    text = "\n".join(
+        f"{message.role.value}: {message.get_text_content()}"
+        for message in prompt_messages
+    )
+    if not text:
+        return 0
+    try:
+        return GPT2Tokenizer.get_num_tokens(text)
+    except Exception:  # noqa: BLE001
+        return max(1, len(text) // 4)
+
+
+def _is_token_count_timeout(error: SlimClientError) -> bool:
+    if error.code == _SLIM_TIMEOUT_ERROR_CODE:
+        return True
+    return _SLIM_TIMEOUT_ERROR_MESSAGE in error.message
 
 
 def _normalize_prompt_message_payload(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/dsl/test_app_bootstrap.py
+++ b/tests/dsl/test_app_bootstrap.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from graphon.dsl import DslError, inspect, loads
+
+
+def _app_dsl_with_runtime_variables(
+    *,
+    environment_variables: object = None,
+    conversation_variables: object = None,
+) -> str:
+    workflow: dict[str, object] = {
+        "graph": {
+            "nodes": [
+                {"id": "start", "data": {"type": "start", "variables": []}},
+            ],
+            "edges": [],
+        },
+    }
+    if environment_variables is not None:
+        workflow["environment_variables"] = environment_variables
+    if conversation_variables is not None:
+        workflow["conversation_variables"] = conversation_variables
+    return yaml.safe_dump({
+        "kind": "app",
+        "app": {"mode": "workflow"},
+        "workflow": workflow,
+    })
+
+
+def test_app_dsl_loads_environment_and_conversation_variables() -> None:
+    dsl = _app_dsl_with_runtime_variables(
+        environment_variables=[
+            {"name": "var1", "value": "env-value"},
+        ],
+        conversation_variables=[
+            {"name": "topic", "value": "conversation-value"},
+        ],
+    )
+
+    engine = loads(dsl)
+    variable_pool = engine.graph_runtime_state.variable_pool
+    env_var = variable_pool.get(["env", "var1"])
+    conversation_var = variable_pool.get(["conversation", "topic"])
+
+    assert env_var is not None
+    assert conversation_var is not None
+    assert env_var.to_object() == "env-value"
+    assert conversation_var.to_object() == "conversation-value"
+
+
+def test_app_dsl_keeps_runtime_variables_out_of_graph_config() -> None:
+    dsl = yaml.safe_dump({
+        "kind": "app",
+        "app": {"mode": "workflow"},
+        "workflow": {
+            "environment_variables": [
+                {"name": "config", "value": {"base_url": "https://example.com"}},
+            ],
+            "conversation_variables": [
+                {"name": "recent_topics", "value": ["billing", "refund"]},
+            ],
+            "graph": {
+                "nodes": [
+                    {"id": "start", "data": {"type": "start", "variables": []}},
+                ],
+                "edges": [],
+            },
+        },
+    })
+
+    plan = inspect(dsl)
+    assert plan.document.graph_config is not None
+    assert "__graphon_bootstrap" not in plan.document.graph_config
+    assert plan.document.runtime_variables.environment_variables[0].name == "config"
+    assert plan.document.runtime_variables.environment_variables[0].source == {
+        "name": "config",
+        "value": {"base_url": "https://example.com"},
+    }
+    assert (
+        plan.document.runtime_variables.environment_variables[0].value["base_url"]
+        == "https://example.com"
+    )
+
+    engine = loads(dsl)
+    variable_pool = engine.graph_runtime_state.variable_pool
+    config_var = variable_pool.get(["env", "config"])
+    topics_var = variable_pool.get(["conversation", "recent_topics"])
+
+    assert config_var is not None
+    assert topics_var is not None
+    assert config_var.to_object() == {"base_url": "https://example.com"}
+    assert topics_var.to_object() == ["billing", "refund"]
+
+
+def test_app_dsl_rejects_invalid_runtime_variables() -> None:
+    dsl = _app_dsl_with_runtime_variables(
+        environment_variables=[{"value": "missing-name"}],
+    )
+
+    with pytest.raises(DslError) as exc_info:
+        inspect(dsl)
+
+    assert exc_info.value.code == "runtime_variables.invalid_name"
+    assert exc_info.value.path == "/workflow/environment_variables/0/name"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "expected_code", "expected_path"),
+    [
+        (
+            "environment_variables",
+            {"name": "not-a-list"},
+            "runtime_variables.invalid",
+            "/workflow/environment_variables",
+        ),
+        (
+            "environment_variables",
+            ["not-a-mapping"],
+            "runtime_variables.invalid_item",
+            "/workflow/environment_variables/0",
+        ),
+        (
+            "conversation_variables",
+            [{"name": 123, "value": "bad-name"}],
+            "runtime_variables.invalid_name",
+            "/workflow/conversation_variables/0/name",
+        ),
+    ],
+)
+def test_app_dsl_rejects_invalid_runtime_variable_shapes(
+    field_name: str,
+    value: object,
+    expected_code: str,
+    expected_path: str,
+) -> None:
+    kwargs = {field_name: value}
+    dsl = _app_dsl_with_runtime_variables(**kwargs)
+
+    with pytest.raises(DslError) as exc_info:
+        inspect(dsl)
+
+    assert exc_info.value.code == expected_code
+    assert exc_info.value.path == expected_path

--- a/tests/dsl/test_importer.py
+++ b/tests/dsl/test_importer.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import yaml
+
+from graphon.dsl import inspect as inspect_dsl
+from graphon.dsl.entities import LoadStatus
+
+_OPENAI_PLUGIN_ID = "langgenius/openai:0.3.8@test"
+
+
+def _graph_dsl_for_node(node_data: dict[str, Any]) -> str:
+    return _graph_dsl_for_nodes(
+        nodes=[{"id": "node", "data": node_data}],
+        edges=[{"source": "start", "target": "node"}],
+    )
+
+
+def _graph_dsl_for_nodes(
+    *,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> str:
+    return yaml.safe_dump({
+        "kind": "graph",
+        "dependencies": [
+            {
+                "type": "marketplace",
+                "value": {
+                    "marketplace_plugin_unique_identifier": _OPENAI_PLUGIN_ID,
+                },
+            },
+        ],
+        "graph": {
+            "nodes": [
+                {"id": "start", "data": {"type": "start", "variables": []}},
+                *nodes,
+            ],
+            "edges": edges,
+        },
+    })
+
+
+def _http_request_data() -> dict[str, Any]:
+    return {
+        "type": "http-request",
+        "method": "get",
+        "url": "https://example.com/api",
+        "authorization": {"type": "no-auth"},
+        "headers": "",
+        "params": "",
+        "body": {"type": "none"},
+    }
+
+
+def _variable_aggregator_data() -> dict[str, Any]:
+    return {
+        "type": "variable-aggregator",
+        "output_type": "string",
+        "variables": [["missing", "value"], ["start", "candidate"]],
+    }
+
+
+def _assigner_data() -> dict[str, Any]:
+    return {
+        "type": "assigner",
+        "version": "2",
+        "items": [
+            {
+                "variable_selector": ["conversation", "topic"],
+                "input_type": "variable",
+                "operation": "over-write",
+                "value": ["start", "value"],
+            },
+        ],
+    }
+
+
+def _list_operator_data() -> dict[str, Any]:
+    return {
+        "type": "list-operator",
+        "variable": ["start", "items"],
+        "filter_by": {"enabled": False, "conditions": []},
+        "order_by": {"enabled": False},
+        "limit": {"enabled": False},
+    }
+
+
+def _model(name: str) -> dict[str, Any]:
+    return {
+        "provider": "langgenius/openai/openai",
+        "name": name,
+        "mode": "chat",
+        "completion_params": {"temperature": 0.1},
+    }
+
+
+def _question_classifier_data() -> dict[str, Any]:
+    return {
+        "type": "question-classifier",
+        "query_variable_selector": ["start", "query"],
+        "model": _model("classifier-model"),
+        "classes": [
+            {"id": "billing", "name": "Billing questions", "label": "Billing"},
+            {"id": "refund", "name": "Refund requests", "label": "Refunds"},
+        ],
+        "instruction": "Choose the best category.",
+    }
+
+
+def _parameter_extractor_data() -> dict[str, Any]:
+    return {
+        "type": "parameter-extractor",
+        "query": ["start", "query"],
+        "model": _model("extractor-model"),
+        "parameters": [
+            {
+                "name": "location",
+                "type": "string",
+                "description": "The requested location",
+                "required": True,
+            },
+        ],
+        "instruction": "Extract the requested location.",
+        "reasoning_mode": "prompt",
+    }
+
+
+@pytest.mark.parametrize(
+    "node_data",
+    [
+        _http_request_data(),
+        _variable_aggregator_data(),
+        _assigner_data(),
+        _list_operator_data(),
+        _question_classifier_data(),
+        _parameter_extractor_data(),
+    ],
+)
+def test_default_factory_node_type_is_loadable(node_data: dict[str, Any]) -> None:
+    plan = inspect_dsl(_graph_dsl_for_node(node_data))
+
+    assert plan.load_status == LoadStatus.LOADABLE
+    assert plan.load_reason is None
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "type": "binary",
+            "data": [{"type": "file", "file": ["start", "file"]}],
+        },
+        {
+            "type": "form-data",
+            "data": [
+                {"key": "file", "type": "file", "file": ["start", "file"]},
+            ],
+        },
+    ],
+)
+def test_http_request_file_request_bodies_are_not_loadable(
+    body: dict[str, Any],
+) -> None:
+    node_data = _http_request_data()
+    node_data["body"] = body
+
+    plan = inspect_dsl(_graph_dsl_for_node(node_data))
+
+    assert plan.load_status == LoadStatus.UNSUPPORTED
+    assert "HTTP request node 'node' is unsupported" in str(plan.load_reason)
+
+
+def test_http_request_form_data_text_fields_remain_loadable() -> None:
+    node_data = _http_request_data()
+    node_data["body"] = {
+        "type": "form-data",
+        "data": [
+            {"key": "query", "type": "text", "value": "{{#start.query#}}"},
+        ],
+    }
+
+    plan = inspect_dsl(_graph_dsl_for_node(node_data))
+
+    assert plan.load_status == LoadStatus.LOADABLE
+    assert plan.load_reason is None
+
+
+def test_unsupported_node_type_and_http_file_body_reasons_are_joined() -> None:
+    http_data = _http_request_data()
+    http_data["body"] = {
+        "type": "binary",
+        "data": [{"type": "file", "file": ["start", "file"]}],
+    }
+    dsl = _graph_dsl_for_nodes(
+        nodes=[
+            {"id": "unknown", "data": {"type": "not-supported"}},
+            {"id": "http", "data": http_data},
+        ],
+        edges=[
+            {"source": "start", "target": "unknown"},
+            {"source": "start", "target": "http"},
+        ],
+    )
+
+    plan = inspect_dsl(dsl)
+
+    assert plan.load_status == LoadStatus.UNSUPPORTED
+    assert plan.load_reason == (
+        "Unsupported node types: not-supported; "
+        "HTTP request node 'http' is unsupported: "
+        "binary request bodies require file download support"
+    )
+
+
+@pytest.mark.parametrize(
+    "node_data",
+    [
+        _question_classifier_data(),
+        _parameter_extractor_data(),
+    ],
+)
+def test_model_node_provider_is_normalized_to_plugin_vendor(
+    node_data: dict[str, Any],
+) -> None:
+    plan = inspect_dsl(_graph_dsl_for_node(node_data))
+
+    assert plan.document.graph_config is not None
+    loaded_node = plan.document.graph_config["nodes"][1]
+    assert loaded_node["data"]["model"]["provider"] == "openai"
+
+
+def test_legacy_variable_assigner_remains_unsupported_by_default() -> None:
+    plan = inspect_dsl(_graph_dsl_for_node({"type": "variable-assigner"}))
+
+    assert plan.load_status == LoadStatus.UNSUPPORTED
+    assert plan.load_reason == "Unsupported node types: variable-assigner"
+
+
+@pytest.mark.parametrize(
+    "node_type",
+    [
+        "iteration",
+        "iteration-start",
+        "loop",
+        "loop-start",
+        "loop-end",
+    ],
+)
+def test_container_nodes_remain_unsupported_by_default(node_type: str) -> None:
+    plan = inspect_dsl(_graph_dsl_for_node({"type": node_type}))
+
+    assert plan.load_status == LoadStatus.UNSUPPORTED
+    assert plan.load_reason == f"Unsupported node types: {node_type}"

--- a/tests/dsl/test_node_factory.py
+++ b/tests/dsl/test_node_factory.py
@@ -1,0 +1,807 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, ClassVar, cast
+
+import pytest
+import yaml
+
+from graphon.dsl import loads
+from graphon.dsl.entities import DslCredentials
+from graphon.dsl.errors import DslError
+from graphon.dsl.node_factory import (
+    SlimDslNodeFactory,
+    _TextOnlyFileSaver,
+    _UnsupportedHttpFileReferenceFactory,
+)
+from graphon.entities.graph_config import NodeConfigDict
+from graphon.file.enums import FileTransferMethod, FileType
+from graphon.file.models import File
+from graphon.graph_events.node import (
+    NodeRunFailedEvent,
+    NodeRunSucceededEvent,
+    NodeRunVariableUpdatedEvent,
+)
+from graphon.http import HttpResponse
+from graphon.model_runtime.entities.common_entities import I18nObject
+from graphon.model_runtime.entities.llm_entities import LLMResult, LLMUsage
+from graphon.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    PromptMessage,
+    PromptMessageTool,
+)
+from graphon.model_runtime.entities.model_entities import (
+    AIModelEntity,
+    FetchFrom,
+    ModelType,
+)
+from graphon.nodes.http_request.exc import HttpRequestNodeError
+from graphon.nodes.http_request.node import HttpRequestNode
+from graphon.nodes.list_operator.node import ListOperatorNode
+from graphon.nodes.llm.exc import LLMNodeError
+from graphon.nodes.parameter_extractor.parameter_extractor_node import (
+    ParameterExtractorNode,
+)
+from graphon.nodes.question_classifier import QuestionClassifierNode
+from graphon.nodes.variable_aggregator.variable_aggregator_node import (
+    VariableAggregatorNode,
+)
+from graphon.nodes.variable_assigner.v1.node import (
+    VariableAssignerNode as VariableAssignerNodeV1,
+)
+from graphon.nodes.variable_assigner.v2.node import (
+    VariableAssignerNode as VariableAssignerNodeV2,
+)
+from graphon.runtime.graph_runtime_state import GraphRuntimeState
+from tests.helpers import build_graph_init_params, build_variable_pool
+
+_OPENAI_PLUGIN_ID = "langgenius/openai:0.3.8@test"
+
+
+class _FakeSlimLLM:
+    instances: ClassVar[list[_FakeSlimLLM]] = []
+    responses: ClassVar[dict[str, Any]] = {}
+
+    def __init__(
+        self,
+        *,
+        config: object,
+        plugin_id: str,
+        provider: str,
+        model_name: str,
+        credentials: Mapping[str, Any],
+        parameters: Mapping[str, Any] | None = None,
+        stop: Sequence[str] | None = None,
+    ) -> None:
+        self.config = config
+        self.plugin_id = plugin_id
+        self._provider = provider
+        self._model_name = model_name
+        self.credentials = dict(credentials)
+        self._parameters = dict(parameters or {})
+        self._stop = list(stop) if stop is not None else None
+        self.invoke_calls: list[dict[str, Any]] = []
+        self.instances.append(self)
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def parameters(self) -> Mapping[str, Any]:
+        return dict(self._parameters)
+
+    @parameters.setter
+    def parameters(self, value: Mapping[str, Any]) -> None:
+        self._parameters = dict(value)
+
+    @property
+    def stop(self) -> Sequence[str] | None:
+        return None if self._stop is None else list(self._stop)
+
+    def get_model_schema(self) -> AIModelEntity:
+        return AIModelEntity(
+            model=self._model_name,
+            label=I18nObject(en_US=self._model_name),
+            model_type=ModelType.LLM,
+            features=[],
+            fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
+            model_properties={},
+            parameter_rules=[],
+        )
+
+    def get_llm_num_tokens(self, prompt_messages: Sequence[PromptMessage]) -> int:
+        _ = prompt_messages
+        return 0
+
+    def invoke_llm(
+        self,
+        *,
+        prompt_messages: Sequence[PromptMessage],
+        model_parameters: Mapping[str, Any],
+        tools: Sequence[PromptMessageTool] | None,
+        stop: Sequence[str] | None,
+        stream: bool,
+    ) -> LLMResult:
+        self.invoke_calls.append({
+            "prompt_messages": list(prompt_messages),
+            "model_parameters": dict(model_parameters),
+            "tools": list(tools or []),
+            "stop": stop,
+            "stream": stream,
+        })
+        return LLMResult(
+            model=self._model_name,
+            prompt_messages=list(prompt_messages),
+            message=AssistantPromptMessage(
+                content=self.responses.get(self._model_name, "{}"),
+            ),
+            usage=LLMUsage.empty_usage(),
+        )
+
+
+def _patch_fake_slim_llm(monkeypatch: pytest.MonkeyPatch) -> type[_FakeSlimLLM]:
+    _FakeSlimLLM.instances = []
+    _FakeSlimLLM.responses = {}
+    monkeypatch.setattr("graphon.dsl.node_factory.SlimLLM", _FakeSlimLLM)
+    return _FakeSlimLLM
+
+
+def _openai_credentials() -> dict[str, Any]:
+    return {
+        "model_credentials": [
+            {
+                "vendor": "openai",
+                "values": {"api_key": "secret-key"},
+            },
+        ],
+    }
+
+
+def _graph_dsl_for_node(node_data: dict[str, Any]) -> str:
+    return _graph_dsl_for_nodes(
+        nodes=[{"id": "node", "data": node_data}],
+        edges=[{"source": "start", "target": "node"}],
+    )
+
+
+def _graph_dsl_for_node_without_dependencies(node_data: dict[str, Any]) -> str:
+    return yaml.safe_dump({
+        "kind": "graph",
+        "graph": {
+            "nodes": [
+                {"id": "start", "data": {"type": "start", "variables": []}},
+                {"id": "node", "data": node_data},
+            ],
+            "edges": [{"source": "start", "target": "node"}],
+        },
+    })
+
+
+def _graph_dsl_for_nodes(
+    *,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> str:
+    return yaml.safe_dump({
+        "kind": "graph",
+        "dependencies": [
+            {
+                "type": "marketplace",
+                "value": {
+                    "marketplace_plugin_unique_identifier": _OPENAI_PLUGIN_ID,
+                },
+            },
+        ],
+        "graph": {
+            "nodes": [
+                {"id": "start", "data": {"type": "start", "variables": []}},
+                *nodes,
+            ],
+            "edges": edges,
+        },
+    })
+
+
+def _exported_app_dsl_with_category_one_two_nodes() -> str:
+    return yaml.safe_dump({
+        "kind": "app",
+        "version": "0.3.0",
+        "app": {
+            "mode": "workflow",
+            "name": "Category one and two export",
+        },
+        "dependencies": [
+            {
+                "type": "marketplace",
+                "value": {
+                    "marketplace_plugin_unique_identifier": _OPENAI_PLUGIN_ID,
+                },
+            },
+        ],
+        "workflow": {
+            "environment_variables": [
+                {"name": "api_key", "value": "env-secret"},
+            ],
+            "conversation_variables": [
+                {"name": "topic", "value": "before"},
+            ],
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "start",
+                        "type": "custom",
+                        "position": {"x": 0, "y": 0},
+                        "data": {"type": "start", "title": "Start", "variables": []},
+                    },
+                    {
+                        "id": "http",
+                        "type": "custom",
+                        "position": {"x": 320, "y": 0},
+                        "data": {
+                            **_http_request_data(),
+                            "title": "HTTP Request",
+                            "headers": "Authorization: Bearer {{#env.api_key#}}",
+                            "params": "q: {{#start.query#}}",
+                            "body": {
+                                "type": "raw-text",
+                                "data": [
+                                    {
+                                        "type": "text",
+                                        "value": "{{#start.query#}}",
+                                    },
+                                ],
+                            },
+                            "timeout": {"connect": 5, "read": 10, "write": 5},
+                        },
+                    },
+                    {
+                        "id": "aggregate",
+                        "type": "custom",
+                        "position": {"x": 640, "y": 0},
+                        "data": {
+                            **_variable_aggregator_data(),
+                            "title": "Variable Aggregator",
+                            "advanced_settings": {
+                                "group_enabled": False,
+                                "groups": [],
+                            },
+                        },
+                    },
+                    {
+                        "id": "assign",
+                        "type": "custom",
+                        "position": {"x": 960, "y": 0},
+                        "data": {
+                            **_assigner_v2_data(),
+                            "title": "Variable Assigner",
+                        },
+                    },
+                    {
+                        "id": "list",
+                        "type": "custom",
+                        "position": {"x": 1280, "y": 0},
+                        "data": {
+                            **_list_operator_data(),
+                            "title": "List Operator",
+                            "extract_by": {"enabled": False, "serial": "1"},
+                        },
+                    },
+                    {
+                        "id": "classifier",
+                        "type": "custom",
+                        "position": {"x": 1600, "y": 0},
+                        "data": {
+                            **_question_classifier_data(),
+                            "title": "Question Classifier",
+                        },
+                    },
+                    {
+                        "id": "extractor",
+                        "type": "custom",
+                        "position": {"x": 1920, "y": 0},
+                        "data": {
+                            **_parameter_extractor_data(),
+                            "title": "Parameter Extractor",
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "start-http",
+                        "source": "start",
+                        "target": "http",
+                        "sourceHandle": "source",
+                        "targetHandle": "target",
+                        "data": {"isInIteration": False},
+                    },
+                    {"source": "start", "target": "aggregate"},
+                    {"source": "start", "target": "assign"},
+                    {"source": "start", "target": "list"},
+                    {
+                        "source": "start",
+                        "target": "classifier",
+                        "sourceHandle": "source",
+                    },
+                    {
+                        "source": "start",
+                        "target": "extractor",
+                        "sourceHandle": "source",
+                    },
+                ],
+                "viewport": {"x": 0, "y": 0, "zoom": 1},
+            },
+        },
+    })
+
+
+def _succeeded_event(events: list[object]) -> NodeRunSucceededEvent:
+    return next(event for event in events if isinstance(event, NodeRunSucceededEvent))
+
+
+def _failed_event(events: list[object]) -> NodeRunFailedEvent:
+    return next(event for event in events if isinstance(event, NodeRunFailedEvent))
+
+
+def _dsl_node_factory(
+    *,
+    variables: Sequence[tuple[Sequence[str], Any]] = (),
+) -> SlimDslNodeFactory:
+    return SlimDslNodeFactory(
+        graph_config={"nodes": [], "edges": []},
+        graph_init_params=build_graph_init_params(
+            graph_config={"nodes": [], "edges": []},
+        ),
+        graph_runtime_state=GraphRuntimeState(
+            variable_pool=build_variable_pool(variables=variables),
+            start_at=0,
+        ),
+        credentials=DslCredentials(),
+        dependencies=[],
+    )
+
+
+def _http_request_data() -> dict[str, Any]:
+    return {
+        "type": "http-request",
+        "method": "get",
+        "url": "https://example.com/api",
+        "authorization": {"type": "no-auth"},
+        "headers": "",
+        "params": "",
+        "body": {"type": "none"},
+    }
+
+
+def _variable_aggregator_data() -> dict[str, Any]:
+    return {
+        "type": "variable-aggregator",
+        "output_type": "string",
+        "variables": [["missing", "value"], ["start", "candidate"]],
+    }
+
+
+def _assigner_v1_data() -> dict[str, Any]:
+    return {
+        "type": "assigner",
+        "version": "1",
+        "assigned_variable_selector": ["conversation", "topic"],
+        "write_mode": "over-write",
+        "input_variable_selector": ["start", "value"],
+    }
+
+
+def _assigner_v2_data() -> dict[str, Any]:
+    return {
+        "type": "assigner",
+        "version": "2",
+        "items": [
+            {
+                "variable_selector": ["conversation", "topic"],
+                "input_type": "variable",
+                "operation": "over-write",
+                "value": ["start", "value"],
+            },
+        ],
+    }
+
+
+def _list_operator_data() -> dict[str, Any]:
+    return {
+        "type": "list-operator",
+        "variable": ["start", "items"],
+        "filter_by": {"enabled": False, "conditions": []},
+        "order_by": {"enabled": False},
+        "limit": {"enabled": False},
+    }
+
+
+def _model(name: str) -> dict[str, Any]:
+    return {
+        "provider": "langgenius/openai/openai",
+        "name": name,
+        "mode": "chat",
+        "completion_params": {"temperature": 0.1},
+    }
+
+
+def _question_classifier_data() -> dict[str, Any]:
+    return {
+        "type": "question-classifier",
+        "query_variable_selector": ["start", "query"],
+        "model": _model("classifier-model"),
+        "classes": [
+            {"id": "billing", "name": "Billing questions", "label": "Billing"},
+            {"id": "refund", "name": "Refund requests", "label": "Refunds"},
+        ],
+        "instruction": "Choose the best category.",
+    }
+
+
+def _parameter_extractor_data() -> dict[str, Any]:
+    return {
+        "type": "parameter-extractor",
+        "query": ["start", "query"],
+        "model": _model("extractor-model"),
+        "parameters": [
+            {
+                "name": "location",
+                "type": "string",
+                "description": "The requested location",
+                "required": True,
+            },
+        ],
+        "instruction": "Extract the requested location.",
+        "reasoning_mode": "prompt",
+    }
+
+
+@pytest.mark.parametrize(
+    ("node_data", "expected_type"),
+    [
+        (_http_request_data(), HttpRequestNode),
+        (_variable_aggregator_data(), VariableAggregatorNode),
+        (_assigner_v1_data(), VariableAssignerNodeV1),
+        (_assigner_v2_data(), VariableAssignerNodeV2),
+        (_list_operator_data(), ListOperatorNode),
+    ],
+)
+def test_default_factory_creates_builtin_runtime_node(
+    node_data: dict[str, Any],
+    expected_type: type[object],
+) -> None:
+    engine = loads(_graph_dsl_for_node(node_data))
+
+    assert isinstance(engine.graph.nodes["node"], expected_type)
+
+
+def test_variable_assigner_invalid_payload_raises_dsl_error() -> None:
+    with pytest.raises(DslError) as exc_info:
+        loads(_graph_dsl_for_node({"type": "assigner"}))
+
+    assert exc_info.value.code == "node.assigner_invalid_payload"
+    assert exc_info.value.path == "/nodes/node/data"
+
+
+@pytest.mark.parametrize(
+    ("node_data", "expected_type", "model_name"),
+    [
+        (_question_classifier_data(), QuestionClassifierNode, "classifier-model"),
+        (_parameter_extractor_data(), ParameterExtractorNode, "extractor-model"),
+    ],
+)
+def test_default_factory_creates_slim_backed_model_node(
+    monkeypatch: pytest.MonkeyPatch,
+    node_data: dict[str, Any],
+    expected_type: type[object],
+    model_name: str,
+) -> None:
+    fake_slim_llm = _patch_fake_slim_llm(monkeypatch)
+
+    engine = loads(
+        _graph_dsl_for_node(node_data),
+        credentials=_openai_credentials(),
+    )
+
+    assert isinstance(engine.graph.nodes["node"], expected_type)
+    model_instance = fake_slim_llm.instances[-1]
+    assert model_instance.plugin_id == _OPENAI_PLUGIN_ID
+    assert model_instance.provider == "openai"
+    assert model_instance.model_name == model_name
+    assert model_instance.credentials == {"openai_api_key": "secret-key"}
+    assert model_instance.parameters == {"temperature": 0.1}
+
+
+@pytest.mark.parametrize(
+    ("node_data", "message"),
+    [
+        (
+            {**_question_classifier_data(), "model": {"name": "classifier-model"}},
+            "Question classifier node is missing model provider.",
+        ),
+        (
+            {**_parameter_extractor_data(), "model": {"name": "extractor-model"}},
+            "Parameter extractor node is missing model provider.",
+        ),
+    ],
+)
+def test_slim_backed_model_node_requires_provider(
+    node_data: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(DslError) as exc_info:
+        loads(_graph_dsl_for_node(node_data), credentials=_openai_credentials())
+
+    assert str(exc_info.value) == message
+    assert exc_info.value.code == "node.llm_missing_provider"
+    assert exc_info.value.path == "/nodes/node/data/model/provider"
+
+
+@pytest.mark.parametrize(
+    "node_data",
+    [
+        _question_classifier_data(),
+        _parameter_extractor_data(),
+    ],
+)
+def test_slim_backed_model_node_requires_plugin_dependency(
+    node_data: dict[str, Any],
+) -> None:
+    with pytest.raises(DslError) as exc_info:
+        loads(
+            _graph_dsl_for_node_without_dependencies(node_data),
+            credentials=_openai_credentials(),
+        )
+
+    assert exc_info.value.code == "dependency.missing_plugin"
+    assert exc_info.value.path == "/nodes/node/data/model/provider"
+
+
+def test_dify_exported_app_loads_category_one_and_two_nodes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_slim_llm = _patch_fake_slim_llm(monkeypatch)
+
+    engine = loads(
+        _exported_app_dsl_with_category_one_two_nodes(),
+        credentials=_openai_credentials(),
+        start_inputs={"query": "Where is my refund?", "items": ["first"]},
+    )
+
+    assert isinstance(engine.graph.nodes["http"], HttpRequestNode)
+    assert isinstance(engine.graph.nodes["aggregate"], VariableAggregatorNode)
+    assert isinstance(engine.graph.nodes["assign"], VariableAssignerNodeV2)
+    assert isinstance(engine.graph.nodes["list"], ListOperatorNode)
+    assert isinstance(engine.graph.nodes["classifier"], QuestionClassifierNode)
+    assert isinstance(engine.graph.nodes["extractor"], ParameterExtractorNode)
+    assert [instance.model_name for instance in fake_slim_llm.instances] == [
+        "classifier-model",
+        "extractor-model",
+    ]
+    env_var = engine.graph_runtime_state.variable_pool.get(["env", "api_key"])
+    conversation_var = engine.graph_runtime_state.variable_pool.get([
+        "conversation",
+        "topic",
+    ])
+    assert env_var is not None
+    assert conversation_var is not None
+    assert env_var.to_object() == "env-secret"
+    assert conversation_var.to_object() == "before"
+
+
+def test_variable_aggregator_node_from_dsl_runs_first_available_selector() -> None:
+    engine = loads(
+        _graph_dsl_for_node(_variable_aggregator_data()),
+        start_inputs={"candidate": "hello"},
+    )
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    output = success.node_run_result.outputs["output"]
+    assert output.to_object() == "hello"
+
+
+def test_list_operator_node_from_dsl_runs_against_start_input_array() -> None:
+    engine = loads(
+        _graph_dsl_for_node(_list_operator_data()),
+        start_inputs={"items": ["first", "second"]},
+    )
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    assert success.node_run_result.outputs["first_record"] == "first"
+    assert success.node_run_result.outputs["last_record"] == "second"
+
+
+def test_assigner_node_from_dsl_emits_variable_update() -> None:
+    engine = loads(
+        _graph_dsl_for_node(_assigner_v2_data()),
+        start_inputs={"value": "after"},
+    )
+    engine.graph_runtime_state.variable_pool.add(["conversation", "topic"], "before")
+    node = engine.graph.nodes["node"]
+
+    events = list(node.run())
+
+    update = next(
+        event for event in events if isinstance(event, NodeRunVariableUpdatedEvent)
+    )
+    assert update.variable.selector == ["conversation", "topic"]
+    assert update.variable.value == "after"
+
+
+class _FakeRequestError(Exception):
+    pass
+
+
+class _FakeMaxRetriesExceededError(Exception):
+    pass
+
+
+class _FakeHttpClient:
+    def __init__(
+        self,
+        *,
+        headers: Mapping[str, str] | None = None,
+        content: bytes = b"ok",
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.headers = dict(headers or {"content-type": "text/plain"})
+        self.content = content
+
+    @property
+    def max_retries_exceeded_error(self) -> type[Exception]:
+        return _FakeMaxRetriesExceededError
+
+    @property
+    def request_error(self) -> type[Exception]:
+        return _FakeRequestError
+
+    def get(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        self.calls.append({"url": url, "max_retries": max_retries, **kwargs})
+        return HttpResponse(
+            status_code=200,
+            headers=self.headers,
+            content=self.content,
+            url=url,
+        )
+
+    def head(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        return self.get(url, max_retries=max_retries, **kwargs)
+
+    def post(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        return self.get(url, max_retries=max_retries, **kwargs)
+
+    def put(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        return self.get(url, max_retries=max_retries, **kwargs)
+
+    def delete(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        return self.get(url, max_retries=max_retries, **kwargs)
+
+    def patch(self, url: str, max_retries: int = 0, **kwargs: Any) -> HttpResponse:
+        return self.get(url, max_retries=max_retries, **kwargs)
+
+
+def test_http_request_node_from_dsl_runs_text_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http_client = _FakeHttpClient()
+    monkeypatch.setattr(
+        "graphon.nodes.http_request.node.get_http_client",
+        lambda: http_client,
+    )
+    engine = loads(_graph_dsl_for_node(_http_request_data()))
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    assert http_client.calls[0]["url"] == "https://example.com/api"
+    assert success.node_run_result.outputs["status_code"] == 200
+    assert success.node_run_result.outputs["body"] == "ok"
+
+
+def test_http_request_node_from_dsl_fails_file_response_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    http_client = _FakeHttpClient(headers={"content-type": "image/png"}, content=b"png")
+    monkeypatch.setattr(
+        "graphon.nodes.http_request.node.get_http_client",
+        lambda: http_client,
+    )
+    engine = loads(_graph_dsl_for_node(_http_request_data()))
+    node = engine.graph.nodes["node"]
+
+    failed = _failed_event(list(node.run()))
+
+    assert failed.error == (
+        "DSL import default HTTP request runtime only supports text responses."
+    )
+
+
+def test_http_request_node_file_body_download_fails_cleanly() -> None:
+    file_value = File(
+        file_type=FileType.IMAGE,
+        transfer_method=FileTransferMethod.REMOTE_URL,
+        remote_url="https://example.com/file.png",
+    )
+    factory = _dsl_node_factory(variables=[(["start", "file"], file_value)])
+    node_data = _http_request_data()
+    node_data["body"] = {
+        "type": "binary",
+        "data": [{"type": "file", "file": ["start", "file"]}],
+    }
+    node = factory.create_node(cast(NodeConfigDict, {"id": "node", "data": node_data}))
+
+    failed = _failed_event(list(node.run()))
+
+    assert failed.error == (
+        "DSL import default HTTP request runtime only supports text requests."
+    )
+
+
+def test_http_file_reference_factory_fails_with_http_node_error() -> None:
+    with pytest.raises(HttpRequestNodeError, match="only supports text responses"):
+        _UnsupportedHttpFileReferenceFactory().build_from_mapping(
+            mapping={
+                "tool_file_id": "tool-file",
+                "transfer_method": FileTransferMethod.TOOL_FILE,
+            },
+        )
+
+
+def test_default_llm_file_saver_fails_with_llm_node_error() -> None:
+    with pytest.raises(LLMNodeError, match="only supports text responses"):
+        _TextOnlyFileSaver().save_remote_url(
+            "https://example.com/image.png",
+            FileType.IMAGE,
+        )
+
+
+def test_question_classifier_node_from_dsl_runs_with_slim_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_slim_llm = _patch_fake_slim_llm(monkeypatch)
+    fake_slim_llm.responses = {
+        "classifier-model": (
+            '{"category_id": "refund", "category_name": "Refund requests"}'
+        ),
+    }
+    engine = loads(
+        _graph_dsl_for_node(_question_classifier_data()),
+        credentials=_openai_credentials(),
+        start_inputs={"query": "Where is my refund?"},
+    )
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    assert success.node_run_result.outputs["class_id"] == "refund"
+    assert success.node_run_result.outputs["class_label"] == "Refunds"
+    assert success.node_run_result.outputs["class_name"] == "Refund requests"
+    assert fake_slim_llm.instances[-1].invoke_calls[-1]["stream"] is True
+
+
+def test_parameter_extractor_node_from_dsl_runs_with_slim_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_slim_llm = _patch_fake_slim_llm(monkeypatch)
+    fake_slim_llm.responses = {"extractor-model": '{"location": "Paris"}'}
+    engine = loads(
+        _graph_dsl_for_node(_parameter_extractor_data()),
+        credentials=_openai_credentials(),
+        start_inputs={"query": "Book a trip to Paris"},
+    )
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    assert success.node_run_result.outputs["__is_success"] == 1
+    assert success.node_run_result.outputs["__reason"] is None
+    assert success.node_run_result.outputs["location"] == "Paris"
+    assert fake_slim_llm.instances[-1].invoke_calls[-1]["stream"] is False

--- a/tests/dsl/test_node_factory.py
+++ b/tests/dsl/test_node_factory.py
@@ -33,6 +33,7 @@ from graphon.model_runtime.entities.message_entities import (
 from graphon.model_runtime.entities.model_entities import (
     AIModelEntity,
     FetchFrom,
+    ModelFeature,
     ModelType,
 )
 from graphon.nodes.http_request.exc import HttpRequestNodeError
@@ -61,6 +62,8 @@ _OPENAI_PLUGIN_ID = "langgenius/openai:0.3.8@test"
 class _FakeSlimLLM:
     instances: ClassVar[list[_FakeSlimLLM]] = []
     responses: ClassVar[dict[str, Any]] = {}
+    features: ClassVar[list[ModelFeature]] = []
+    tool_calls: ClassVar[dict[str, list[AssistantPromptMessage.ToolCall]]] = {}
 
     def __init__(
         self,
@@ -108,7 +111,7 @@ class _FakeSlimLLM:
             model=self._model_name,
             label=I18nObject(en_US=self._model_name),
             model_type=ModelType.LLM,
-            features=[],
+            features=list(self.features),
             fetch_from=FetchFrom.CUSTOMIZABLE_MODEL,
             model_properties={},
             parameter_rules=[],
@@ -139,6 +142,7 @@ class _FakeSlimLLM:
             prompt_messages=list(prompt_messages),
             message=AssistantPromptMessage(
                 content=self.responses.get(self._model_name, "{}"),
+                tool_calls=list(self.tool_calls.get(self._model_name, [])),
             ),
             usage=LLMUsage.empty_usage(),
         )
@@ -147,6 +151,8 @@ class _FakeSlimLLM:
 def _patch_fake_slim_llm(monkeypatch: pytest.MonkeyPatch) -> type[_FakeSlimLLM]:
     _FakeSlimLLM.instances = []
     _FakeSlimLLM.responses = {}
+    _FakeSlimLLM.features = []
+    _FakeSlimLLM.tool_calls = {}
     monkeypatch.setattr("graphon.dsl.node_factory.SlimLLM", _FakeSlimLLM)
     return _FakeSlimLLM
 
@@ -805,3 +811,40 @@ def test_parameter_extractor_node_from_dsl_runs_with_slim_model(
     assert success.node_run_result.outputs["__reason"] is None
     assert success.node_run_result.outputs["location"] == "Paris"
     assert fake_slim_llm.instances[-1].invoke_calls[-1]["stream"] is False
+
+
+def test_parameter_extractor_node_from_dsl_runs_function_call_with_slim_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_slim_llm = _patch_fake_slim_llm(monkeypatch)
+    fake_slim_llm.features = [ModelFeature.TOOL_CALL]
+    fake_slim_llm.tool_calls = {
+        "extractor-model": [
+            AssistantPromptMessage.ToolCall(
+                id="call-1",
+                type="function",
+                function=AssistantPromptMessage.ToolCall.ToolCallFunction(
+                    name="extract_parameters",
+                    arguments='{"location": "Berlin"}',
+                ),
+            ),
+        ],
+    }
+    engine = loads(
+        _graph_dsl_for_node({
+            **_parameter_extractor_data(),
+            "reasoning_mode": "function_call",
+        }),
+        credentials=_openai_credentials(),
+        start_inputs={"query": "Book a trip to Berlin"},
+    )
+    node = engine.graph.nodes["node"]
+
+    success = _succeeded_event(list(node.run()))
+
+    assert success.node_run_result.outputs["__is_success"] == 1
+    assert success.node_run_result.outputs["__reason"] is None
+    assert success.node_run_result.outputs["location"] == "Berlin"
+    invoke_call = fake_slim_llm.instances[-1].invoke_calls[-1]
+    assert invoke_call["stream"] is False
+    assert [tool.name for tool in invoke_call["tools"]] == ["extract_parameters"]

--- a/tests/dsl/test_slim_client.py
+++ b/tests/dsl/test_slim_client.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+import graphon.dsl.slim.client as slim_client_module
 from graphon.dsl.slim.client import (
     SlimChunkEvent,
     SlimClient,
@@ -13,6 +14,7 @@ from graphon.dsl.slim.client import (
     SlimClientError,
     SlimDoneEvent,
     SlimEvent,
+    parse_slim_event,
 )
 from graphon.model_runtime.entities.model_entities import ModelType, ParameterType
 
@@ -85,6 +87,154 @@ def test_remote_slim_client_raises_daemon_error(tmp_path: Path) -> None:
 
     with pytest.raises(SlimClientError, match="bad credentials"):
         list(client.invoke_chunks(plugin_id="plugin", action="action", data={}))
+
+
+def test_remote_slim_client_preserves_daemon_error_metadata(tmp_path: Path) -> None:
+    client = _FakeSlimClient(
+        config=SlimClientConfig(
+            folder=tmp_path,
+            mode="remote",
+            daemon_addr="http://daemon.test",
+            daemon_key="secret",
+        ),
+        events=[
+            SlimChunkEvent(
+                data={
+                    "code": "killed_by_timeout",
+                    "message": "killed by timeout",
+                    "data": {"stage": "token_count"},
+                },
+            ),
+            SlimDoneEvent(),
+        ],
+    )
+
+    with pytest.raises(SlimClientError) as exc_info:
+        list(client.invoke_chunks(plugin_id="plugin", action="action", data={}))
+
+    assert exc_info.value.code == "killed_by_timeout"
+    assert exc_info.value.stage == "token_count"
+    assert exc_info.value.data["data"] == {"stage": "token_count"}
+
+
+def test_remote_slim_client_preserves_top_level_daemon_stage(
+    tmp_path: Path,
+) -> None:
+    client = _FakeSlimClient(
+        config=SlimClientConfig(
+            folder=tmp_path,
+            mode="remote",
+            daemon_addr="http://daemon.test",
+            daemon_key="secret",
+        ),
+        events=[
+            SlimChunkEvent(
+                data={
+                    "code": "killed_by_timeout",
+                    "stage": "token_count",
+                    "message": "killed by timeout",
+                    "data": "not-a-mapping",
+                },
+            ),
+            SlimDoneEvent(),
+        ],
+    )
+
+    with pytest.raises(SlimClientError) as exc_info:
+        list(client.invoke_chunks(plugin_id="plugin", action="action", data={}))
+
+    assert exc_info.value.code == "killed_by_timeout"
+    assert exc_info.value.stage == "token_count"
+
+
+def test_slim_error_event_preserves_code_and_stage() -> None:
+    with pytest.raises(SlimClientError) as exc_info:
+        parse_slim_event(
+            '{"event":"error","data":{'
+            '"code":"killed_by_timeout",'
+            '"stage":"get_llm_num_tokens",'
+            '"message":"killed by timeout"'
+            "}}",
+        )
+
+    assert exc_info.value.code == "killed_by_timeout"
+    assert exc_info.value.stage == "get_llm_num_tokens"
+
+
+def test_slim_error_event_accepts_non_mapping_data() -> None:
+    with pytest.raises(SlimClientError) as exc_info:
+        parse_slim_event('{"event":"error","data":"plain failure"}')
+
+    assert str(exc_info.value) == "plain failure"
+    assert exc_info.value.code is None
+    assert exc_info.value.stage is None
+
+
+def test_slim_extract_preserves_process_error_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def run_stub(*args: Any, **kwargs: Any) -> object:
+        _ = args, kwargs
+
+        class ProcessResult:
+            returncode = 1
+            stdout = ""
+            stderr = (
+                '{"error_code":"killed_by_timeout",'
+                '"stage":"get_llm_num_tokens",'
+                '"message":"killed by timeout"}'
+            )
+
+        return ProcessResult()
+
+    monkeypatch.setattr(slim_client_module.subprocess, "run", run_stub)
+    client = SlimClient(config=SlimClientConfig(folder=tmp_path), binary_path="slim")
+
+    with pytest.raises(SlimClientError) as exc_info:
+        client.extract(plugin_id="plugin")
+
+    assert str(exc_info.value) == "killed by timeout"
+    assert exc_info.value.code == "killed_by_timeout"
+    assert exc_info.value.stage == "get_llm_num_tokens"
+    assert exc_info.value.return_code == 1
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected_message"),
+    [
+        ("", "Slim process exited with code 1"),
+        ("not json", "Slim process exited with code 1: not json"),
+        ('["not", "a", "mapping"]', "Slim process exited with code 1: "),
+    ],
+)
+def test_slim_extract_preserves_unstructured_process_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stderr: str,
+    expected_message: str,
+) -> None:
+    def run_stub(*args: Any, **kwargs: Any) -> object:
+        _ = args, kwargs
+
+        class ProcessResult:
+            returncode = 1
+            stdout = ""
+            stderr = stderr_value
+
+        return ProcessResult()
+
+    stderr_value = stderr
+    monkeypatch.setattr(slim_client_module.subprocess, "run", run_stub)
+    client = SlimClient(config=SlimClientConfig(folder=tmp_path), binary_path="slim")
+
+    with pytest.raises(SlimClientError) as exc_info:
+        client.extract(plugin_id="plugin")
+
+    assert str(exc_info.value).startswith(expected_message)
+    assert exc_info.value.code is None
+    assert exc_info.value.stage is None
+    assert exc_info.value.return_code == 1
 
 
 def test_local_slim_client_keeps_raw_payloads(tmp_path: Path) -> None:

--- a/tests/dsl/test_slim_llm.py
+++ b/tests/dsl/test_slim_llm.py
@@ -9,6 +9,7 @@ import pytest
 import graphon.dsl.slim.llm as slim_llm_module
 from graphon.dsl.slim import SlimClientConfig, SlimClientError, SlimLLM
 from graphon.model_runtime.entities.llm_entities import LLMResult
+from graphon.model_runtime.entities.message_entities import SystemPromptMessage
 
 
 class _RecordingSlimClient:
@@ -46,6 +47,31 @@ class _FailingSlimClient:
         _ = plugin_id, action, data
         message = "daemon down"
         raise SlimClientError(message)
+
+
+class _TimeoutSlimClient:
+    def __init__(
+        self,
+        *,
+        message: str = "token counting timed out",
+        code: str | None = "killed_by_timeout",
+    ) -> None:
+        self.message = message
+        self.code = code
+
+    def invoke_chunks(
+        self,
+        *,
+        plugin_id: str,
+        action: str,
+        data: Mapping[str, Any],
+    ) -> Iterable[Any]:
+        _ = plugin_id, action, data
+        raise SlimClientError(
+            self.message,
+            code=self.code,
+            stage="get_llm_num_tokens",
+        )
 
 
 def _patch_recording_slim_client(
@@ -153,7 +179,7 @@ def test_slim_llm_counts_tokens_and_collects_blocking_result(
     }
 
 
-def test_slim_llm_wraps_slim_client_errors(
+def test_slim_llm_preserves_slim_client_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -164,5 +190,66 @@ def test_slim_llm_wraps_slim_client_errors(
     monkeypatch.setattr(slim_llm_module, "SlimClient", slim_client_factory)
     llm = _build_llm(tmp_path)
 
-    with pytest.raises(RuntimeError, match="daemon down"):
+    with pytest.raises(SlimClientError, match="daemon down"):
         llm.get_llm_num_tokens([])
+
+
+def test_slim_llm_estimates_tokens_when_slim_token_count_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def slim_client_factory(*, config: SlimClientConfig) -> _TimeoutSlimClient:
+        _ = config
+        return _TimeoutSlimClient()
+
+    monkeypatch.setattr(slim_llm_module, "SlimClient", slim_client_factory)
+    llm = _build_llm(tmp_path)
+
+    token_count = llm.get_llm_num_tokens([
+        SystemPromptMessage(content="classify this short prompt"),
+    ])
+
+    assert token_count > 0
+
+
+def test_slim_llm_estimates_tokens_when_timeout_is_only_in_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def slim_client_factory(*, config: SlimClientConfig) -> _TimeoutSlimClient:
+        _ = config
+        return _TimeoutSlimClient(message="killed by timeout", code=None)
+
+    monkeypatch.setattr(slim_llm_module, "SlimClient", slim_client_factory)
+    llm = _build_llm(tmp_path)
+
+    token_count = llm.get_llm_num_tokens([
+        SystemPromptMessage(content="classify this short prompt"),
+    ])
+
+    assert token_count > 0
+
+
+def test_slim_llm_token_estimate_returns_zero_for_empty_prompt() -> None:
+    assert slim_llm_module._estimate_prompt_message_tokens([]) == 0
+
+
+def test_slim_llm_token_estimate_uses_length_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_tokenizer(text: str) -> int:
+        _ = text
+        msg = "tokenizer unavailable"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        slim_llm_module.GPT2Tokenizer,
+        "get_num_tokens",
+        fail_tokenizer,
+    )
+
+    token_count = slim_llm_module._estimate_prompt_message_tokens([
+        SystemPromptMessage(content="x" * 20),
+    ])
+
+    assert token_count == 7


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue
#154 

## Summary
- Added DSL import/load support for category 1 2 workflow nodes: http-request, variable-aggregator, assigner, list-operator, question-classifier,
    and parameter-extractor.
 - Added app-level runtime variable handling for Dify environment_variables and conversation_variables.
 - Preserved structured Slim error metadata and added token-count timeout fallback for Slim-backed LLM nodes.
 - Kept container/category 3 nodes unsupported until nested graph execution semantics are defined.
 - Added coverage for import validation, node factory behavior, Slim error handling, and real debug YAML execution paths.

## Checklist

- [X] This pull request links the issue it resolves or advances
- [X] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [X] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
