### PR TITLE
fix(variables): accept JSON string and empty input for json_schema

### DIFF
--- a/src/graphon/variables/input_entities.py
+++ b/src/graphon/variables/input_entities.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any
@@ -53,14 +54,25 @@ class VariableEntity(BaseModel):
     def convert_none_options(cls, value: Any) -> Sequence[str]:
         return value or []
 
-    @field_validator("json_schema")
+    @field_validator("json_schema", mode="before")
     @classmethod
     def validate_json_schema(
         cls,
-        schema: dict[str, Any] | None,
+        schema: str | dict[str, Any] | None,
     ) -> dict[str, Any] | None:
-        if schema is None:
+        # The schema is persisted as raw editor text on the frontend, so accept
+        # either a parsed object, a JSON string, or empty/None inputs.
+        if schema is None or schema == "":
             return None
+        if isinstance(schema, str):
+            try:
+                schema = json.loads(schema)
+            except json.JSONDecodeError as error:
+                msg = f"json_schema is not valid JSON: {error.msg}"
+                raise ValueError(msg) from error
+        if not isinstance(schema, dict):
+            msg = f"json_schema must be a JSON object, got {type(schema).__name__}"
+            raise ValueError(msg)
         try:
             Draft7Validator.check_schema(schema)
         except SchemaError as error:

--- a/src/graphon/variables/input_entities.py
+++ b/src/graphon/variables/input_entities.py
@@ -12,6 +12,11 @@ from graphon.file.enums import (
 )
 
 
+def _reject_non_standard_json_constant(constant: str) -> None:
+    msg = f"json_schema is not valid JSON: invalid constant {constant}"
+    raise ValueError(msg)
+
+
 class VariableEntityType(StrEnum):
     TEXT_INPUT = "text-input"
     SELECT = "select"
@@ -65,10 +70,14 @@ class VariableEntity(BaseModel):
         if schema is None:
             return None
         if isinstance(schema, str):
+            schema = schema.strip()
             if not schema:
                 return None
             try:
-                schema = json.loads(schema)
+                schema = json.loads(
+                    schema,
+                    parse_constant=_reject_non_standard_json_constant,
+                )
             except json.JSONDecodeError as error:
                 msg = f"json_schema is not valid JSON: {error.msg}"
                 raise ValueError(msg) from error

--- a/src/graphon/variables/input_entities.py
+++ b/src/graphon/variables/input_entities.py
@@ -62,17 +62,21 @@ class VariableEntity(BaseModel):
     ) -> dict[str, Any] | None:
         # The schema is persisted as raw editor text on the frontend, so accept
         # either a parsed object, a JSON string, or empty/None inputs.
-        if schema is None or schema == "":
+        if schema is None:
             return None
         if isinstance(schema, str):
+            if not schema:
+                return None
             try:
                 schema = json.loads(schema)
             except json.JSONDecodeError as error:
                 msg = f"json_schema is not valid JSON: {error.msg}"
                 raise ValueError(msg) from error
         if not isinstance(schema, dict):
+            # Pydantic only wraps ValueError/AssertionError into ValidationError,
+            # so we deliberately keep ValueError instead of TypeError here.
             msg = f"json_schema must be a JSON object, got {type(schema).__name__}"
-            raise ValueError(msg)
+            raise ValueError(msg)  # noqa: TRY004
         try:
             Draft7Validator.check_schema(schema)
         except SchemaError as error:

--- a/tests/variables/test_input_entities.py
+++ b/tests/variables/test_input_entities.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -13,7 +15,7 @@ _VALID_SCHEMA: dict = {
 }
 
 
-def _make_payload(json_schema):
+def _make_payload(json_schema: Any) -> dict[str, Any]:
     return {
         "variable": "profile",
         "label": "profile",
@@ -23,11 +25,11 @@ def _make_payload(json_schema):
 
 
 class TestValidateJsonSchema:
-    def test_accepts_dict_input(self):
+    def test_accepts_dict_input(self) -> None:
         entity = VariableEntity.model_validate(_make_payload(_VALID_SCHEMA))
         assert entity.json_schema == _VALID_SCHEMA
 
-    def test_accepts_json_string_input(self):
+    def test_accepts_json_string_input(self) -> None:
         # The frontend's code editor persists the schema as a raw JSON string.
         raw = (
             "{\n"
@@ -42,33 +44,33 @@ class TestValidateJsonSchema:
         entity = VariableEntity.model_validate(_make_payload(raw))
         assert entity.json_schema == _VALID_SCHEMA
 
-    def test_treats_none_as_none(self):
+    def test_treats_none_as_none(self) -> None:
         entity = VariableEntity.model_validate(_make_payload(None))
         assert entity.json_schema is None
 
-    def test_treats_empty_string_as_none(self):
+    def test_treats_empty_string_as_none(self) -> None:
         # Frontend "clear schema" sends "" rather than removing the field;
         # treating it as None matches the user's intent of "no constraint".
         entity = VariableEntity.model_validate(_make_payload(""))
         assert entity.json_schema is None
 
-    def test_rejects_malformed_json_string(self):
+    def test_rejects_malformed_json_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             VariableEntity.model_validate(_make_payload('{"type": "object"'))
         assert "not valid JSON" in str(exc_info.value)
 
-    def test_rejects_non_object_non_string_input(self):
+    def test_rejects_non_object_non_string_input(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             VariableEntity.model_validate(_make_payload(123))
         assert "must be a JSON object" in str(exc_info.value)
 
-    def test_rejects_semantically_invalid_schema(self):
+    def test_rejects_semantically_invalid_schema(self) -> None:
         bad_schema = {"type": "not_a_real_type"}
         with pytest.raises(ValidationError) as exc_info:
             VariableEntity.model_validate(_make_payload(bad_schema))
         assert "Invalid JSON schema" in str(exc_info.value)
 
-    def test_rejects_semantically_invalid_schema_from_string(self):
+    def test_rejects_semantically_invalid_schema_from_string(self) -> None:
         bad_schema_str = '{"type": "not_a_real_type"}'
         with pytest.raises(ValidationError) as exc_info:
             VariableEntity.model_validate(_make_payload(bad_schema_str))

--- a/tests/variables/test_input_entities.py
+++ b/tests/variables/test_input_entities.py
@@ -1,0 +1,75 @@
+import pytest
+from pydantic import ValidationError
+
+from graphon.variables.input_entities import VariableEntity, VariableEntityType
+
+_VALID_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "age": {"type": "integer", "minimum": 0},
+    },
+    "required": ["name"],
+}
+
+
+def _make_payload(json_schema):
+    return {
+        "variable": "profile",
+        "label": "profile",
+        "type": VariableEntityType.JSON_OBJECT,
+        "json_schema": json_schema,
+    }
+
+
+class TestValidateJsonSchema:
+    def test_accepts_dict_input(self):
+        entity = VariableEntity.model_validate(_make_payload(_VALID_SCHEMA))
+        assert entity.json_schema == _VALID_SCHEMA
+
+    def test_accepts_json_string_input(self):
+        # The frontend's code editor persists the schema as a raw JSON string.
+        raw = (
+            "{\n"
+            '  "type": "object",\n'
+            '  "properties": {\n'
+            '    "name": {"type": "string"},\n'
+            '    "age": {"type": "integer", "minimum": 0}\n'
+            "  },\n"
+            '  "required": ["name"]\n'
+            "}"
+        )
+        entity = VariableEntity.model_validate(_make_payload(raw))
+        assert entity.json_schema == _VALID_SCHEMA
+
+    def test_treats_none_as_none(self):
+        entity = VariableEntity.model_validate(_make_payload(None))
+        assert entity.json_schema is None
+
+    def test_treats_empty_string_as_none(self):
+        # Frontend "clear schema" sends "" rather than removing the field;
+        # treating it as None matches the user's intent of "no constraint".
+        entity = VariableEntity.model_validate(_make_payload(""))
+        assert entity.json_schema is None
+
+    def test_rejects_malformed_json_string(self):
+        with pytest.raises(ValidationError) as exc_info:
+            VariableEntity.model_validate(_make_payload('{"type": "object"'))
+        assert "not valid JSON" in str(exc_info.value)
+
+    def test_rejects_non_object_non_string_input(self):
+        with pytest.raises(ValidationError) as exc_info:
+            VariableEntity.model_validate(_make_payload(123))
+        assert "must be a JSON object" in str(exc_info.value)
+
+    def test_rejects_semantically_invalid_schema(self):
+        bad_schema = {"type": "not_a_real_type"}
+        with pytest.raises(ValidationError) as exc_info:
+            VariableEntity.model_validate(_make_payload(bad_schema))
+        assert "Invalid JSON schema" in str(exc_info.value)
+
+    def test_rejects_semantically_invalid_schema_from_string(self):
+        bad_schema_str = '{"type": "not_a_real_type"}'
+        with pytest.raises(ValidationError) as exc_info:
+            VariableEntity.model_validate(_make_payload(bad_schema_str))
+        assert "Invalid JSON schema" in str(exc_info.value)

--- a/tests/variables/test_input_entities.py
+++ b/tests/variables/test_input_entities.py
@@ -54,10 +54,22 @@ class TestValidateJsonSchema:
         entity = VariableEntity.model_validate(_make_payload(""))
         assert entity.json_schema is None
 
+    def test_treats_whitespace_string_as_none(self) -> None:
+        entity = VariableEntity.model_validate(_make_payload("  \n\t  "))
+        assert entity.json_schema is None
+
     def test_rejects_malformed_json_string(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             VariableEntity.model_validate(_make_payload('{"type": "object"'))
         assert "not valid JSON" in str(exc_info.value)
+
+    @pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+    def test_rejects_non_standard_json_constant(self, constant: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            VariableEntity.model_validate(
+                _make_payload(f'{{"type": "number", "minimum": {constant}}}'),
+            )
+        assert "invalid constant" in str(exc_info.value)
 
     def test_rejects_non_object_non_string_input(self) -> None:
         with pytest.raises(ValidationError) as exc_info:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #164

## Summary

`VariableEntity.json_schema` previously only accepted `dict | None`. However:

- The frontend code editor persists the schema as **raw JSON text**, so the
  backend receives a string and validation fails.
- "Clear schema" on the frontend sends `""` instead of dropping the field,
  which also fails validation even though the user intent is "no schema".

### Changes

- `validate_json_schema` is switched to `mode="before"` so it can pre-process
  the raw input.
- Accept a JSON string and parse it into a dict; raise a clear `ValueError`
  when the string is not valid JSON.
- Treat `None` and `""` uniformly as "no schema" and return `None`.
- Reject non-dict / non-string inputs with an explicit error message.
- Existing `Draft7Validator.check_schema(...)` semantic validation is kept.

### Tests

Adds `tests/variables/test_input_entities.py` covering:

- valid dict input
- valid JSON string input (mirrors the frontend payload)
- `None` input → `None`
- `""` input → `None`
- malformed JSON string → `ValidationError`
- non-object / non-string input (e.g. `123`) → `ValidationError`
- semantically invalid schema, both as dict and as string → `ValidationError`

No public API or behavior is broken for callers that were already passing
`dict | None`.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation