### PR TITLE
fix(llm): strip <think> reasoning from separated-mode streaming

### DIFF
--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -5,7 +5,6 @@ import binascii
 import io
 import json
 import logging
-import re
 import time
 from collections.abc import Generator, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -62,6 +61,11 @@ from graphon.node_events.node import (
 from graphon.nodes.base.entities import VariableSelector
 from graphon.nodes.base.node import Node
 from graphon.nodes.base.variable_template_parser import VariableTemplateParser
+from graphon.nodes.llm.reasoning import (
+    ThinkStreamFilter,
+    extract_stream_reasoning,
+    split_reasoning,
+)
 from graphon.nodes.llm.runtime_protocols import (
     LLMPollingCapableProtocol,
     LLMProtocol,
@@ -130,13 +134,12 @@ class _StreamingInvokeState:
     first_token_time: float | None = None
     has_content: bool = False
     structured_output: dict[str, Any] | None = None
+    # None in "tagged" mode (stream raw tokens); a filter in "separated" mode.
+    text_filter: ThinkStreamFilter | None = None
 
 
 class LLMNode(Node[LLMNodeData]):
     node_type = BuiltinNodeTypes.LLM
-
-    # Compiled regex for extracting <think> blocks (with compatibility for attributes)
-    _THINK_PATTERN = re.compile(r"<think[^>]*>(.*?)</think>", re.IGNORECASE | re.DOTALL)
 
     # Instance attributes specific to LLMNode.
     # Output variable for file
@@ -688,10 +691,7 @@ class LLMNode(Node[LLMNodeData]):
         if self.node_data.reasoning_format == "tagged":
             return text
 
-        clean_text, _ = LLMNode._split_reasoning(
-            text,
-            self.node_data.reasoning_format,
-        )
+        clean_text, _ = split_reasoning(text, self.node_data.reasoning_format)
         return clean_text
 
     def _build_process_data(
@@ -857,6 +857,8 @@ class LLMNode(Node[LLMNodeData]):
             else time.perf_counter()
         )
         state = _StreamingInvokeState(start_time=start_time)
+        if reasoning_format == "separated":
+            state.text_filter = ThinkStreamFilter()
 
         try:
             yield from LLMNode._yield_streaming_events(
@@ -878,9 +880,19 @@ class LLMNode(Node[LLMNodeData]):
                 raise LLMNodeError(msg) from e
             raise
 
+        # Flush any clean text the filter was still holding (separated mode).
+        if state.text_filter is not None:
+            remainder = state.text_filter.finalize()
+            if remainder:
+                yield StreamChunkEvent(
+                    selector=[node_id, "text"],
+                    chunk=remainder,
+                    is_final=False,
+                )
+
         # Extract reasoning content from <think> tags in the main text
         full_text = state.full_text_buffer.getvalue()
-        clean_text, reasoning_content = LLMNode._extract_stream_reasoning(
+        clean_text, reasoning_content = extract_stream_reasoning(
             full_text=full_text,
             reasoning_format=reasoning_format,
         )
@@ -959,11 +971,13 @@ class LLMNode(Node[LLMNodeData]):
             file_outputs=file_outputs,
         )
         for text_part in text_parts:
-            yield LLMNode._build_stream_text_event(
+            event = LLMNode._build_stream_text_event(
                 text_part=text_part,
                 state=state,
                 node_id=node_id,
             )
+            if event is not None:
+                yield event
 
     @staticmethod
     def _build_stream_text_event(
@@ -971,15 +985,30 @@ class LLMNode(Node[LLMNodeData]):
         text_part: str,
         state: _StreamingInvokeState,
         node_id: str,
-    ) -> StreamChunkEvent:
+    ) -> StreamChunkEvent | None:
         if text_part and not state.has_content:
             state.first_token_time = time.perf_counter()
             state.has_content = True
 
+        # Keep the raw text (including <think> tags) in the buffer so the final
+        # reasoning extraction still sees the full output.
         state.full_text_buffer.write(text_part)
+
+        # "tagged" (no filter): stream the raw token unchanged.
+        if state.text_filter is None:
+            return StreamChunkEvent(
+                selector=[node_id, "text"],
+                chunk=text_part,
+                is_final=False,
+            )
+
+        # "separated": strip <think> reasoning before it reaches the selector.
+        chunk = state.text_filter.feed(text_part)
+        if not chunk:
+            return None
         return StreamChunkEvent(
             selector=[node_id, "text"],
-            chunk=text_part,
+            chunk=chunk,
             is_final=False,
         )
 
@@ -1011,16 +1040,6 @@ class LLMNode(Node[LLMNodeData]):
         )
 
     @staticmethod
-    def _extract_stream_reasoning(
-        *,
-        full_text: str,
-        reasoning_format: Literal["separated", "tagged"],
-    ) -> tuple[str, str]:
-        if reasoning_format == "tagged":
-            return full_text, ""
-        return LLMNode._split_reasoning(full_text, reasoning_format)
-
-    @staticmethod
     def _finalize_streaming_usage(
         *,
         usage: LLMUsage,
@@ -1044,45 +1063,6 @@ class LLMNode(Node[LLMNodeData]):
         if file.type == FileType.IMAGE:
             return f"![]({file.generate_url()})"
         return file.markdown
-
-    @classmethod
-    def _split_reasoning(
-        cls,
-        text: str,
-        reasoning_format: Literal["separated", "tagged"] = "tagged",
-    ) -> tuple[str, str]:
-        """Split reasoning content from text based on reasoning_format strategy.
-
-        Args:
-            text: Full text that may contain <think> blocks
-            reasoning_format: Strategy for handling reasoning content
-                - "separated": Remove <think> tags and return clean text
-                plus reasoning_content field
-                - "tagged": Keep <think> tags in text, return empty reasoning_content
-
-        Returns:
-            tuple of (clean_text, reasoning_content)
-
-        """
-        if reasoning_format == "tagged":
-            return text, ""
-
-        # Find all <think>...</think> blocks (case-insensitive)
-        matches = cls._THINK_PATTERN.findall(text)
-
-        # Extract reasoning content from all <think> blocks
-        reasoning_content = (
-            "\n".join(match.strip() for match in matches) if matches else ""
-        )
-
-        # Remove all <think>...</think> blocks from original text
-        clean_text = cls._THINK_PATTERN.sub("", text)
-
-        # Clean up extra whitespace
-        clean_text = re.sub(r"\n\s*\n", "\n\n", clean_text).strip()
-
-        # Separated mode: always return clean text and reasoning_content
-        return clean_text, reasoning_content or ""
 
     def _transform_chat_messages(
         self,
@@ -1962,7 +1942,7 @@ class LLMNode(Node[LLMNodeData]):
             reasoning_content = ""
         else:
             # Extract clean text and reasoning from <think> tags
-            clean_text, reasoning_content = LLMNode._split_reasoning(
+            clean_text, reasoning_content = split_reasoning(
                 full_text,
                 reasoning_format,
             )

--- a/src/graphon/nodes/llm/reasoning.py
+++ b/src/graphon/nodes/llm/reasoning.py
@@ -1,0 +1,174 @@
+"""Handling of inline ``<think>...</think>`` reasoning in LLM output.
+
+Reasoning models emit their chain-of-thought wrapped in ``<think>`` tags inside
+the normal text stream. This module owns everything that strips or separates
+that reasoning so the two code paths stay consistent:
+
+- :class:`ThinkStreamFilter` strips it incrementally while the node streams
+  tokens (``separated`` mode), handling tags split across chunk boundaries.
+- :func:`split_reasoning` / :func:`extract_stream_reasoning` strip it in one
+  pass from a fully buffered string (blocking results and the streaming
+  completion event).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+# Content of complete <think>...</think> blocks (optional attributes,
+# case-insensitive, across newlines).
+_THINK_PATTERN = re.compile(r"<think[^>]*>(.*?)</think>", re.IGNORECASE | re.DOTALL)
+# Open/close matchers used by the streaming filter; mirror _THINK_PATTERN.
+_THINK_OPEN_RE = re.compile(r"<think[^>]*>", re.IGNORECASE)
+_THINK_CLOSE_RE = re.compile(r"</think>", re.IGNORECASE)
+# A trailing, unclosed <think> with no matching </think> (e.g. a truncated
+# generation). Used to keep reasoning out of the final text on both paths.
+_THINK_OPEN_TRAILING_RE = re.compile(
+    r"<think[^>]*>(?P<reasoning>(?:(?!</think>)[\s\S])*)\Z",
+    re.IGNORECASE,
+)
+_THINK_OPEN_KEYWORD = "<think"
+_THINK_CLOSE_TAG = "</think>"
+
+
+class ThinkStreamFilter:
+    """Stateful, chunk-boundary-safe stripper for ``<think>...</think>`` blocks.
+
+    Used only in ``separated`` mode, where the LLM node must not stream
+    reasoning to the ``text`` selector. Reasoning arrives inline as
+    ``<think>...</think>`` and is streamed token by token, so a single tag can
+    be split across chunks (``"<thi" + "nk>"``). This filter buffers only the
+    minimal trailing bytes that could still grow into a tag and emits everything
+    else as clean text.
+
+    ``tagged`` mode does not use this filter at all (it streams raw tokens), so
+    the class is unconditional: it always strips.
+    """
+
+    def __init__(self) -> None:
+        self._inside_think = False
+        self._hold = ""
+        self._seen_clean = False
+
+    def feed(self, text_part: str) -> str:
+        """Return the clean text that is safe to emit for this chunk."""
+        out_parts: list[str] = []
+        work = self._hold + text_part
+        self._hold = ""
+        while work:
+            if not self._inside_think:
+                match = _THINK_OPEN_RE.search(work)
+                if match:
+                    out_parts.append(work[: match.start()])
+                    self._inside_think = True
+                    work = work[match.end() :]
+                    continue
+                keep = self._open_suffix_len(work)
+                if keep:
+                    out_parts.append(work[:-keep])
+                    self._hold = work[-keep:]
+                else:
+                    out_parts.append(work)
+                work = ""
+            else:
+                match = _THINK_CLOSE_RE.search(work)
+                if match:
+                    self._inside_think = False
+                    work = work[match.end() :]
+                    continue
+                keep = self._close_suffix_len(work)
+                self._hold = work[-keep:] if keep else ""
+                work = ""
+        return self._strip_leading("".join(out_parts))
+
+    def finalize(self) -> str:
+        """Flush whatever is safe to emit once the stream ends."""
+        if self._inside_think:
+            # Unclosed trailing <think>: drop the truncated reasoning, never leak.
+            self._hold = ""
+            return ""
+        remainder = self._hold
+        self._hold = ""
+        return self._strip_leading(remainder)
+
+    def _strip_leading(self, clean: str) -> str:
+        # Mirror split_reasoning()'s leading .strip() for the first visible text
+        # (covers reasoning-first models: "<think>...</think>\nanswer").
+        if self._seen_clean or not clean:
+            return clean
+        stripped = clean.lstrip()
+        if stripped:
+            self._seen_clean = True
+        return stripped
+
+    @staticmethod
+    def _open_suffix_len(work: str) -> int:
+        """Length of the trailing suffix that could still become ``<think...>``."""
+        lt = work.rfind("<")
+        if lt == -1:
+            return 0
+        tail = work[lt:]
+        if ">" in tail:
+            return 0
+        keyword = _THINK_OPEN_KEYWORD
+        if len(tail) <= len(keyword):
+            return len(tail) if keyword.startswith(tail.lower()) else 0
+        if tail[: len(keyword)].lower() == keyword:
+            return len(tail)
+        return 0
+
+    @staticmethod
+    def _close_suffix_len(work: str) -> int:
+        """Length of the trailing suffix that could still become ``</think>``."""
+        max_k = min(len(work), len(_THINK_CLOSE_TAG) - 1)
+        for k in range(max_k, 0, -1):
+            if _THINK_CLOSE_TAG.startswith(work[-k:].lower()):
+                return k
+        return 0
+
+
+def split_reasoning(
+    text: str,
+    reasoning_format: Literal["separated", "tagged"] = "tagged",
+) -> tuple[str, str]:
+    """Split reasoning content from text based on ``reasoning_format``.
+
+    - ``separated``: remove ``<think>`` blocks and return clean text plus the
+      extracted reasoning content.
+    - ``tagged``: keep ``<think>`` tags in text and return empty reasoning.
+
+    Returns:
+        A tuple of ``(clean_text, reasoning_content)``.
+
+    """
+    if reasoning_format == "tagged":
+        return text, ""
+
+    # Closed <think>...</think> blocks (case-insensitive).
+    matches = _THINK_PATTERN.findall(text)
+    reasoning_parts = [match.strip() for match in matches if match.strip()]
+    clean_text = _THINK_PATTERN.sub("", text)
+
+    # Also drop a trailing, unclosed <think> (e.g. truncated generation) so
+    # reasoning never leaks into the final text; keep it as reasoning.
+    trailing = _THINK_OPEN_TRAILING_RE.search(clean_text)
+    if trailing:
+        trailing_reasoning = trailing.group("reasoning").strip()
+        if trailing_reasoning:
+            reasoning_parts.append(trailing_reasoning)
+        clean_text = clean_text[: trailing.start()]
+
+    clean_text = re.sub(r"\n\s*\n", "\n\n", clean_text).strip()
+    return clean_text, "\n".join(reasoning_parts)
+
+
+def extract_stream_reasoning(
+    *,
+    full_text: str,
+    reasoning_format: Literal["separated", "tagged"],
+) -> tuple[str, str]:
+    """Like :func:`split_reasoning` but a no-op in ``tagged`` mode."""
+    if reasoning_format == "tagged":
+        return full_text, ""
+    return split_reasoning(full_text, reasoning_format)

--- a/src/graphon/nodes/llm/reasoning.py
+++ b/src/graphon/nodes/llm/reasoning.py
@@ -16,14 +16,11 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-# Content of complete <think>...</think> blocks (optional attributes,
-# case-insensitive, across newlines).
+# Complete <think>...</think> blocks (attrs, case-insensitive, multiline).
 _THINK_PATTERN = re.compile(r"<think[^>]*>(.*?)</think>", re.IGNORECASE | re.DOTALL)
-# Open/close matchers used by the streaming filter; mirror _THINK_PATTERN.
 _THINK_OPEN_RE = re.compile(r"<think[^>]*>", re.IGNORECASE)
 _THINK_CLOSE_RE = re.compile(r"</think>", re.IGNORECASE)
-# A trailing, unclosed <think> with no matching </think> (e.g. a truncated
-# generation). Used to keep reasoning out of the final text on both paths.
+# Trailing unclosed <think> (truncated generation).
 _THINK_OPEN_TRAILING_RE = re.compile(
     r"<think[^>]*>(?P<reasoning>(?:(?!</think>)[\s\S])*)\Z",
     re.IGNORECASE,
@@ -44,6 +41,9 @@ class ThinkStreamFilter:
 
     ``tagged`` mode does not use this filter at all (it streams raw tokens), so
     the class is unconditional: it always strips.
+
+    Matches :func:`split_reasoning` only up to whitespace: that also collapses
+    blank-line runs and strips; this only lstrips the leading text.
     """
 
     def __init__(self) -> None:
@@ -85,7 +85,7 @@ class ThinkStreamFilter:
     def finalize(self) -> str:
         """Flush whatever is safe to emit once the stream ends."""
         if self._inside_think:
-            # Unclosed trailing <think>: drop the truncated reasoning, never leak.
+            # Unclosed <think>: drop truncated reasoning, never leak.
             self._hold = ""
             return ""
         remainder = self._hold
@@ -93,8 +93,7 @@ class ThinkStreamFilter:
         return self._strip_leading(remainder)
 
     def _strip_leading(self, clean: str) -> str:
-        # Mirror split_reasoning()'s leading .strip() for the first visible text
-        # (covers reasoning-first models: "<think>...</think>\nanswer").
+        # Mirror split_reasoning()'s leading strip (reasoning-first models).
         if self._seen_clean or not clean:
             return clean
         stripped = clean.lstrip()
@@ -145,13 +144,11 @@ def split_reasoning(
     if reasoning_format == "tagged":
         return text, ""
 
-    # Closed <think>...</think> blocks (case-insensitive).
     matches = _THINK_PATTERN.findall(text)
     reasoning_parts = [match.strip() for match in matches if match.strip()]
     clean_text = _THINK_PATTERN.sub("", text)
 
-    # Also drop a trailing, unclosed <think> (e.g. truncated generation) so
-    # reasoning never leaks into the final text; keep it as reasoning.
+    # Drop a trailing unclosed <think>, keeping it as reasoning, not text.
     trailing = _THINK_OPEN_TRAILING_RE.search(clean_text)
     if trailing:
         trailing_reasoning = trailing.group("reasoning").strip()

--- a/src/graphon/nodes/llm/reasoning.py
+++ b/src/graphon/nodes/llm/reasoning.py
@@ -17,16 +17,22 @@ import re
 from typing import Literal
 
 # Complete <think>...</think> blocks (attrs, case-insensitive, multiline).
-_THINK_PATTERN = re.compile(r"<think[^>]*>(.*?)</think>", re.IGNORECASE | re.DOTALL)
-_THINK_OPEN_RE = re.compile(r"<think[^>]*>", re.IGNORECASE)
+_THINK_OPEN_ATTR_MAX_CHARS = 512
+_THINK_OPEN_PREFIX = "<think"
+_THINK_OPEN_TAG = rf"<think(?:\s[^<>]{{0,{_THINK_OPEN_ATTR_MAX_CHARS}}})?>"
+_THINK_PATTERN = re.compile(
+    rf"{_THINK_OPEN_TAG}(.*?)</think>",
+    re.IGNORECASE | re.DOTALL,
+)
+_THINK_OPEN_RE = re.compile(_THINK_OPEN_TAG, re.IGNORECASE)
 _THINK_CLOSE_RE = re.compile(r"</think>", re.IGNORECASE)
 # Trailing unclosed <think> (truncated generation).
 _THINK_OPEN_TRAILING_RE = re.compile(
-    r"<think[^>]*>(?P<reasoning>(?:(?!</think>)[\s\S])*)\Z",
+    rf"{_THINK_OPEN_TAG}(?P<reasoning>(?:(?!</think>)[\s\S])*)\Z",
     re.IGNORECASE,
 )
-_THINK_OPEN_KEYWORD = "<think"
 _THINK_CLOSE_TAG = "</think>"
+_THINK_OPEN_PREFIX_MAX_LEN = len(_THINK_OPEN_PREFIX) + 1 + _THINK_OPEN_ATTR_MAX_CHARS
 
 
 class ThinkStreamFilter:
@@ -104,18 +110,22 @@ class ThinkStreamFilter:
     @staticmethod
     def _open_suffix_len(work: str) -> int:
         """Length of the trailing suffix that could still become ``<think...>``."""
+        keep = 0
         lt = work.rfind("<")
-        if lt == -1:
-            return 0
-        tail = work[lt:]
-        if ">" in tail:
-            return 0
-        keyword = _THINK_OPEN_KEYWORD
-        if len(tail) <= len(keyword):
-            return len(tail) if keyword.startswith(tail.lower()) else 0
-        if tail[: len(keyword)].lower() == keyword:
-            return len(tail)
-        return 0
+        if lt != -1:
+            tail = work[lt:]
+            tail_lower = tail.lower()
+            if ">" in tail:
+                keep = 0
+            elif len(tail) <= len(_THINK_OPEN_PREFIX):
+                keep = len(tail) if _THINK_OPEN_PREFIX.startswith(tail_lower) else 0
+            elif (
+                tail_lower.startswith(_THINK_OPEN_PREFIX)
+                and tail[len(_THINK_OPEN_PREFIX)].isspace()
+                and len(tail) <= _THINK_OPEN_PREFIX_MAX_LEN
+            ):
+                keep = len(tail)
+        return keep
 
     @staticmethod
     def _close_suffix_len(work: str) -> int:

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -839,6 +839,28 @@ def test_separated_stream_does_not_swallow_non_think_angle_brackets() -> None:
     assert "".join(chunks) == "<div>ok"
 
 
+def test_separated_stream_keeps_tags_with_think_prefix() -> None:
+    chunks, completed = _run_stream(
+        ["before<think", "ing>idea</thinking>after"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "before<thinking>idea</thinking>after"
+    assert completed.text == "before<thinking>idea</thinking>after"
+    assert completed.reasoning_content == ""
+
+
+def test_separated_stream_keeps_malformed_open_tag_with_nested_bracket() -> None:
+    chunks, completed = _run_stream(
+        ["x<think <y", ">secret</think>z"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "x<think <y>secret</think>z"
+    assert completed.text == "x<think <y>secret</think>z"
+    assert completed.reasoning_content == ""
+
+
 def test_separated_stream_flushes_held_partial_open_on_finalize() -> None:
     # Stream ends on a held partial open: finalize() must flush "<thi", not drop it.
     chunks, completed = _run_stream(["answer<thi"], reasoning_format="separated")

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -2,7 +2,7 @@ import base64
 from collections.abc import Generator, Sequence
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import Any, Never, cast
+from typing import Any, Literal, Never, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -37,6 +37,7 @@ from graphon.node_events.node import (
 )
 from graphon.nodes.llm import LLMNode, LLMNodeData
 from graphon.nodes.llm.exc import LLMNodeError
+from graphon.nodes.llm.reasoning import ThinkStreamFilter, split_reasoning
 from graphon.nodes.llm.runtime_protocols import LLMPollingCapableProtocol, LLMProtocol
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
@@ -748,3 +749,156 @@ def test_polling_progress_event_dispatches_to_graph_event() -> None:
 
     assert isinstance(graph_event, NodeRunModelPollingProgressEvent)
     assert graph_event.attempt == 2
+
+
+def _run_stream(
+    parts: Sequence[str],
+    *,
+    reasoning_format: Literal["separated", "tagged"],
+) -> tuple[list[str], ModelInvokeCompletedEvent]:
+    """Stream ``parts`` through the LLM node and return (chunks, completion)."""
+    model = MagicMock(is_structured_output_parse_error=lambda _error: False)
+    events = list(
+        LLMNode.handle_invoke_result(
+            invoke_result=_stream_results(*[_stream_chunk(part) for part in parts]),
+            file_saver=MagicMock(),
+            file_outputs=[],
+            node_id="llm",
+            model_instance=cast(LLMProtocol, model),
+            reasoning_format=reasoning_format,
+        ),
+    )
+    chunks = [e.chunk for e in events if isinstance(e, StreamChunkEvent)]
+    completed = next(e for e in events if isinstance(e, ModelInvokeCompletedEvent))
+    return chunks, completed
+
+
+def test_separated_stream_strips_think_in_single_chunk() -> None:
+    chunks, completed = _run_stream(
+        ["<think>plan</think>answer"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "answer"
+    assert all("<think>" not in chunk for chunk in chunks)
+    assert completed.text == "answer"
+    assert completed.reasoning_content == "plan"
+
+
+def test_separated_stream_strips_think_split_across_chunks() -> None:
+    chunks, completed = _run_stream(
+        ["<thi", "nk>plan</thi", "nk>ans", "wer"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "answer"
+    assert all("think" not in chunk for chunk in chunks)
+    assert completed.text == "answer"
+    assert completed.reasoning_content == "plan"
+
+
+def test_separated_stream_handles_think_tag_attributes() -> None:
+    chunks, completed = _run_stream(
+        ['<think foo="x">p</think>hi'],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "hi"
+    assert completed.text == "hi"
+    assert completed.reasoning_content == "p"
+
+
+def test_separated_stream_handles_multiple_think_blocks() -> None:
+    chunks, completed = _run_stream(
+        ["<think>a</think>X<think>b</think>Y"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "XY"
+    assert completed.text == "XY"
+    assert completed.reasoning_content == "a\nb"
+
+
+def test_separated_stream_drops_unclosed_trailing_think() -> None:
+    chunks, completed = _run_stream(
+        ["hi<think>tail"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "hi"
+    assert all("<think>" not in chunk for chunk in chunks)
+    # Truncated reasoning is kept out of the text but preserved as reasoning.
+    assert completed.text == "hi"
+    assert completed.reasoning_content == "tail"
+
+
+def test_separated_stream_does_not_swallow_non_think_angle_brackets() -> None:
+    chunks, _ = _run_stream(["<div>ok"], reasoning_format="separated")
+
+    assert "".join(chunks) == "<div>ok"
+
+
+def test_separated_stream_strips_leading_whitespace_after_reasoning() -> None:
+    chunks, completed = _run_stream(
+        ["<think>r</think>", "\n", "answer"],
+        reasoning_format="separated",
+    )
+
+    assert "".join(chunks) == "answer"
+    assert completed.text == "answer"
+
+
+def test_tagged_stream_keeps_think_tags_unchanged() -> None:
+    chunks, completed = _run_stream(
+        ["<think>plan</think>answer"],
+        reasoning_format="tagged",
+    )
+
+    assert "".join(chunks) == "<think>plan</think>answer"
+    assert completed.text == "<think>plan</think>answer"
+    assert completed.reasoning_content == ""
+
+
+@pytest.mark.parametrize(
+    "full_text",
+    [
+        "<think>plan</think>answer",
+        "before<think>a</think>middle<think>b</think>after",
+        "<think>only reasoning</think>\n\nanswer body",
+    ],
+)
+def test_separated_stream_matches_split_reasoning(full_text: str) -> None:
+    # Any chunk boundary must produce the same clean text as the batch splitter.
+    parts = [full_text[i : i + 3] for i in range(0, len(full_text), 3)]
+    chunks, _ = _run_stream(parts, reasoning_format="separated")
+    expected, _ = split_reasoning(full_text, "separated")
+
+    assert "".join(chunks).strip() == expected
+
+
+def test_think_stream_filter_strips_reasoning() -> None:
+    flt = ThinkStreamFilter()
+
+    assert flt.feed("<think>x</think>y") == "y"
+    assert flt.finalize() == ""
+
+
+def test_split_reasoning_strips_closed_block() -> None:
+    clean, reasoning = split_reasoning("<think>a</think>hello", "separated")
+
+    assert clean == "hello"
+    assert reasoning == "a"
+
+
+def test_split_reasoning_strips_unclosed_trailing_block() -> None:
+    clean, reasoning = split_reasoning("hello<think>oops", "separated")
+
+    assert clean == "hello"
+    assert reasoning == "oops"
+
+
+def test_split_reasoning_tagged_is_noop() -> None:
+    clean, reasoning = split_reasoning("<think>a</think>hi", "tagged")
+
+    assert clean == "<think>a</think>hi"
+    assert reasoning == ""

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -37,7 +37,7 @@ from graphon.node_events.node import (
 )
 from graphon.nodes.llm import LLMNode, LLMNodeData
 from graphon.nodes.llm.exc import LLMNodeError
-from graphon.nodes.llm.reasoning import ThinkStreamFilter, split_reasoning
+from graphon.nodes.llm.reasoning import split_reasoning
 from graphon.nodes.llm.runtime_protocols import LLMPollingCapableProtocol, LLMProtocol
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 
@@ -874,31 +874,3 @@ def test_separated_stream_matches_split_reasoning(full_text: str) -> None:
     expected, _ = split_reasoning(full_text, "separated")
 
     assert "".join(chunks).strip() == expected
-
-
-def test_think_stream_filter_strips_reasoning() -> None:
-    flt = ThinkStreamFilter()
-
-    assert flt.feed("<think>x</think>y") == "y"
-    assert flt.finalize() == ""
-
-
-def test_split_reasoning_strips_closed_block() -> None:
-    clean, reasoning = split_reasoning("<think>a</think>hello", "separated")
-
-    assert clean == "hello"
-    assert reasoning == "a"
-
-
-def test_split_reasoning_strips_unclosed_trailing_block() -> None:
-    clean, reasoning = split_reasoning("hello<think>oops", "separated")
-
-    assert clean == "hello"
-    assert reasoning == "oops"
-
-
-def test_split_reasoning_tagged_is_noop() -> None:
-    clean, reasoning = split_reasoning("<think>a</think>hi", "tagged")
-
-    assert clean == "<think>a</think>hi"
-    assert reasoning == ""

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -1,4 +1,5 @@
 import base64
+import re
 from collections.abc import Generator, Sequence
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -838,6 +839,15 @@ def test_separated_stream_does_not_swallow_non_think_angle_brackets() -> None:
     assert "".join(chunks) == "<div>ok"
 
 
+def test_separated_stream_flushes_held_partial_open_on_finalize() -> None:
+    # Stream ends on a held partial open: finalize() must flush "<thi", not drop it.
+    chunks, completed = _run_stream(["answer<thi"], reasoning_format="separated")
+
+    assert "".join(chunks) == "answer<thi"
+    assert chunks[-1] == "<thi"  # from the finalize() flush, not feed()
+    assert completed.text == "answer<thi"
+
+
 def test_separated_stream_strips_leading_whitespace_after_reasoning() -> None:
     chunks, completed = _run_stream(
         ["<think>r</think>", "\n", "answer"],
@@ -859,18 +869,25 @@ def test_tagged_stream_keeps_think_tags_unchanged() -> None:
     assert completed.reasoning_content == ""
 
 
+def _normalize_like_split_reasoning(text: str) -> str:
+    # Mirror split_reasoning()'s whitespace handling: collapse blank-line runs + strip.
+    return re.sub(r"\n\s*\n", "\n\n", text).strip()
+
+
 @pytest.mark.parametrize(
     "full_text",
     [
         "<think>plan</think>answer",
         "before<think>a</think>middle<think>b</think>after",
         "<think>only reasoning</think>\n\nanswer body",
+        "before<think>a</think>\n\n\nmiddle",  # internal blank-line run
+        "<think>r</think>answer\n\n",  # trailing whitespace
     ],
 )
 def test_separated_stream_matches_split_reasoning(full_text: str) -> None:
-    # Any chunk boundary must produce the same clean text as the batch splitter.
+    # Stream and batch splitter agree only up to split_reasoning()'s whitespace pass.
     parts = [full_text[i : i + 3] for i in range(0, len(full_text), 3)]
     chunks, _ = _run_stream(parts, reasoning_format="separated")
     expected, _ = split_reasoning(full_text, "separated")
 
-    assert "".join(chunks).strip() == expected
+    assert _normalize_like_split_reasoning("".join(chunks)) == expected

--- a/tests/nodes/llm/test_reasoning.py
+++ b/tests/nodes/llm/test_reasoning.py
@@ -20,6 +20,13 @@ def test_filter_passes_through_non_think_angle_brackets() -> None:
     assert _feed_all(["<div>ok"]) == "<div>ok"
 
 
+def test_filter_passes_through_tags_with_think_prefix() -> None:
+    assert (
+        _feed_all(["before<think", "ing>idea</thinking>after"])
+        == "before<thinking>idea</thinking>after"
+    )
+
+
 def test_filter_strips_tag_split_across_chunks() -> None:
     assert _feed_all(["<thi", "nk>plan</thi", "nk>ans", "wer"]) == "answer"
 
@@ -92,6 +99,18 @@ def test_filter_releases_dangling_open_bracket_as_literal() -> None:
     assert _feed_all(["a<", "b"]) == "a<b"
 
 
+def test_filter_keeps_malformed_open_tag_with_nested_bracket() -> None:
+    assert _feed_all(["x<think <y", ">secret</think>z"]) == (
+        "x<think <y>secret</think>z"
+    )
+
+
+def test_filter_releases_overlong_partial_open_tag_as_literal() -> None:
+    partial = "<think " + ("x" * 600)
+
+    assert _feed_all(["a", partial, " end"]) == f"a{partial} end"
+
+
 def test_filter_handles_empty_input() -> None:
     flt = ThinkStreamFilter()
 
@@ -112,3 +131,21 @@ def test_split_reasoning_is_case_insensitive() -> None:
 
     assert clean == "hi"
     assert reasoning == "a"
+
+
+def test_split_reasoning_keeps_tags_with_think_prefix() -> None:
+    text = "before<thinking>idea</thinking>after"
+
+    clean, reasoning = split_reasoning(text, "separated")
+
+    assert clean == text
+    assert reasoning == ""
+
+
+def test_split_reasoning_keeps_malformed_open_tag_with_nested_bracket() -> None:
+    text = "x<think <y>secret</think>z"
+
+    clean, reasoning = split_reasoning(text, "separated")
+
+    assert clean == text
+    assert reasoning == ""

--- a/tests/nodes/llm/test_reasoning.py
+++ b/tests/nodes/llm/test_reasoning.py
@@ -1,0 +1,77 @@
+"""Unit tests for graphon.nodes.llm.reasoning (pure, node-independent)."""
+
+from graphon.nodes.llm.reasoning import ThinkStreamFilter, split_reasoning
+
+
+def _feed_all(parts: list[str]) -> str:
+    flt = ThinkStreamFilter()
+    out = "".join(flt.feed(part) for part in parts)
+    return out + flt.finalize()
+
+
+def test_filter_strips_single_block() -> None:
+    flt = ThinkStreamFilter()
+
+    assert flt.feed("<think>x</think>y") == "y"
+    assert flt.finalize() == ""
+
+
+def test_filter_passes_through_non_think_angle_brackets() -> None:
+    assert _feed_all(["<div>ok"]) == "<div>ok"
+
+
+def test_filter_strips_tag_split_across_chunks() -> None:
+    assert _feed_all(["<thi", "nk>plan</thi", "nk>ans", "wer"]) == "answer"
+
+
+def test_filter_handles_tag_attributes() -> None:
+    assert _feed_all(['<think foo="x">p</think>hi']) == "hi"
+
+
+def test_filter_handles_multiple_blocks() -> None:
+    assert _feed_all(["<think>a</think>X<think>b</think>Y"]) == "XY"
+
+
+def test_filter_drops_unclosed_trailing_think() -> None:
+    assert _feed_all(["hi<think>tail"]) == "hi"
+
+
+def test_filter_strips_leading_whitespace_after_reasoning() -> None:
+    assert _feed_all(["<think>r</think>", "\n", "answer"]) == "answer"
+
+
+def test_split_reasoning_strips_closed_block() -> None:
+    clean, reasoning = split_reasoning("<think>a</think>hello", "separated")
+
+    assert clean == "hello"
+    assert reasoning == "a"
+
+
+def test_split_reasoning_joins_multiple_blocks() -> None:
+    clean, reasoning = split_reasoning(
+        "<think>a</think>X<think>b</think>Y", "separated"
+    )
+
+    assert clean == "XY"
+    assert reasoning == "a\nb"
+
+
+def test_split_reasoning_strips_unclosed_trailing_block() -> None:
+    clean, reasoning = split_reasoning("hello<think>oops", "separated")
+
+    assert clean == "hello"
+    assert reasoning == "oops"
+
+
+def test_split_reasoning_without_think_is_unchanged() -> None:
+    clean, reasoning = split_reasoning("plain text", "separated")
+
+    assert clean == "plain text"
+    assert reasoning == ""
+
+
+def test_split_reasoning_tagged_is_noop() -> None:
+    clean, reasoning = split_reasoning("<think>a</think>hi", "tagged")
+
+    assert clean == "<think>a</think>hi"
+    assert reasoning == ""

--- a/tests/nodes/llm/test_reasoning.py
+++ b/tests/nodes/llm/test_reasoning.py
@@ -75,3 +75,40 @@ def test_split_reasoning_tagged_is_noop() -> None:
 
     assert clean == "<think>a</think>hi"
     assert reasoning == ""
+
+
+def test_filter_is_case_insensitive() -> None:
+    assert _feed_all(["<THINK>x</THINK>y"]) == "y"
+
+
+def test_filter_keeps_discarding_on_false_partial_close() -> None:
+    # "</thi" looks like a closing tag start but turns into "</this", which is
+    # still reasoning and must stay discarded.
+    assert _feed_all(["<think>a</thi", "s b</think>c"]) == "c"
+
+
+def test_filter_releases_dangling_open_bracket_as_literal() -> None:
+    # A "<" that never grows into "<think" is literal text, not a held tag.
+    assert _feed_all(["a<", "b"]) == "a<b"
+
+
+def test_filter_handles_empty_input() -> None:
+    flt = ThinkStreamFilter()
+
+    assert flt.feed("") == ""
+    assert flt.finalize() == ""
+
+
+def test_filter_emits_nothing_for_reasoning_only_output() -> None:
+    assert _feed_all(["<think>just reasoning</think>"]) == ""
+
+
+def test_filter_strips_block_streamed_character_by_character() -> None:
+    assert _feed_all(list("<think>plan</think>answer")) == "answer"
+
+
+def test_split_reasoning_is_case_insensitive() -> None:
+    clean, reasoning = split_reasoning("<THINK>a</THINK>hi", "separated")
+
+    assert clean == "hi"
+    assert reasoning == "a"


### PR DESCRIPTION
## Related Issue

Related: langgenius/dify#37184

## Summary

In `reasoning_format="separated"` mode the LLM node only cleaned the final `text` variable; the per-token stream still emitted raw `<think>...</think>`, so Chatflow answers (assembled from the stream) leaked reasoning even with the toggle on.

This adds a stateful, chunk-boundary-safe `ThinkStreamFilter` that strips `<think>` blocks as they stream — handling tags split across chunks, attributes, multiple blocks, and an unclosed trailing think. The mode is distinguished explicitly at the wiring point: `text_filter is None` → tagged streams raw tokens (provably unchanged); a filter instance → separated. `split_reasoning` also drops a trailing unclosed `<think>` so the final text matches the stream up to whitespace normalization (the batch splitter additionally collapses blank-line runs and strips the result, which a token-by-token filter can't reproduce).

All `<think>` handling (matchers + the streaming filter + `split_reasoning`/`extract_stream_reasoning`) now lives in a dedicated `graphon/nodes/llm/reasoning.py` module instead of being scattered across `node.py`.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
