### PR TITLE
refactor(runtime)!: consolidate ready queue protocol

### DIFF
--- a/src/graphon/graph_engine/graph_state_manager.py
+++ b/src/graphon/graph_engine/graph_state_manager.py
@@ -7,8 +7,7 @@ from typing import TypedDict, final
 from graphon.enums import NodeState
 from graphon.graph.edge import Edge
 from graphon.graph.graph import Graph
-
-from .ready_queue import ReadyQueue
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 
 
 class EdgeStateAnalysis(TypedDict):
@@ -21,12 +20,12 @@ class EdgeStateAnalysis(TypedDict):
 
 @final
 class GraphStateManager:
-    def __init__(self, graph: Graph, ready_queue: ReadyQueue) -> None:
+    def __init__(self, graph: Graph, ready_queue: ReadyQueueProtocol) -> None:
         """Initialize the state manager.
 
         Args:
             graph: The workflow graph
-            ready_queue: Queue for nodes ready to execute
+            ready_queue: Ready queue protocol for nodes ready to execute
 
         """
         self._graph = graph

--- a/src/graphon/graph_engine/ready_queue/__init__.py
+++ b/src/graphon/graph_engine/ready_queue/__init__.py
@@ -1,16 +1,11 @@
-"""Ready queue implementations for GraphEngine.
-
-This package contains the protocol and implementations for managing
-the queue of nodes ready for execution.
-"""
+"""Ready queue implementations and serialized state helpers for GraphEngine."""
 
 from .factory import create_ready_queue_from_state
 from .in_memory import InMemoryReadyQueue
-from .protocol import ReadyQueue, ReadyQueueState
+from .protocol import ReadyQueueState
 
 __all__ = [
     "InMemoryReadyQueue",
-    "ReadyQueue",
     "ReadyQueueState",
     "create_ready_queue_from_state",
 ]

--- a/src/graphon/graph_engine/ready_queue/factory.py
+++ b/src/graphon/graph_engine/ready_queue/factory.py
@@ -1,26 +1,28 @@
-"""Factory for creating ReadyQueue instances from serialized state."""
+"""Factory for creating ready queue instances from serialized state."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
 
-from .in_memory import InMemoryReadyQueue
-from .protocol import ReadyQueue, ReadyQueueState
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 
-_READY_QUEUE_BUILDERS: dict[str, tuple[Callable[[], ReadyQueue], str]] = {
+from .in_memory import InMemoryReadyQueue
+from .protocol import ReadyQueueState
+
+_READY_QUEUE_BUILDERS: dict[str, tuple[Callable[[], ReadyQueueProtocol], str]] = {
     "InMemoryReadyQueue": (InMemoryReadyQueue, "1.0"),
 }
 
 
-def create_ready_queue_from_state(state: ReadyQueueState) -> ReadyQueue:
-    """Create a ReadyQueue instance from a serialized state.
+def create_ready_queue_from_state(state: ReadyQueueState) -> ReadyQueueProtocol:
+    """Create a ready queue instance from a serialized state.
 
     Args:
         state: The serialized queue state (Pydantic model, dict, or JSON string),
             or None for a new empty queue
 
     Returns:
-        A ReadyQueue instance initialized with the given state
+        A ready queue instance initialized with the given state
 
     Raises:
         ValueError: If the queue type is unknown or version is unsupported

--- a/src/graphon/graph_engine/ready_queue/in_memory.py
+++ b/src/graphon/graph_engine/ready_queue/in_memory.py
@@ -1,4 +1,4 @@
-"""In-memory implementation of the ReadyQueue protocol.
+"""In-memory implementation of the ready queue protocol.
 
 This implementation wraps Python's standard queue.Queue and adds
 serialization capabilities for state storage.
@@ -7,11 +7,13 @@ serialization capabilities for state storage.
 import queue
 from typing import final
 
-from .protocol import ReadyQueue, ReadyQueueState
+from graphon.runtime.ready_queue import ReadyQueueProtocol
+
+from .protocol import ReadyQueueState
 
 
 @final
-class InMemoryReadyQueue(ReadyQueue):
+class InMemoryReadyQueue(ReadyQueueProtocol):
     """In-memory ready queue implementation with serialization support.
 
     This implementation uses Python's queue.Queue internally and provides

--- a/src/graphon/graph_engine/ready_queue/protocol.py
+++ b/src/graphon/graph_engine/ready_queue/protocol.py
@@ -1,4 +1,8 @@
-"""Public ready queue types for GraphEngine."""
+"""ReadyQueue protocol for GraphEngine node execution queue.
+
+This protocol defines the interface for managing the queue of nodes ready
+for execution, supporting both in-memory and persistent storage scenarios.
+"""
 
 from collections.abc import Sequence
 

--- a/src/graphon/graph_engine/ready_queue/protocol.py
+++ b/src/graphon/graph_engine/ready_queue/protocol.py
@@ -1,14 +1,8 @@
-"""ReadyQueue protocol for GraphEngine node execution queue.
-
-This protocol defines the interface for managing the queue of nodes ready
-for execution, supporting both in-memory and persistent storage scenarios.
-"""
+"""Serialized state models for GraphEngine ready queue implementations."""
 
 from collections.abc import Sequence
 
 from pydantic import BaseModel, Field
-
-from graphon.runtime.ready_queue import ReadyQueueProtocol
 
 
 class ReadyQueueState(BaseModel):
@@ -26,6 +20,3 @@ class ReadyQueueState(BaseModel):
         default_factory=list,
         description="List of node IDs in the queue",
     )
-
-
-ReadyQueue = ReadyQueueProtocol

--- a/src/graphon/graph_engine/ready_queue/protocol.py
+++ b/src/graphon/graph_engine/ready_queue/protocol.py
@@ -1,14 +1,10 @@
-"""ReadyQueue protocol for GraphEngine node execution queue.
+"""Public ready queue types for GraphEngine."""
 
-This protocol defines the interface for managing the queue of nodes ready
-for execution, supporting both in-memory and persistent storage scenarios.
-"""
-
-from abc import abstractmethod
 from collections.abc import Sequence
-from typing import Protocol
 
 from pydantic import BaseModel, Field
+
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 
 
 class ReadyQueueState(BaseModel):
@@ -28,83 +24,4 @@ class ReadyQueueState(BaseModel):
     )
 
 
-class ReadyQueue(Protocol):
-    """Protocol for managing nodes ready for execution in GraphEngine.
-
-    This protocol defines the interface that any ready queue implementation
-    must provide, enabling both in-memory queues and persistent queues
-    that can be serialized for state storage.
-    """
-
-    @abstractmethod
-    def put(self, item: str) -> None:
-        """Add a node ID to the ready queue.
-
-        Args:
-            item: The node ID to add to the queue
-
-        """
-        ...
-
-    @abstractmethod
-    def get(self, timeout: float | None = None) -> str:
-        """Retrieve and remove a node ID from the queue.
-
-        Args:
-            timeout: Maximum time to wait for an item (None for blocking)
-
-        Returns:
-            The node ID retrieved from the queue
-
-        """
-        ...
-
-    @abstractmethod
-    def task_done(self) -> None:
-        """Indicate that a previously retrieved task is complete.
-
-        Used by worker threads to signal task completion for
-        join() synchronization.
-        """
-        ...
-
-    @abstractmethod
-    def empty(self) -> bool:
-        """Check if the queue is empty.
-
-        Returns:
-            True if the queue has no items, False otherwise
-
-        """
-        ...
-
-    @abstractmethod
-    def qsize(self) -> int:
-        """Get the approximate size of the queue.
-
-        Returns:
-            The approximate number of items in the queue
-
-        """
-        ...
-
-    @abstractmethod
-    def dumps(self) -> str:
-        """Serialize the queue state to a JSON string for storage.
-
-        Returns:
-            A JSON string containing the serialized queue state
-            that can be persisted and later restored
-
-        """
-        ...
-
-    @abstractmethod
-    def loads(self, data: str) -> None:
-        """Restore the queue state from a JSON string.
-
-        Args:
-            data: The JSON string containing the serialized queue state to restore
-
-        """
-        ...
+ReadyQueue = ReadyQueueProtocol

--- a/src/graphon/graph_engine/worker.py
+++ b/src/graphon/graph_engine/worker.py
@@ -24,8 +24,7 @@ from graphon.graph_events.node import (
 )
 from graphon.node_events.base import NodeRunResult
 from graphon.nodes.base.node import Node
-
-from .ready_queue import ReadyQueue
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 
 logger = logging.getLogger(__name__)
 WORKER_IDLE_THRESHOLD_SECONDS = 0.2
@@ -42,7 +41,7 @@ class Worker(threading.Thread):
 
     def __init__(
         self,
-        ready_queue: ReadyQueue,
+        ready_queue: ReadyQueueProtocol,
         event_queue: queue.Queue[GraphNodeEventBase],
         graph: Graph,
         layers: Sequence[GraphEngineLayer],

--- a/src/graphon/graph_engine/worker_management/worker_pool.py
+++ b/src/graphon/graph_engine/worker_management/worker_pool.py
@@ -12,10 +12,10 @@ from typing import final
 
 from graphon.graph.graph import Graph
 from graphon.graph_events.base import GraphNodeEventBase
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 
 from ..config import GraphEngineConfig
 from ..layers.base import GraphEngineLayer
-from ..ready_queue import ReadyQueue
 from ..worker import Worker
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class WorkerPool:
 
     def __init__(
         self,
-        ready_queue: ReadyQueue,
+        ready_queue: ReadyQueueProtocol,
         event_queue: queue.Queue[GraphNodeEventBase],
         graph: Graph,
         layers: list[GraphEngineLayer],
@@ -43,7 +43,7 @@ class WorkerPool:
         """Initialize the simple worker pool.
 
         Args:
-            ready_queue: Ready queue for nodes ready for execution
+            ready_queue: Ready queue protocol for nodes ready for execution
             event_queue: Queue for worker events
             graph: The workflow graph
             layers: Graph engine layers for node execution hooks

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -14,53 +14,13 @@ from pydantic_core import to_jsonable_python
 
 from graphon.enums import NodeExecutionType, NodeState, NodeType
 from graphon.model_runtime.entities.llm_entities import LLMUsage
+from graphon.runtime.ready_queue import ReadyQueueProtocol
 from graphon.runtime.variable_pool import VariablePool
 
 if TYPE_CHECKING:
     from graphon.entities.graph_init_params import GraphInitParams
     from graphon.entities.pause_reason import PauseReason
     from graphon.graph.graph import Graph
-
-
-class ReadyQueueProtocol(Protocol):
-    """Structural interface required from ready queue implementations."""
-
-    @abstractmethod
-    def put(self, item: str) -> None:
-        """Enqueue the identifier of a node that is ready to run."""
-        ...
-
-    @abstractmethod
-    def get(self, timeout: float | None = None) -> str:
-        """Return the next node identifier,
-        blocking until available or timeout expires.
-        """
-        ...
-
-    @abstractmethod
-    def task_done(self) -> None:
-        """Signal that the most recently dequeued node has completed processing."""
-        ...
-
-    @abstractmethod
-    def empty(self) -> bool:
-        """Return True when the queue contains no pending nodes."""
-        ...
-
-    @abstractmethod
-    def qsize(self) -> int:
-        """Approximate the number of pending nodes awaiting execution."""
-        ...
-
-    @abstractmethod
-    def dumps(self) -> str:
-        """Serialize the queue contents for persistence."""
-        ...
-
-    @abstractmethod
-    def loads(self, data: str) -> None:
-        """Restore the queue contents from a serialized payload."""
-        ...
 
 
 class NodeExecutionProtocol(Protocol):

--- a/src/graphon/runtime/ready_queue.py
+++ b/src/graphon/runtime/ready_queue.py
@@ -46,6 +46,12 @@ class ReadyQueueProtocol(Protocol):
     def empty(self) -> bool:
         """Check whether the queue contains any pending nodes.
 
+        This method must be safe to call concurrently with other queue operations,
+        including put and get.
+
+        NOTE: Because the queue can be modified by other threads between the check
+        and the subsequent use, this method is prone to TOCTOU errors.
+
         Returns:
             ``True`` when the queue has no pending items, otherwise ``False``.
         """
@@ -54,6 +60,12 @@ class ReadyQueueProtocol(Protocol):
     @abstractmethod
     def qsize(self) -> int:
         """Return the approximate number of pending nodes awaiting execution.
+
+        This method must be safe to call concurrently with other queue operations,
+        including put and get.
+
+        NOTE: Because the queue can be modified by other threads between the check
+        and the subsequent use, this method is prone to TOCTOU errors.
 
         Returns:
             The approximate number of items currently in the queue.

--- a/src/graphon/runtime/ready_queue.py
+++ b/src/graphon/runtime/ready_queue.py
@@ -5,42 +5,76 @@ from typing import Protocol
 
 
 class ReadyQueueProtocol(Protocol):
-    """Structural interface required from ready queue implementations."""
+    """Structural interface required from ready queue implementations.
+
+    Implementations may be in-memory or persistence-backed, but they must
+    provide the same queue semantics and serialization surface.
+    """
 
     @abstractmethod
     def put(self, item: str) -> None:
-        """Enqueue the identifier of a node that is ready to run."""
+        """Add a node identifier to the ready queue.
+
+        Args:
+            item: The node identifier to add to the queue.
+        """
         ...
 
     @abstractmethod
     def get(self, timeout: float | None = None) -> str:
-        """Return the next node identifier.
+        """Retrieve and remove the next node identifier from the queue.
 
-        Block until available or until the timeout expires.
+        Args:
+            timeout: Maximum time to wait for an item. ``None`` blocks until an
+                item becomes available.
+
+        Returns:
+            The node identifier retrieved from the queue.
         """
         ...
 
     @abstractmethod
     def task_done(self) -> None:
-        """Signal that the most recently dequeued node has completed processing."""
+        """Indicate that a previously retrieved task is complete.
+
+        Used by worker threads to signal task completion for join-style
+        synchronization.
+        """
         ...
 
     @abstractmethod
     def empty(self) -> bool:
-        """Return True when the queue contains no pending nodes."""
+        """Check whether the queue contains any pending nodes.
+
+        Returns:
+            ``True`` when the queue has no pending items, otherwise ``False``.
+        """
         ...
 
     @abstractmethod
     def qsize(self) -> int:
-        """Approximate the number of pending nodes awaiting execution."""
+        """Return the approximate number of pending nodes awaiting execution.
+
+        Returns:
+            The approximate number of items currently in the queue.
+        """
         ...
 
     @abstractmethod
     def dumps(self) -> str:
-        """Serialize the queue contents for persistence."""
+        """Serialize the queue contents for persistence.
+
+        Returns:
+            A serialized representation of the queue state that can be stored
+            and later restored.
+        """
         ...
 
     @abstractmethod
     def loads(self, data: str) -> None:
-        """Restore the queue contents from a serialized payload."""
+        """Restore the queue contents from a serialized payload.
+
+        Args:
+            data: The serialized queue state to restore.
+        """
         ...

--- a/src/graphon/runtime/ready_queue.py
+++ b/src/graphon/runtime/ready_queue.py
@@ -1,0 +1,46 @@
+"""Runtime ready queue protocol."""
+
+from abc import abstractmethod
+from typing import Protocol
+
+
+class ReadyQueueProtocol(Protocol):
+    """Structural interface required from ready queue implementations."""
+
+    @abstractmethod
+    def put(self, item: str) -> None:
+        """Enqueue the identifier of a node that is ready to run."""
+        ...
+
+    @abstractmethod
+    def get(self, timeout: float | None = None) -> str:
+        """Return the next node identifier.
+
+        Block until available or until the timeout expires.
+        """
+        ...
+
+    @abstractmethod
+    def task_done(self) -> None:
+        """Signal that the most recently dequeued node has completed processing."""
+        ...
+
+    @abstractmethod
+    def empty(self) -> bool:
+        """Return True when the queue contains no pending nodes."""
+        ...
+
+    @abstractmethod
+    def qsize(self) -> int:
+        """Approximate the number of pending nodes awaiting execution."""
+        ...
+
+    @abstractmethod
+    def dumps(self) -> str:
+        """Serialize the queue contents for persistence."""
+        ...
+
+    @abstractmethod
+    def loads(self, data: str) -> None:
+        """Restore the queue contents from a serialized payload."""
+        ...

--- a/tests/test_protocol_abstract_contracts.py
+++ b/tests/test_protocol_abstract_contracts.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import pytest
 
+from graphon.graph_engine.ready_queue.protocol import ReadyQueue
+from graphon.runtime.ready_queue import ReadyQueueProtocol
+
 
 def _is_direct_protocol_class(
     class_def: ast.ClassDef,
@@ -109,6 +112,10 @@ def _protocol_id(protocol_cls: type[object]) -> str:
 
 def test_protocol_targets_should_be_discovered() -> None:
     assert PROTOCOL_TARGETS
+
+
+def test_graph_engine_ready_queue_reuses_runtime_protocol() -> None:
+    assert ReadyQueue is ReadyQueueProtocol
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol_abstract_contracts.py
+++ b/tests/test_protocol_abstract_contracts.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from graphon.runtime.ready_queue import ReadyQueueProtocol
-
 
 def _is_direct_protocol_class(
     class_def: ast.ClassDef,
@@ -111,19 +109,6 @@ def _protocol_id(protocol_cls: type[object]) -> str:
 
 def test_protocol_targets_should_be_discovered() -> None:
     assert PROTOCOL_TARGETS
-
-
-def test_graph_engine_ready_queue_protocol_module_has_no_legacy_alias() -> None:
-    package = importlib.import_module("graphon.graph_engine.ready_queue")
-    module = importlib.import_module("graphon.graph_engine.ready_queue.protocol")
-    runtime_module = importlib.import_module("graphon.runtime.ready_queue")
-
-    assert not hasattr(package, "ReadyQueue")
-    assert hasattr(module, "ReadyQueueState")
-    assert not hasattr(module, "ReadyQueue")
-    assert not hasattr(module, "ReadyQueueProtocol")
-    assert hasattr(runtime_module, "ReadyQueueProtocol")
-    assert runtime_module.ReadyQueueProtocol is ReadyQueueProtocol
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol_abstract_contracts.py
+++ b/tests/test_protocol_abstract_contracts.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from graphon.graph_engine.ready_queue.protocol import ReadyQueue
-from graphon.runtime.ready_queue import ReadyQueueProtocol
-
 
 def _is_direct_protocol_class(
     class_def: ast.ClassDef,
@@ -112,10 +109,6 @@ def _protocol_id(protocol_cls: type[object]) -> str:
 
 def test_protocol_targets_should_be_discovered() -> None:
     assert PROTOCOL_TARGETS
-
-
-def test_graph_engine_ready_queue_reuses_runtime_protocol() -> None:
-    assert ReadyQueue is ReadyQueueProtocol
 
 
 @pytest.mark.parametrize(

--- a/tests/test_protocol_abstract_contracts.py
+++ b/tests/test_protocol_abstract_contracts.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from graphon.runtime.ready_queue import ReadyQueueProtocol
+
 
 def _is_direct_protocol_class(
     class_def: ast.ClassDef,
@@ -109,6 +111,19 @@ def _protocol_id(protocol_cls: type[object]) -> str:
 
 def test_protocol_targets_should_be_discovered() -> None:
     assert PROTOCOL_TARGETS
+
+
+def test_graph_engine_ready_queue_protocol_module_has_no_legacy_alias() -> None:
+    package = importlib.import_module("graphon.graph_engine.ready_queue")
+    module = importlib.import_module("graphon.graph_engine.ready_queue.protocol")
+    runtime_module = importlib.import_module("graphon.runtime.ready_queue")
+
+    assert not hasattr(package, "ReadyQueue")
+    assert hasattr(module, "ReadyQueueState")
+    assert not hasattr(module, "ReadyQueue")
+    assert not hasattr(module, "ReadyQueueProtocol")
+    assert hasattr(runtime_module, "ReadyQueueProtocol")
+    assert runtime_module.ReadyQueueProtocol is ReadyQueueProtocol
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #140

## Summary

- Consolidates the ready queue protocol into `graphon.runtime.ready_queue.ReadyQueueProtocol`.
- Update documentation for `ReadyQueueProtocol`

BREAKING CHANGE: import path updated for `ReadyQueueProtocol`


## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation

## Validation

- `uv run prek validate-config prek.toml`
- `uv lock --check`
- `uv run ruff format --check`
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest tests/test_protocol_abstract_contracts.py tests/runtime/test_graph_runtime_state.py -q`
