### PR TITLE
fix(response-stream): avoid duplicate streamed prefixes

### DIFF
--- a/src/graphon/graph_engine/filters/response_stream.py
+++ b/src/graphon/graph_engine/filters/response_stream.py
@@ -159,6 +159,9 @@ class StreamBuffers:
         position = self.positions.get(key, 0)
         return position < len(self.events[key])
 
+    def has_events(self, selector: Sequence[str]) -> bool:
+        return tuple(selector) in self.events
+
     def close(self, selector: Sequence[str]) -> None:
         self.closed_selectors.add(tuple(selector))
 
@@ -597,6 +600,7 @@ class ResponseStreamFilter:
         else:
             output_node_id = source_selector_prefix
         execution_id = self._get_or_create_execution_id(output_node_id)
+        has_stream_events = self._stream_buffers.has_events(segment.selector)
 
         while self._stream_buffers.has_unread(segment.selector):
             event = self._stream_buffers.pop(segment.selector)
@@ -620,7 +624,9 @@ class ResponseStreamFilter:
 
         if self._stream_buffers.is_closed(segment.selector):
             is_complete = True
-        elif value := self._bound_runtime_state.variable_pool.get(segment.selector):
+        elif not has_stream_events and (
+            value := self._bound_runtime_state.variable_pool.get(segment.selector)
+        ):
             is_last_segment = bool(
                 self._active_session
                 and self._active_session.index

--- a/tests/graph_engine/test_response_stream_filter.py
+++ b/tests/graph_engine/test_response_stream_filter.py
@@ -279,6 +279,25 @@ def test_response_stream_filter_reads_scalar_variable_values() -> None:
     assert [event.chunk for event in chunks] == ["saved"]
 
 
+def test_response_stream_filter_does_not_mix_buffered_chunks_with_final_value() -> None:
+    graph = _variable_response_graph()
+    variable_pool = VariablePool()
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph, variable_pool))
+
+    assert list(event_filter.on_event(_stream_chunk("Quiet", is_final=False))) == []
+    variable_pool.add(["source", "answer"], StringSegment(value="Quiet Night Thought"))
+
+    output = [
+        *event_filter.on_event(_edge_taken()),
+        *event_filter.on_event(_stream_chunk(" Night", is_final=False)),
+        *event_filter.on_event(_stream_chunk(" Thought")),
+    ]
+
+    chunks = [event for event in output if isinstance(event, NodeRunStreamChunkEvent)]
+    assert [event.chunk for event in chunks] == ["Quiet", " Night", " Thought"]
+
+
 def test_response_stream_filter_uses_retry_execution_id_for_scalar_value() -> None:
     graph = _variable_response_graph()
     variable_pool = VariablePool()


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #174

## Summary

Prevents `ResponseStreamFilter` from mixing buffered stream chunks with the final runtime variable value for the same selector. Once a selector has emitted stream chunks, the filter continues consuming that stream instead of falling back to the completed value from `VariablePool`.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
