### PR TITLE
fix(model-runtime): align polling interval types

### DIFF
--- a/src/graphon/model_runtime/entities/llm_entities.py
+++ b/src/graphon/model_runtime/entities/llm_entities.py
@@ -225,9 +225,9 @@ class LLMPollingResult(BaseModel):
     plugin_state: dict[str, JsonValue] | None = None
     result: LLMResult | LLMResultWithStructuredOutput | None = None
     error: str | None = None
-    next_check_after_seconds: float | None = Field(default=None, gt=0)
-    expires_after_seconds: float | None = Field(default=None, gt=0)
-    max_attempts: int | None = Field(default=None, ge=1)
+    next_check_after_seconds: StrictInt | None = Field(default=None, ge=1)
+    expires_after_seconds: StrictInt | None = Field(default=None, ge=1)
+    max_attempts: StrictInt | None = Field(default=None, ge=1)
 
     @model_validator(mode="after")
     def _validate_status_payload(self) -> LLMPollingResult:

--- a/tests/model_runtime/test_model_entities.py
+++ b/tests/model_runtime/test_model_entities.py
@@ -68,16 +68,26 @@ def test_llm_polling_result_validates_status_payload() -> None:
             LLMPollingResult.model_validate(payload)
 
 
-def test_llm_polling_result_accepts_fractional_intervals() -> None:
+def test_llm_polling_result_accepts_positive_integer_intervals() -> None:
     result = LLMPollingResult(
         status=LLMPollingStatus.RUNNING,
         plugin_state={"job_id": "job-1"},
-        next_check_after_seconds=0.25,
-        expires_after_seconds=0.5,
+        next_check_after_seconds=1,
+        expires_after_seconds=2,
     )
 
-    assert result.next_check_after_seconds == pytest.approx(0.25)
-    assert result.expires_after_seconds == pytest.approx(0.5)
+    assert result.next_check_after_seconds == 1
+    assert result.expires_after_seconds == 2
+
+
+def test_llm_polling_result_rejects_fractional_intervals() -> None:
+    with pytest.raises(ValidationError):
+        LLMPollingResult.model_validate({
+            "status": "running",
+            "plugin_state": {"job_id": "job-1"},
+            "next_check_after_seconds": 0.25,
+            "expires_after_seconds": 0.5,
+        })
 
 
 def test_llm_polling_config_rejects_zero_min_interval() -> None:


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #181

## Summary

- align `LLMPollingResult.next_check_after_seconds` and `expires_after_seconds` with the integer-based daemon and SDK polling contracts
- tighten `max_attempts` to `StrictInt` for consistency within the same polling payload
- update model entity tests to accept positive integer intervals and reject fractional intervals

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
