### PR TITLE
refactor(llm)!: remove workflow_run_id and node_id from polling protocol

### DIFF
--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -489,7 +489,6 @@ class LLMNode(Node[LLMNodeData]):
             else None
         )
         self._raise_if_polling_aborted()
-        workflow_run_id = self._resolve_required_workflow_run_id()
         request_start_time = time.perf_counter()
         polling_result = self._normalize_polling_result(
             polling_model.start_llm_polling(
@@ -498,8 +497,6 @@ class LLMNode(Node[LLMNodeData]):
                 tools=None,
                 stop=stop,
                 json_schema=json_schema,
-                workflow_run_id=workflow_run_id,
-                node_id=self._node_id,
             ),
         )
 
@@ -567,8 +564,6 @@ class LLMNode(Node[LLMNodeData]):
                     polling_result = self._normalize_polling_result(
                         polling_model.check_llm_polling(
                             plugin_state=plugin_state,
-                            workflow_run_id=workflow_run_id,
-                            node_id=self._node_id,
                         ),
                     )
 

--- a/src/graphon/nodes/llm/runtime_protocols.py
+++ b/src/graphon/nodes/llm/runtime_protocols.py
@@ -140,8 +140,6 @@ class LLMPollingCapableProtocol(ABC):
         tools: Sequence[PromptMessageTool] | None,
         stop: Sequence[str] | None,
         json_schema: Mapping[str, Any] | None,
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         pass
 
@@ -150,8 +148,6 @@ class LLMPollingCapableProtocol(ABC):
         self,
         *,
         plugin_state: Mapping[str, JsonValue],
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         pass
 

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -231,8 +231,6 @@ def test_polling_llm_start_can_succeed_immediately(
         completed_event.node_run_result.status == WorkflowNodeExecutionStatus.SUCCEEDED
     )
     assert completed_event.node_run_result.outputs["text"] == "done"
-    assert model.start_calls[0]["workflow_run_id"] == "wr-1"
-    assert model.start_calls[0]["node_id"] == "llm"
     assert model.check_calls == []
 
 
@@ -572,8 +570,6 @@ def test_polling_llm_fails_when_max_attempts_are_exceeded(
     assert model.check_calls == [
         {
             "plugin_state": {"job_id": "job-1"},
-            "workflow_run_id": "wr-test",
-            "node_id": "llm",
         },
     ]
     assert completed_event.node_run_result.status == WorkflowNodeExecutionStatus.FAILED
@@ -603,29 +599,7 @@ def test_polling_llm_respects_existing_abort_before_start(
     assert "aborted" in completed_event.node_run_result.error
 
 
-def test_polling_llm_requires_workflow_run_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    model = _PollingLLM([
-        LLMPollingResult(
-            status=LLMPollingStatus.SUCCEEDED,
-            result=_llm_result(),
-        ),
-    ])
-    node = _build_llm_node(model_instance=model, workflow_run_id=None)
-    _stub_simple_prompt(monkeypatch, node)
-
-    events = list(node._run())
-
-    completed_event = next(
-        event for event in events if isinstance(event, StreamCompletedEvent)
-    )
-    assert model.start_calls == []
-    assert completed_event.node_run_result.status == WorkflowNodeExecutionStatus.FAILED
-    assert "workflow_run_id" in completed_event.node_run_result.error
-
-
-def test_polling_llm_uses_run_context_workflow_run_id(
+def test_polling_llm_not_use_run_context_workflow_run_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = _PollingLLM([
@@ -650,7 +624,6 @@ def test_polling_llm_uses_run_context_workflow_run_id(
         completed_event.node_run_result.status == WorkflowNodeExecutionStatus.SUCCEEDED
     )
     assert completed_event.node_run_result.outputs["text"] == "done"
-    assert model.start_calls[0]["workflow_run_id"] == "wr-context"
 
 
 def test_polling_llm_ignores_schema_feature_without_capability_base() -> None:


### PR DESCRIPTION
## Related Issue

Closes #183 

## Summary

Remove unused `workflow_run_id` and `node_id` from LLM polling protocol.

BREAKING CHNAGE: public interface `LLMPollingCapableProtocol` updated

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
