### PR TITLE
fix(document-extractor): add PDF text fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     'pandas[excel]>=2.1',
     'pydantic>=2.7',
     'pydantic-extra-types>=2',
+    'pypdf>=6.14.2',
     'pypdfium2>=5',
     'python-docx>=1.2',
     'pyyaml>=6',

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -6,6 +6,7 @@ import json
 import logging
 import pathlib
 import tempfile
+import threading
 import zipfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ import charset_normalizer
 import docx
 import pandas as pd
 import pypandoc
+import pypdf
 import pypdfium2
 import webvtt
 import yaml
@@ -44,6 +46,7 @@ from .exc import (
 )
 
 logger = logging.getLogger(__name__)
+_PDFIUM_LOCK = threading.Lock()
 
 _MIME_PLAIN_TEXT_TYPES = frozenset((
     "text/plain",
@@ -468,23 +471,61 @@ def _extract_text_from_yaml(file_content: bytes) -> str:
 
 def _extract_text_from_pdf(file_content: bytes) -> str:
     try:
-        pdf_document = pypdfium2.PdfDocument(io.BytesIO(file_content), autoclose=True)
-        return _read_pdf_text(pdf_document)
+        text = _read_pdf_text_with_pdfium(file_content)
     except Exception as e:
         msg = f"Failed to extract text from PDF: {e!s}"
         raise TextExtractionError(msg) from e
+    if text.strip():
+        return text
+    logger.debug("PDFium returned empty text for PDF; trying pypdf fallback")
+    return _read_fallback_pdf_text(file_content, default_text=text)
+
+
+def _read_pdf_text_with_pdfium(file_content: bytes) -> str:
+    with (
+        _PDFIUM_LOCK,
+        pypdfium2.PdfDocument(
+            io.BytesIO(file_content),
+            autoclose=True,
+        ) as pdf_document,
+    ):
+        return _read_pdf_text(pdf_document)
 
 
 def _read_pdf_text(pdf_document: pypdfium2.PdfDocument) -> str:
     text_parts = []
     for page in pdf_document:
-        text_page = page.get_textpage()
         try:
-            text_parts.append(text_page.get_text_range())
+            text_page = page.get_textpage()
+            try:
+                text_parts.append(text_page.get_text_range())
+            finally:
+                text_page.close()
         finally:
-            text_page.close()
             page.close()
     return "".join(text_parts)
+
+
+def _read_pdf_text_with_pypdf(file_content: bytes) -> str:
+    pdf_reader = pypdf.PdfReader(io.BytesIO(file_content))
+    try:
+        text_parts = [page.extract_text() or "" for page in pdf_reader.pages]
+        return "".join(text_parts)
+    finally:
+        pdf_reader.close()
+
+
+def _read_fallback_pdf_text(file_content: bytes, *, default_text: str) -> str:
+    try:
+        fallback_text = _read_pdf_text_with_pypdf(file_content)
+    except Exception:
+        logger.debug("pypdf fallback failed for PDF text extraction", exc_info=True)
+        return default_text
+    if fallback_text.strip():
+        logger.debug("pypdf fallback extracted text from PDF")
+        return fallback_text
+    logger.debug("pypdf fallback returned empty text for PDF")
+    return default_text
 
 
 def _extract_text_from_doc(

--- a/tests/nodes/document_extractor/test_dispatch.py
+++ b/tests/nodes/document_extractor/test_dispatch.py
@@ -1,7 +1,7 @@
 import io
 import json
 from types import SimpleNamespace
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -13,6 +13,46 @@ from graphon.nodes.document_extractor.exc import (
     TextExtractionError,
     UnsupportedFileTypeError,
 )
+
+_PDF_BYTES = b"%PDF"
+
+
+def _minimal_text_pdf(text: str) -> bytes:
+    stream = f"BT /F1 24 Tf 72 720 Td ({text}) Tj ET".encode()
+    objects = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        (
+            b"3 0 obj\n"
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\n"
+            b"endobj\n"
+        ),
+        b"4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        (
+            b"5 0 obj\n<< /Length "
+            + str(len(stream)).encode()
+            + b" >>\nstream\n"
+            + stream
+            + b"\nendstream\nendobj\n"
+        ),
+    ]
+    content = b"%PDF-1.4\n"
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(content))
+        content += obj
+
+    xref_offset = len(content)
+    xref = [b"xref\n0 6\n", b"0000000000 65535 f \n"]
+    xref.extend(f"{offset:010d} 00000 n \n".encode() for offset in offsets[1:])
+    return (
+        content
+        + b"".join(xref)
+        + b"trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n"
+        + str(xref_offset).encode()
+        + b"\n%%EOF\n"
+    )
 
 
 def test_extract_text_by_file_extension_routes_registered_extractor() -> None:
@@ -97,6 +137,188 @@ def test_extract_text_from_excel_reads_memory_workbook() -> None:
 
     assert "| Name | Value |" in extracted
     assert "| Alice Smith | 1 |" in extracted
+
+
+@pytest.mark.parametrize("route_kind", ["direct", "extension", "mime_type"])
+def test_pdf_extractors_read_real_text_pdf(route_kind: str) -> None:
+    file_content = _minimal_text_pdf("Graphon PDF")
+
+    if route_kind == "direct":
+        extracted = document_extractor_node._extract_text_from_pdf(file_content)
+    elif route_kind == "extension":
+        extracted = document_extractor_node._extract_text_by_file_extension(
+            file_content=file_content,
+            file_extension=".pdf",
+            unstructured_api_config=UnstructuredApiConfig(),
+        )
+    else:
+        extracted = document_extractor_node._extract_text_by_mime_type(
+            file_content=file_content,
+            mime_type="application/pdf",
+            unstructured_api_config=UnstructuredApiConfig(),
+        )
+
+    assert "Graphon PDF" in extracted
+
+
+@pytest.mark.parametrize(
+    ("pdfium_text", "fallback_text", "expected", "fallback_calls"),
+    [
+        ("pdfium text", "unused fallback", "pdfium text", 0),
+        ("\n  ", "fallback text", "fallback text", 1),
+    ],
+)
+def test_extract_text_from_pdf_uses_fallback_only_for_empty_pdfium_text(
+    monkeypatch: pytest.MonkeyPatch,
+    pdfium_text: str,
+    fallback_text: str,
+    expected: str,
+    fallback_calls: int,
+) -> None:
+    fallback_inputs = []
+
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pdfium",
+        lambda _file_content: pdfium_text,
+    )
+
+    def read_fallback(file_content: bytes) -> str:
+        fallback_inputs.append(file_content)
+        return fallback_text
+
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pypdf",
+        read_fallback,
+    )
+
+    extracted = document_extractor_node._extract_text_from_pdf(_PDF_BYTES)
+
+    assert extracted == expected
+    assert fallback_inputs == [_PDF_BYTES] * fallback_calls
+
+
+@pytest.mark.parametrize("fallback_text", ["", "  "])
+def test_extract_text_from_pdf_keeps_pdfium_empty_text_when_fallback_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    fallback_text: str,
+) -> None:
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pdfium",
+        lambda _file_content: "\n  ",
+    )
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pypdf",
+        lambda _file_content: fallback_text,
+    )
+
+    extracted = document_extractor_node._extract_text_from_pdf(_PDF_BYTES)
+
+    assert extracted == "\n  "
+
+
+def test_extract_text_from_pdf_keeps_pdfium_empty_text_when_fallback_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_fallback_error(_file_content: bytes) -> str:
+        msg = "cannot parse fallback"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pdfium",
+        lambda _file_content: "\n  ",
+    )
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pypdf",
+        raise_fallback_error,
+    )
+
+    extracted = document_extractor_node._extract_text_from_pdf(_PDF_BYTES)
+
+    assert extracted == "\n  "
+
+
+def test_extract_text_from_pdf_closes_reader_when_fallback_page_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Page:
+        def extract_text(self) -> str:
+            msg = "bad page"
+            raise RuntimeError(msg)
+
+    class Reader:
+        def __init__(self) -> None:
+            self.pages = [Page()]
+
+        def close(self) -> None:
+            events.append("reader.close")
+
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_read_pdf_text_with_pdfium",
+        lambda _file_content: "\n  ",
+    )
+    monkeypatch.setattr(
+        document_extractor_node.pypdf,
+        "PdfReader",
+        lambda *_args, **_kwargs: Reader(),
+    )
+
+    extracted = document_extractor_node._extract_text_from_pdf(_PDF_BYTES)
+
+    assert extracted == "\n  "
+    assert events == ["reader.close"]
+
+
+def test_read_pdf_text_with_pdfium_closes_resources_when_text_page_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Page:
+        def get_textpage(self) -> None:
+            events.append("page.get_textpage")
+            msg = "missing text page"
+            raise RuntimeError(msg)
+
+        def close(self) -> None:
+            events.append("page.close")
+
+    class Document:
+        def __enter__(self) -> Self:
+            events.append("document.enter")
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            events.append("document.close")
+
+        def __iter__(self) -> Any:
+            events.append("document.iter")
+            return iter([Page()])
+
+    events: list[str] = []
+
+    monkeypatch.setattr(
+        document_extractor_node.pypdfium2,
+        "PdfDocument",
+        lambda *_args, **_kwargs: Document(),
+    )
+
+    with pytest.raises(RuntimeError, match="missing text page"):
+        document_extractor_node._read_pdf_text_with_pdfium(_PDF_BYTES)
+
+    assert events == [
+        "document.enter",
+        "document.iter",
+        "page.get_textpage",
+        "page.close",
+        "document.close",
+    ]
 
 
 def test_excel_file_to_markdown_skips_invalid_sheet() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -355,6 +355,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-extra-types" },
     { name = "pypandoc" },
+    { name = "pypdf" },
     { name = "pypdfium2" },
     { name = "python-docx" },
     { name = "pyyaml" },
@@ -387,6 +388,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-extra-types", specifier = ">=2" },
     { name = "pypandoc", specifier = ">=1.13" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pypdfium2", specifier = ">=5" },
     { name = "python-docx", specifier = ">=1.2" },
     { name = "pyyaml", specifier = ">=6" },
@@ -1167,11 +1169,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.2"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #188
Refs langgenius/dify#37488

## Summary

- Add a `pypdf` fallback when PDFium extracts only empty or whitespace text from a PDF.
- Keep PDFium as the primary parser and preserve the original empty result if the fallback also has no text or cannot parse the file.
- Add regression coverage for the empty-PDFium-output path and declare `pypdf` as a direct dependency.

## Validation

- `uv lock --check`
- `uv run ruff format --check src/graphon/nodes/document_extractor/node.py tests/nodes/document_extractor/test_dispatch.py`
- `uv run ruff check src/graphon/nodes/document_extractor/node.py tests/nodes/document_extractor/test_dispatch.py`
- `uv run ty check`
- `uv run pytest tests/nodes/document_extractor`
- `uv run pytest`

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation