### PR TITLE
chore: bump version to v0.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'graphon'
-version = "0.5.2"
+version = "0.5.3"
 description = 'Graph execution engine for agentic AI workflows.'
 readme = 'README.md'
 license = 'Apache-2.0'

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "graphon"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Bump the package version from 0.5.2 to 0.5.3 to release #180 (out-of-band reasoning stream event), the only commit on `main` since the `v0.5.2` tag. Keeps the editable `graphon` entry in `uv.lock` in sync; no dependency changes.

Validation: `just check` passes locally.

## Checklist

- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation