### PR TITLE
feat(document-extractor): support OpenDocument text files

### DIFF
--- a/src/graphon/file/constants.py
+++ b/src/graphon/file/constants.py
@@ -38,6 +38,7 @@ DOCUMENT_EXTENSIONS = _with_case_variants(
         "pptx",
         "xml",
         "epub",
+        "odt",
     )),
 )
 

--- a/src/graphon/file/file_factory.py
+++ b/src/graphon/file/file_factory.py
@@ -50,7 +50,7 @@ def _get_file_type_by_extension(extension: str) -> FileType | None:
 
 
 def get_file_type_by_mime_type(mime_type: str) -> FileType:
-    normalized_mime_type = mime_type.lower()
+    normalized_mime_type = mime_type.partition(";")[0].strip().lower()
     if "image" in normalized_mime_type:
         return FileType.IMAGE
     if "video" in normalized_mime_type:

--- a/src/graphon/file/file_factory.py
+++ b/src/graphon/file/file_factory.py
@@ -6,7 +6,8 @@ from .constants import (
 )
 from .enums import FileType
 
-_DOCUMENT_MIME_TYPES = frozenset((
+_CONTENT_FILE_TYPES = (FileType.IMAGE, FileType.VIDEO, FileType.AUDIO)
+_DOCUMENT_MIME_TYPE_ALLOWLIST = frozenset((
     "application/epub+zip",
     "application/msword",
     "application/pdf",
@@ -19,7 +20,7 @@ _DOCUMENT_MIME_TYPES = frozenset((
     "application/vnd.oasis.opendocument.text",
     "message/rfc822",
 ))
-_DOCUMENT_MIME_PREFIXES = (
+_DOCUMENT_MIME_TYPE_PREFIXES = (
     "application/vnd.openxmlformats-officedocument",
     "application/wps-office",
     "text/",
@@ -51,14 +52,12 @@ def _get_file_type_by_extension(extension: str) -> FileType | None:
 
 def get_file_type_by_mime_type(mime_type: str) -> FileType:
     normalized_mime_type = mime_type.partition(";")[0].strip().lower()
-    if "image" in normalized_mime_type:
-        return FileType.IMAGE
-    if "video" in normalized_mime_type:
-        return FileType.VIDEO
-    if "audio" in normalized_mime_type:
-        return FileType.AUDIO
-    if normalized_mime_type in _DOCUMENT_MIME_TYPES or normalized_mime_type.startswith(
-        _DOCUMENT_MIME_PREFIXES
+    for file_type in _CONTENT_FILE_TYPES:
+        if normalized_mime_type.startswith(f"{file_type.value}/"):
+            return file_type
+    if (
+        normalized_mime_type in _DOCUMENT_MIME_TYPE_ALLOWLIST
+        or normalized_mime_type.startswith(_DOCUMENT_MIME_TYPE_PREFIXES)
     ):
         return FileType.DOCUMENT
     return FileType.CUSTOM

--- a/src/graphon/file/file_factory.py
+++ b/src/graphon/file/file_factory.py
@@ -6,6 +6,25 @@ from .constants import (
 )
 from .enums import FileType
 
+_DOCUMENT_MIME_TYPES = frozenset((
+    "application/epub+zip",
+    "application/msword",
+    "application/pdf",
+    "application/dps",
+    "application/et",
+    "application/kswps",
+    "application/vnd.ms-excel",
+    "application/vnd.ms-outlook",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.oasis.opendocument.text",
+    "message/rfc822",
+))
+_DOCUMENT_MIME_PREFIXES = (
+    "application/vnd.openxmlformats-officedocument",
+    "application/wps-office",
+    "text/",
+)
+
 
 def standardize_file_type(*, extension: str = "", mime_type: str = "") -> FileType:
     """Infer the actual file type from extension and mime type."""
@@ -31,12 +50,15 @@ def _get_file_type_by_extension(extension: str) -> FileType | None:
 
 
 def get_file_type_by_mime_type(mime_type: str) -> FileType:
-    if "image" in mime_type:
+    normalized_mime_type = mime_type.lower()
+    if "image" in normalized_mime_type:
         return FileType.IMAGE
-    if "video" in mime_type:
+    if "video" in normalized_mime_type:
         return FileType.VIDEO
-    if "audio" in mime_type:
+    if "audio" in normalized_mime_type:
         return FileType.AUDIO
-    if "text" in mime_type or "pdf" in mime_type:
+    if normalized_mime_type in _DOCUMENT_MIME_TYPES or normalized_mime_type.startswith(
+        _DOCUMENT_MIME_PREFIXES
+    ):
         return FileType.DOCUMENT
     return FileType.CUSTOM

--- a/src/graphon/nodes/document_extractor/node.py
+++ b/src/graphon/nodes/document_extractor/node.py
@@ -898,6 +898,24 @@ def _extract_text_from_epub(
         raise TextExtractionError(msg) from e
 
 
+def _extract_text_from_odt(
+    file_content: bytes,
+    *,
+    unstructured_api_config: UnstructuredApiConfig,
+) -> str:
+    try:
+        return _partition_unstructured_file(
+            file_content,
+            suffix=".odt",
+            unstructured_api_config=unstructured_api_config,
+            load_local_partition=_load_partition_odt,
+            render_element=_render_unstructured_text_element,
+        )
+    except Exception as e:
+        msg = f"Failed to extract text from ODT: {e!s}"
+        raise TextExtractionError(msg) from e
+
+
 def _partition_unstructured_file(
     file_content: bytes,
     *,
@@ -967,6 +985,12 @@ def _load_partition_epub() -> Callable[..., Sequence[Any]]:
     from unstructured.partition.epub import partition_epub  # noqa: PLC0415
 
     return partition_epub
+
+
+def _load_partition_odt() -> Callable[..., Sequence[Any]]:
+    from unstructured.partition.odt import partition_odt  # noqa: PLC0415
+
+    return partition_odt
 
 
 def _render_unstructured_text_element(element: Any) -> str:
@@ -1141,6 +1165,13 @@ def _build_text_extractor_registry() -> _TextExtractorRegistry:
             extractor=_extract_text_from_epub,
             mime_types=frozenset({"application/epub+zip"}),
             file_extensions=frozenset({".epub"}),
+            requires_unstructured_config=True,
+        ),
+        _ExtractorRegistration(
+            name="odt",
+            extractor=_extract_text_from_odt,
+            mime_types=frozenset({"application/vnd.oasis.opendocument.text"}),
+            file_extensions=frozenset({".odt"}),
             requires_unstructured_config=True,
         ),
         _ExtractorRegistration(

--- a/tests/file/test_file_factory.py
+++ b/tests/file/test_file_factory.py
@@ -26,5 +26,18 @@ def test_get_file_type_by_mime_type_recognizes_document_office_mime_types() -> N
     assert get_file_type_by_mime_type("application/wps-office.wps") == FileType.DOCUMENT
 
 
+def test_get_file_type_by_mime_type_ignores_parameters() -> None:
+    assert (
+        get_file_type_by_mime_type("application/pdf; charset=binary")
+        == FileType.DOCUMENT
+    )
+    assert (
+        get_file_type_by_mime_type(
+            "application/vnd.oasis.opendocument.text; charset=utf-8",
+        )
+        == FileType.DOCUMENT
+    )
+
+
 def test_get_file_type_by_mime_type_returns_custom_for_unknown_type() -> None:
     assert get_file_type_by_mime_type("application/octet-stream") == FileType.CUSTOM

--- a/tests/file/test_file_factory.py
+++ b/tests/file/test_file_factory.py
@@ -39,5 +39,9 @@ def test_get_file_type_by_mime_type_ignores_parameters() -> None:
     )
 
 
+def test_get_file_type_by_mime_type_requires_top_level_media_type() -> None:
+    assert get_file_type_by_mime_type("application/image-metadata") == FileType.CUSTOM
+
+
 def test_get_file_type_by_mime_type_returns_custom_for_unknown_type() -> None:
     assert get_file_type_by_mime_type("application/octet-stream") == FileType.CUSTOM

--- a/tests/file/test_file_factory.py
+++ b/tests/file/test_file_factory.py
@@ -10,8 +10,20 @@ def test_standardize_file_type_recognizes_document_extension() -> None:
     assert standardize_file_type(extension=".txt") == FileType.DOCUMENT
 
 
+def test_standardize_file_type_recognizes_opendocument_extension() -> None:
+    assert standardize_file_type(extension=".odt") == FileType.DOCUMENT
+
+
 def test_standardize_file_type_falls_back_to_mime_type() -> None:
     assert standardize_file_type(mime_type="video/mp4") == FileType.VIDEO
+
+
+def test_get_file_type_by_mime_type_recognizes_document_office_mime_types() -> None:
+    assert (
+        get_file_type_by_mime_type("application/vnd.oasis.opendocument.text")
+        == FileType.DOCUMENT
+    )
+    assert get_file_type_by_mime_type("application/wps-office.wps") == FileType.DOCUMENT
 
 
 def test_get_file_type_by_mime_type_returns_custom_for_unknown_type() -> None:

--- a/tests/nodes/document_extractor/test_dispatch.py
+++ b/tests/nodes/document_extractor/test_dispatch.py
@@ -77,6 +77,50 @@ def test_extract_text_by_mime_type_routes_registered_extractor() -> None:
     assert extracted == "# comment\nfoo: bar"
 
 
+@pytest.mark.parametrize(
+    ("route_kind", "file_kind"),
+    [
+        ("extension", ".odt"),
+        ("mime_type", "application/vnd.oasis.opendocument.text"),
+    ],
+)
+def test_opendocument_text_routes_to_unstructured_extractor(
+    monkeypatch: pytest.MonkeyPatch,
+    route_kind: str,
+    file_kind: str,
+) -> None:
+    calls = []
+
+    def extract_odt(
+        file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+    ) -> str:
+        calls.append((file_content, unstructured_api_config))
+        return "OpenDocument text"
+
+    monkeypatch.setattr(document_extractor_node, "_extract_text_from_odt", extract_odt)
+    monkeypatch.setattr(
+        document_extractor_node,
+        "_TEXT_EXTRACTOR_REGISTRY",
+        document_extractor_node._build_text_extractor_registry(),
+    )
+
+    if route_kind == "extension":
+        extracted = document_extractor_node._extract_text_by_file_extension(
+            file_content=b"odt",
+            file_extension=file_kind,
+            unstructured_api_config=UnstructuredApiConfig(),
+        )
+    else:
+        extracted = document_extractor_node._extract_text_by_mime_type(
+            file_content=b"odt",
+            mime_type=file_kind,
+            unstructured_api_config=UnstructuredApiConfig(),
+        )
+
+    assert extracted == "OpenDocument text"
+    assert calls == [(b"odt", UnstructuredApiConfig())]
+
+
 def test_extract_text_from_file_prefers_extension_over_mime_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -383,6 +427,7 @@ def test_partition_unstructured_file_uses_api_partition(
         (document_extractor_node._extract_text_from_ppt, "PPT"),
         (document_extractor_node._extract_text_from_pptx, "PPTX"),
         (document_extractor_node._extract_text_from_epub, "EPUB"),
+        (document_extractor_node._extract_text_from_odt, "ODT"),
     ],
 )
 def test_unstructured_extractors_convert_partition_errors(

--- a/tests/nodes/document_extractor/test_dispatch.py
+++ b/tests/nodes/document_extractor/test_dispatch.py
@@ -78,23 +78,27 @@ def test_extract_text_by_mime_type_routes_registered_extractor() -> None:
 
 
 @pytest.mark.parametrize(
-    ("route_kind", "file_kind"),
+    ("extract", "route_kwargs"),
     [
-        ("extension", ".odt"),
-        ("mime_type", "application/vnd.oasis.opendocument.text"),
+        (
+            document_extractor_node._extract_text_by_file_extension,
+            {"file_extension": ".odt"},
+        ),
+        (
+            document_extractor_node._extract_text_by_mime_type,
+            {"mime_type": "application/vnd.oasis.opendocument.text"},
+        ),
     ],
 )
 def test_opendocument_text_routes_to_unstructured_extractor(
     monkeypatch: pytest.MonkeyPatch,
-    route_kind: str,
-    file_kind: str,
+    extract: Any,
+    route_kwargs: dict[str, str],
 ) -> None:
-    calls = []
-
     def extract_odt(
-        file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
+        _file_content: bytes, *, unstructured_api_config: UnstructuredApiConfig
     ) -> str:
-        calls.append((file_content, unstructured_api_config))
+        _ = unstructured_api_config
         return "OpenDocument text"
 
     monkeypatch.setattr(document_extractor_node, "_extract_text_from_odt", extract_odt)
@@ -104,21 +108,14 @@ def test_opendocument_text_routes_to_unstructured_extractor(
         document_extractor_node._build_text_extractor_registry(),
     )
 
-    if route_kind == "extension":
-        extracted = document_extractor_node._extract_text_by_file_extension(
+    assert (
+        extract(
             file_content=b"odt",
-            file_extension=file_kind,
             unstructured_api_config=UnstructuredApiConfig(),
+            **route_kwargs,
         )
-    else:
-        extracted = document_extractor_node._extract_text_by_mime_type(
-            file_content=b"odt",
-            mime_type=file_kind,
-            unstructured_api_config=UnstructuredApiConfig(),
-        )
-
-    assert extracted == "OpenDocument text"
-    assert calls == [(b"odt", UnstructuredApiConfig())]
+        == "OpenDocument text"
+    )
 
 
 def test_extract_text_from_file_prefers_extension_over_mime_type(


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #202

## Summary

- classify `.odt` and `application/vnd.oasis.opendocument.text` as document files
- classify common WPS Office document MIME types as document files
- add an ODT document extractor that reuses the existing unstructured partition path
- cover file type standardization, extractor dispatch, and ODT error wrapping with tests

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation

## Validation

- `uv run pytest tests/file/test_file_factory.py tests/nodes/document_extractor/test_dispatch.py -q`
- `uv run ruff format --check src/graphon/file/constants.py src/graphon/file/file_factory.py src/graphon/nodes/document_extractor/node.py tests/file/test_file_factory.py tests/nodes/document_extractor/test_dispatch.py`
- `uv run ruff check src/graphon/file/constants.py src/graphon/file/file_factory.py src/graphon/nodes/document_extractor/node.py tests/file/test_file_factory.py tests/nodes/document_extractor/test_dispatch.py`
- `uv run ty check`
- `uv run pytest`
- `uv run prek validate-config prek.toml && uv lock --check && uv run ruff format --check && uv run ruff check && uv run ty check`