### PR TITLE
refactor(variables)!: extract template resolution helper

### DIFF
--- a/src/graphon/dsl/tool_runtime.py
+++ b/src/graphon/dsl/tool_runtime.py
@@ -17,6 +17,7 @@ from graphon.nodes.tool_runtime_entities import (
     ToolRuntimeParameter,
 )
 from graphon.runtime.variable_pool import VariablePool
+from graphon.variables.template_resolution import convert_template
 
 from .entities import DslToolCredential
 from .slim.client import SlimClient, SlimClientConfig, SlimClientError
@@ -246,7 +247,7 @@ class _SlimToolParameterResolver:
             case ToolInputType.MIXED:
                 if self.variable_pool is None:
                     return str(value)
-                return self.variable_pool.convert_template(str(value)).text
+                return convert_template(self.variable_pool, str(value)).text
             case ToolInputType.VARIABLE:
                 if self.variable_pool is None:
                     return _MISSING

--- a/src/graphon/nodes/answer/answer_node.py
+++ b/src/graphon/nodes/answer/answer_node.py
@@ -17,6 +17,7 @@ from graphon.variables.segments import (
     FileSegment,
     Segment,
 )
+from graphon.variables.template_resolution import convert_template
 
 
 class AnswerNode(Node[AnswerNodeData]):
@@ -30,7 +31,8 @@ class AnswerNode(Node[AnswerNodeData]):
 
     @override
     def _run(self) -> NodeRunResult:
-        segments = self.graph_runtime_state.variable_pool.convert_template(
+        segments = convert_template(
+            self.graph_runtime_state.variable_pool,
             self.node_data.answer,
         )
         files = self._extract_files_from_segments(segments.value)

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -13,6 +13,7 @@ from graphon.file.enums import FileTransferMethod
 from graphon.http import HttpClientProtocol, HttpResponse
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import ArrayFileSegment, FileSegment
+from graphon.variables.template_resolution import convert_template
 
 from ..protocols import FileManagerProtocol
 from .entities import (
@@ -93,7 +94,8 @@ class Executor:
             if node_data.authorization.config is None:
                 msg = "authorization config is required"
                 raise AuthorizationConfigError(msg)
-            node_data.authorization.config.api_key = variable_pool.convert_template(
+            node_data.authorization.config.api_key = convert_template(
+                variable_pool,
                 node_data.authorization.config.api_key,
             ).text
             # Validate that API key is not empty after template conversion
@@ -143,7 +145,7 @@ class Executor:
         self._init_body()
 
     def _init_url(self) -> None:
-        self.url = self.variable_pool.convert_template(self.node_data.url).text
+        self.url = convert_template(self.variable_pool, self.node_data.url).text
 
         # check if url is a valid URL
         if not self.url:
@@ -170,8 +172,8 @@ class Executor:
 
             value_str = value[0].strip() if value else ""
             result.append((
-                self.variable_pool.convert_template(key).text,
-                self.variable_pool.convert_template(value_str).text,
+                convert_template(self.variable_pool, key).text,
+                convert_template(self.variable_pool, value_str).text,
             ))
 
         if result:
@@ -190,7 +192,7 @@ class Executor:
             'aa\n cc : dd'   -> {'aa': '', 'cc': 'dd'}
 
         """
-        headers = self.variable_pool.convert_template(self.node_data.headers).text
+        headers = convert_template(self.variable_pool, self.node_data.headers).text
         self.headers = {
             key.strip(): (value[0].strip() if value else "")
             for line in headers.splitlines()
@@ -237,11 +239,11 @@ class Executor:
 
     def _init_raw_text_body(self, data: Sequence[BodyData]) -> None:
         item = self._require_single_body_item(data, body_type="raw-text")
-        self.content = self.variable_pool.convert_template(item.value).text
+        self.content = convert_template(self.variable_pool, item.value).text
 
     def _init_json_body(self, data: Sequence[BodyData]) -> None:
         item = self._require_single_body_item(data, body_type="json")
-        json_string = self.variable_pool.convert_template(item.value).text
+        json_string = convert_template(self.variable_pool, item.value).text
         try:
             repaired = repair_json(json_string)
             self.json = json.loads(repaired, strict=False)
@@ -260,9 +262,10 @@ class Executor:
 
     def _init_urlencoded_body(self, data: Sequence[BodyData]) -> None:
         self.data = {
-            self.variable_pool.convert_template(
+            convert_template(
+                self.variable_pool,
                 item.key,
-            ).text: self.variable_pool.convert_template(item.value).text
+            ).text: convert_template(self.variable_pool, item.value).text
             for item in data
         }
 
@@ -274,9 +277,10 @@ class Executor:
 
     def _build_form_text_data(self, data: Sequence[BodyData]) -> dict[str, str]:
         return {
-            self.variable_pool.convert_template(
+            convert_template(
+                self.variable_pool,
                 item.key,
-            ).text: self.variable_pool.convert_template(item.value).text
+            ).text: convert_template(self.variable_pool, item.value).text
             for item in data
             if item.type == "text"
         }
@@ -286,7 +290,7 @@ class Executor:
         data: Sequence[BodyData],
     ) -> dict[str, Sequence[str]]:
         return {
-            self.variable_pool.convert_template(item.key).text: item.file
+            convert_template(self.variable_pool, item.key).text: item.file
             for item in data
             if item.type == "file"
         }

--- a/src/graphon/nodes/list_operator/node.py
+++ b/src/graphon/nodes/list_operator/node.py
@@ -14,6 +14,7 @@ from graphon.variables.segments import (
     ArraySegment,
     ArrayStringSegment,
 )
+from graphon.variables.template_resolution import convert_template
 
 from .entities import FilterOperator, ListOperatorNodeData, Order
 from .exc import (
@@ -196,7 +197,8 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
                 if not isinstance(condition.value, str):
                     msg = f"Invalid filter value: {condition.value}"
                     raise InvalidFilterValueError(msg)
-                value = self.graph_runtime_state.variable_pool.convert_template(
+                value = convert_template(
+                    self.graph_runtime_state.variable_pool,
                     condition.value,
                 ).text
                 filter_func = _get_string_filter_func(
@@ -209,7 +211,8 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
                 if not isinstance(condition.value, str):
                     msg = f"Invalid filter value: {condition.value}"
                     raise InvalidFilterValueError(msg)
-                value = self.graph_runtime_state.variable_pool.convert_template(
+                value = convert_template(
+                    self.graph_runtime_state.variable_pool,
                     condition.value,
                 ).text
                 filter_func = _get_number_filter_func(
@@ -220,7 +223,8 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
                 variable = variable.model_copy(update={"value": result})
             elif isinstance(variable, ArrayFileSegment):
                 if isinstance(condition.value, str):
-                    value = self.graph_runtime_state.variable_pool.convert_template(
+                    value = convert_template(
+                        self.graph_runtime_state.variable_pool,
                         condition.value,
                     ).text
                 elif isinstance(condition.value, bool):
@@ -282,7 +286,8 @@ class ListOperatorNode(Node[ListOperatorNodeData]):
         variable: _SUPPORTED_TYPES_ALIAS,
     ) -> _SUPPORTED_TYPES_ALIAS:
         value = int(
-            self.graph_runtime_state.variable_pool.convert_template(
+            convert_template(
+                self.graph_runtime_state.variable_pool,
                 self.node_data.extract_by.serial,
             ).text,
         )

--- a/src/graphon/nodes/llm/llm_utils.py
+++ b/src/graphon/nodes/llm/llm_utils.py
@@ -35,6 +35,7 @@ from graphon.variables.segments import (
     FileSegment,
     NoneSegment,
 )
+from graphon.variables.template_resolution import convert_template
 
 from .entities import (
     LLMNodeChatModelMessage,
@@ -364,7 +365,7 @@ def handle_list_messages(
             continue
 
         template = message.text.replace(CONTEXT_PLACEHOLDER, context)
-        segment_group = variable_pool.convert_template(template)
+        segment_group = convert_template(variable_pool, template)
         file_contents: list[PromptMessageContentUnionTypes] = []
         for segment in segment_group.value:
             if isinstance(segment, ArrayFileSegment):
@@ -454,7 +455,7 @@ def handle_completion_template(
         )
     else:
         template_text = template.text.replace(CONTEXT_PLACEHOLDER, context)
-        result_text = variable_pool.convert_template(template_text).text
+        result_text = convert_template(variable_pool, template_text).text
     return [
         combine_message_content_with_role(
             contents=[TextPromptMessageContent(data=result_text)],
@@ -627,8 +628,8 @@ def resolve_completion_params_variables(
     Security notes:
     - Resolved values are length-capped to ``MAX_RESOLVED_VALUE_LENGTH`` to
       prevent denial-of-service through excessively large variable payloads.
-    - This follows the same ``VariablePool.convert_template`` pattern used across
-      Dify (Answer Node, HTTP Request Node, Agent Node, etc.).  The downstream
+    - This follows the shared Graphon template-resolution path used across
+      nodes (Answer Node, HTTP Request Node, Agent Node, etc.). The downstream
       model plugin receives these values as structured JSON key-value pairs — they
       are never concatenated into raw HTTP headers or SQL queries.
     - Numeric/boolean coercion is applied so that variables holding ``"0.7"`` are
@@ -641,7 +642,7 @@ def resolve_completion_params_variables(
     resolved: dict[str, Any] = {}
     for key, value in completion_params.items():
         if isinstance(value, str) and VARIABLE_PATTERN.search(value):
-            segment_group = variable_pool.convert_template(value)
+            segment_group = convert_template(variable_pool, value)
             text = segment_group.text
             if len(text) > MAX_RESOLVED_VALUE_LENGTH:
                 logger.warning(

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -86,6 +86,7 @@ from graphon.variables.segments import (
     ObjectSegment,
     StringSegment,
 )
+from graphon.variables.template_resolution import convert_template
 
 from . import llm_utils
 from .entities import (
@@ -1881,7 +1882,7 @@ class LLMNode(Node[LLMNodeData]):
         vision_detail_config: ImagePromptMessageContent.DETAIL,
     ) -> list[PromptMessage]:
         template = message.text.replace(llm_utils.CONTEXT_PLACEHOLDER, context)
-        segment_group = variable_pool.convert_template(template)
+        segment_group = convert_template(variable_pool, template)
         prompt_messages: list[PromptMessage] = []
         plain_text = segment_group.text
         if plain_text:
@@ -2312,7 +2313,7 @@ def _handle_completion_template(
         )
     else:
         template_text = template.text.replace(llm_utils.CONTEXT_PLACEHOLDER, context)
-        result_text = variable_pool.convert_template(template_text).text
+        result_text = convert_template(variable_pool, template_text).text
     prompt_message = _combine_message_content_with_role(
         contents=[TextPromptMessageContent(data=result_text)],
         role=PromptMessageRole.USER,

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -48,6 +48,7 @@ from graphon.nodes.llm.runtime_protocols import (
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.factory import build_segment_with_type
+from graphon.variables.template_resolution import convert_template
 from graphon.variables.types import ArrayValidation, SegmentType
 
 from .entities import ParameterConfig, ParameterExtractorNodeData
@@ -975,7 +976,10 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     ) -> list[LLMNodeChatModelMessage]:
         input_text = query
         memory_str = ""
-        instruction = variable_pool.convert_template(node_data.instruction or "").text
+        instruction = convert_template(
+            variable_pool,
+            node_data.instruction or "",
+        ).text
 
         if memory and node_data.memory and node_data.memory.window:
             memory_str = llm_utils.fetch_memory_text(
@@ -1027,7 +1031,10 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
     ) -> list[LLMNodeChatModelMessage] | LLMNodeCompletionModelPromptTemplate:
         input_text = query
         memory_str = ""
-        instruction = variable_pool.convert_template(node_data.instruction or "").text
+        instruction = convert_template(
+            variable_pool,
+            node_data.instruction or "",
+        ).text
 
         if memory and node_data.memory and node_data.memory.window:
             memory_str = llm_utils.fetch_memory_text(

--- a/src/graphon/nodes/question_classifier/question_classifier_node.py
+++ b/src/graphon/nodes/question_classifier/question_classifier_node.py
@@ -45,6 +45,7 @@ from graphon.nodes.llm.runtime_protocols import (
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.template_rendering import Jinja2TemplateRenderer
 from graphon.utils.json_in_md_parser import parse_and_check_json_markdown
+from graphon.variables.template_resolution import convert_template
 
 from .entities import QuestionClassifierNodeData
 from .exc import InvalidModelTypeError
@@ -262,7 +263,8 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             else None
         )
         query = variable.value if variable else None
-        node_data.instruction = variable_pool.convert_template(
+        node_data.instruction = convert_template(
+            variable_pool,
             node_data.instruction or "",
         ).text
         model_instance = self._prepare_model_instance(variable_pool=variable_pool)
@@ -285,7 +287,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
         }
         rendered_classes = [
             class_.model_copy(
-                update={"name": variable_pool.convert_template(class_.name).text},
+                update={"name": convert_template(variable_pool, class_.name).text},
             )
             for class_ in node_data.classes
         ]

--- a/src/graphon/nodes/tool/tool_node.py
+++ b/src/graphon/nodes/tool/tool_node.py
@@ -34,6 +34,7 @@ from graphon.nodes.tool_runtime_entities import (
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
 from graphon.runtime.variable_pool import VariablePool
 from graphon.variables.segments import ArrayFileSegment
+from graphon.variables.template_resolution import convert_template
 
 from .entities import ToolInputType, ToolNodeData
 from .exc import ToolFileError, ToolNodeError, ToolParameterError
@@ -247,7 +248,7 @@ class ToolNode(Node[ToolNodeData]):
                     continue
                 parameter_value = variable.value
             elif tool_input.type in _TEMPLATE_TOOL_INPUT_TYPES:
-                segment_group = variable_pool.convert_template(str(tool_input.value))
+                segment_group = convert_template(variable_pool, str(tool_input.value))
                 parameter_value = segment_group.log if for_log else segment_group.text
             else:
                 msg = f"Unknown tool input type '{tool_input.type}'"

--- a/src/graphon/runtime/variable_pool.py
+++ b/src/graphon/runtime/variable_pool.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
@@ -16,15 +15,10 @@ from graphon.variables.factory import (
     build_segment,
     segment_to_variable,
 )
-from graphon.variables.segment_group import SegmentGroup
 from graphon.variables.segments import FileSegment, ObjectSegment, Segment
 from graphon.variables.variables import RAGPipelineVariableInput, Variable
 
 type VariableValue = str | int | float | dict[str, object] | list[object] | File
-
-VARIABLE_PATTERN = re.compile(
-    r"\{\{#([a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10})#\}\}",
-)
 
 
 def _default_variable_dictionary() -> defaultdict[str, dict[str, Variable]]:
@@ -322,16 +316,6 @@ class VariablePool(BaseModel):
             return
         key, hash_key = self._selector_to_keys(selector)
         self.variable_dictionary[key].pop(hash_key, None)
-
-    def convert_template(self, template: str, /) -> SegmentGroup:
-        parts = VARIABLE_PATTERN.split(template)
-        segments: list[Segment] = []
-        for part in filter(lambda x: x, parts):
-            if "." in part and (variable := self.get(part.split("."))):
-                segments.append(variable)
-            else:
-                segments.append(build_segment(part))
-        return SegmentGroup(value=segments)
 
     def get_file(self, selector: Sequence[str], /) -> FileSegment | None:
         segment = self.get(selector)

--- a/src/graphon/utils/condition/processor.py
+++ b/src/graphon/utils/condition/processor.py
@@ -6,12 +6,13 @@ from typing_extensions import TypeIs
 
 from graphon.file import file_manager
 from graphon.file.enums import FileAttribute
-from graphon.runtime.variable_pool import VariablePool
+from graphon.runtime.graph_runtime_state_protocol import ReadOnlyVariablePool
 from graphon.variables.segments import (
     ArrayBooleanSegment,
     ArrayFileSegment,
     BooleanSegment,
 )
+from graphon.variables.template_resolution import convert_template
 
 from .entities import Condition, SubCondition, SupportedComparisonOperator
 
@@ -78,7 +79,7 @@ class ConditionProcessor:
     def process_conditions(
         self,
         *,
-        variable_pool: VariablePool,
+        variable_pool: ReadOnlyVariablePool,
         conditions: Sequence[Condition],
         operator: Literal["and", "or"],
     ) -> ConditionCheckResult:
@@ -176,12 +177,13 @@ def _is_bool_sequence(value: object) -> TypeIs[Sequence[bool]]:
 def _prepare_expected_value(
     *,
     variable: Any,
-    variable_pool: VariablePool,
+    variable_pool: ReadOnlyVariablePool,
     expected_value: str | Sequence[str] | bool | Sequence[bool] | None,
 ) -> str | Sequence[str] | bool | list[bool] | None:
     match expected_value:
         case str():
-            normalized_expected_value = variable_pool.convert_template(
+            normalized_expected_value = convert_template(
+                variable_pool,
                 expected_value,
             ).text
         case _:

--- a/src/graphon/variables/template_resolution.py
+++ b/src/graphon/variables/template_resolution.py
@@ -16,8 +16,7 @@ VARIABLE_PATTERN = re.compile(
 
 class _TemplateLookupPool(Protocol):
     @abstractmethod
-    def get(self, selector: Sequence[str], /) -> Segment | None:
-        ...
+    def get(self, selector: Sequence[str], /) -> Segment | None: ...
 
 
 def convert_template(

--- a/src/graphon/variables/template_resolution.py
+++ b/src/graphon/variables/template_resolution.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+
+from graphon.runtime.graph_runtime_state_protocol import ReadOnlyVariablePool
+from graphon.variables.factory import build_segment
+from graphon.variables.segment_group import SegmentGroup
+from graphon.variables.segments import Segment
+
+VARIABLE_PATTERN = re.compile(
+    r"\{\{#([a-zA-Z0-9_]{1,50}(?:\.[a-zA-Z_][a-zA-Z0-9_]{0,29}){1,10})#\}\}",
+)
+
+
+def convert_template(
+    pool: ReadOnlyVariablePool,
+    template: str,
+    /,
+) -> SegmentGroup:
+    segments: list[Segment] = []
+    for part in filter(None, VARIABLE_PATTERN.split(template)):
+        if "." in part:
+            variable = pool.get(part.split("."))
+            if variable is not None:
+                segments.append(variable)
+                continue
+        segments.append(build_segment(part))
+    return SegmentGroup(value=segments)

--- a/src/graphon/variables/template_resolution.py
+++ b/src/graphon/variables/template_resolution.py
@@ -14,7 +14,7 @@ VARIABLE_PATTERN = re.compile(
 )
 
 
-class TemplateLookupPool(Protocol):
+class _TemplateLookupPool(Protocol):
     @abstractmethod
     def get(self, selector: Sequence[str], /) -> Segment | None:
         """Return a segment for the selector when it exists."""
@@ -22,7 +22,7 @@ class TemplateLookupPool(Protocol):
 
 
 def convert_template(
-    pool: TemplateLookupPool,
+    pool: _TemplateLookupPool,
     template: str,
     /,
 ) -> SegmentGroup:

--- a/src/graphon/variables/template_resolution.py
+++ b/src/graphon/variables/template_resolution.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import re
+from abc import abstractmethod
+from collections.abc import Sequence
+from typing import Protocol
 
-from graphon.runtime.graph_runtime_state_protocol import ReadOnlyVariablePool
 from graphon.variables.factory import build_segment
 from graphon.variables.segment_group import SegmentGroup
 from graphon.variables.segments import Segment
@@ -12,8 +14,15 @@ VARIABLE_PATTERN = re.compile(
 )
 
 
+class TemplateLookupPool(Protocol):
+    @abstractmethod
+    def get(self, selector: Sequence[str], /) -> Segment | None:
+        """Return a segment for the selector when it exists."""
+        ...
+
+
 def convert_template(
-    pool: ReadOnlyVariablePool,
+    pool: TemplateLookupPool,
     template: str,
     /,
 ) -> SegmentGroup:

--- a/src/graphon/variables/template_resolution.py
+++ b/src/graphon/variables/template_resolution.py
@@ -17,7 +17,6 @@ VARIABLE_PATTERN = re.compile(
 class _TemplateLookupPool(Protocol):
     @abstractmethod
     def get(self, selector: Sequence[str], /) -> Segment | None:
-        """Return a segment for the selector when it exists."""
         ...
 
 
@@ -28,10 +27,8 @@ def convert_template(
 ) -> SegmentGroup:
     segments: list[Segment] = []
     for part in filter(None, VARIABLE_PATTERN.split(template)):
-        if "." in part:
-            variable = pool.get(part.split("."))
-            if variable is not None:
-                segments.append(variable)
-                continue
-        segments.append(build_segment(part))
+        if "." in part and (variable := pool.get(part.split("."))) is not None:
+            segments.append(variable)
+        else:
+            segments.append(build_segment(part))
     return SegmentGroup(value=segments)

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -116,9 +116,6 @@ def test_question_classifier_constructor_accepts_dependency_bundle(
     })
     variable_pool = MagicMock()
     variable_pool.get.return_value = SimpleNamespace(value="Question about billing")
-    variable_pool.convert_template.side_effect = lambda value: SimpleNamespace(
-        text=value
-    )
     template_renderer = MagicMock()
     model_instance = MagicMock(
         provider="openai",
@@ -259,9 +256,6 @@ def test_question_classifier_run_returns_custom_class_label(
     })
     variable_pool = MagicMock()
     variable_pool.get.return_value = SimpleNamespace(value="Where is my refund?")
-    variable_pool.convert_template.side_effect = lambda value: SimpleNamespace(
-        text=value
-    )
     template_renderer = MagicMock()
     node = _build_question_classifier_node(
         node_data,
@@ -331,9 +325,6 @@ def test_question_classifier_run_falls_back_to_canonical_class_label(
     })
     variable_pool = MagicMock()
     variable_pool.get.return_value = SimpleNamespace(value="Where is my refund?")
-    variable_pool.convert_template.side_effect = lambda value: SimpleNamespace(
-        text=value
-    )
     template_renderer = MagicMock()
     node = _build_question_classifier_node(
         node_data,

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -6,6 +6,7 @@ from graphon.variables.segments import (
     ObjectSegment,
     StringSegment,
 )
+from graphon.variables.template_resolution import convert_template
 from graphon.variables.variables import (
     RAGPipelineVariable,
     RAGPipelineVariableInput,
@@ -174,7 +175,7 @@ class TestVariablePoolGetNotModifyVariableDictionary:
     def test_convert_to_template_should_not_introduce_extra_keys(self) -> None:
         pool = VariablePool.empty()
         pool.add([self._NODE_ID, self._VAR_NAME], 0)
-        pool.convert_template("The start.name is {{#start.name#}}")
+        convert_template(pool, "The start.name is {{#start.name#}}")
         assert "The start" not in pool.variable_dictionary
 
     def test_get_should_not_modify_variable_dictionary(self) -> None:

--- a/tests/runtime/test_variable_pool.py
+++ b/tests/runtime/test_variable_pool.py
@@ -6,7 +6,6 @@ from graphon.variables.segments import (
     ObjectSegment,
     StringSegment,
 )
-from graphon.variables.template_resolution import convert_template
 from graphon.variables.variables import (
     RAGPipelineVariable,
     RAGPipelineVariableInput,
@@ -171,12 +170,6 @@ class TestVariablePoolGetAndNestedAttribute:
 class TestVariablePoolGetNotModifyVariableDictionary:
     _NODE_ID = "start"
     _VAR_NAME = "name"
-
-    def test_convert_to_template_should_not_introduce_extra_keys(self) -> None:
-        pool = VariablePool.empty()
-        pool.add([self._NODE_ID, self._VAR_NAME], 0)
-        convert_template(pool, "The start.name is {{#start.name#}}")
-        assert "The start" not in pool.variable_dictionary
 
     def test_get_should_not_modify_variable_dictionary(self) -> None:
         pool = VariablePool.empty()

--- a/tests/utils/test_condition_processor.py
+++ b/tests/utils/test_condition_processor.py
@@ -1,3 +1,4 @@
+from graphon.runtime import ReadOnlyVariablePoolWrapper
 from graphon.runtime.variable_pool import VariablePool
 from graphon.utils.condition.entities import Condition
 from graphon.utils.condition.processor import ConditionProcessor
@@ -122,3 +123,24 @@ def test_process_conditions_contains_supports_string_and_list_values() -> None:
 
     assert text_result.final_result is True
     assert list_result.final_result is True
+
+
+def test_process_conditions_resolves_templates_from_read_only_variable_pool() -> None:
+    condition_processor = ConditionProcessor()
+    variable_pool = VariablePool()
+    variable_pool.add(["test_node_id", "text"], "graphon")
+    variable_pool.add(["test_node_id", "needle"], "pho")
+
+    result = condition_processor.process_conditions(
+        variable_pool=ReadOnlyVariablePoolWrapper(variable_pool),
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "text"],
+                comparison_operator="contains",
+                value="{{#test_node_id.needle#}}",
+            ),
+        ],
+        operator="and",
+    )
+
+    assert result.final_result is True

--- a/tests/variables/test_template_resolution.py
+++ b/tests/variables/test_template_resolution.py
@@ -1,6 +1,22 @@
+import ast
+import inspect
+from collections.abc import Sequence
+from pathlib import Path
+
 from graphon.runtime.read_only_wrappers import ReadOnlyVariablePoolWrapper
 from graphon.runtime.variable_pool import VariablePool
+from graphon.variables import template_resolution
+from graphon.variables.segments import Segment
 from graphon.variables.template_resolution import convert_template
+
+
+class _LookupOnlyPool:
+    def get(self, selector: Sequence[str], /) -> Segment | None:
+        if list(selector) == ["start", "name"]:
+            pool = VariablePool.empty()
+            pool.add(("start", "name"), "Joe")
+            return pool.get(("start", "name"))
+        return None
 
 
 class TestConvertTemplate:
@@ -18,6 +34,46 @@ class TestConvertTemplate:
             "The start.name is ",
             "Joe",
         ]
+
+    def test_accepts_minimal_lookup_protocol(self) -> None:
+        rendered = convert_template(
+            _LookupOnlyPool(),
+            "The start.name is {{#start.name#}}",
+        )
+
+        assert rendered.text == "The start.name is Joe"
+
+    def test_uses_local_minimal_lookup_protocol(self) -> None:
+        module_path = Path(template_resolution.__file__)
+        parsed = ast.parse(module_path.read_text())
+
+        imports_read_only_pool = any(
+            isinstance(node, ast.ImportFrom)
+            and node.module == "graphon.runtime.graph_runtime_state_protocol"
+            and any(alias.name == "ReadOnlyVariablePool" for alias in node.names)
+            for node in parsed.body
+        )
+        assert not imports_read_only_pool
+
+        local_protocols = [
+            cls
+            for cls in vars(template_resolution).values()
+            if inspect.isclass(cls)
+            and cls.__module__ == template_resolution.__name__
+            and getattr(cls, "_is_protocol", False)
+        ]
+        assert len(local_protocols) == 1
+
+        protocol_cls = local_protocols[0]
+        assert protocol_cls.__name__.startswith("_")
+
+        protocol_members = [
+            name
+            for name, value in protocol_cls.__dict__.items()
+            if inspect.isfunction(value) and not name.startswith("__")
+        ]
+        assert protocol_members == ["get"]
+        assert getattr(protocol_cls.__dict__["get"], "__isabstractmethod__", False)
 
     def test_does_not_mutate_variable_dictionary(self) -> None:
         pool = VariablePool.empty()

--- a/tests/variables/test_template_resolution.py
+++ b/tests/variables/test_template_resolution.py
@@ -1,0 +1,31 @@
+from graphon.runtime.read_only_wrappers import ReadOnlyVariablePoolWrapper
+from graphon.runtime.variable_pool import VariablePool
+from graphon.variables.template_resolution import convert_template
+
+
+class TestConvertTemplate:
+    def test_resolves_variables_from_read_only_pool(self) -> None:
+        pool = VariablePool.empty()
+        pool.add(("start", "name"), "Joe")
+
+        rendered = convert_template(
+            ReadOnlyVariablePoolWrapper(pool),
+            "The start.name is {{#start.name#}}",
+        )
+
+        assert rendered.text == "The start.name is Joe"
+        assert [segment.value for segment in rendered.value] == [
+            "The start.name is ",
+            "Joe",
+        ]
+
+    def test_does_not_mutate_variable_dictionary(self) -> None:
+        pool = VariablePool.empty()
+        pool.add(("start", "name"), 0)
+
+        convert_template(
+            ReadOnlyVariablePoolWrapper(pool),
+            "The start.name is {{#start.name#}}",
+        )
+
+        assert "The start" not in pool.variable_dictionary

--- a/tests/variables/test_template_resolution.py
+++ b/tests/variables/test_template_resolution.py
@@ -1,18 +1,6 @@
-from collections.abc import Sequence
-
 from graphon.runtime.read_only_wrappers import ReadOnlyVariablePoolWrapper
 from graphon.runtime.variable_pool import VariablePool
-from graphon.variables.segments import Segment
 from graphon.variables.template_resolution import convert_template
-
-
-class _LookupOnlyPool:
-    def get(self, selector: Sequence[str], /) -> Segment | None:
-        if list(selector) == ["start", "name"]:
-            pool = VariablePool.empty()
-            pool.add(("start", "name"), "Joe")
-            return pool.get(("start", "name"))
-        return None
 
 
 class TestConvertTemplate:
@@ -30,14 +18,6 @@ class TestConvertTemplate:
             "The start.name is ",
             "Joe",
         ]
-
-    def test_accepts_minimal_lookup_protocol(self) -> None:
-        rendered = convert_template(
-            _LookupOnlyPool(),
-            "The start.name is {{#start.name#}}",
-        )
-
-        assert rendered.text == "The start.name is Joe"
 
     def test_does_not_mutate_variable_dictionary(self) -> None:
         pool = VariablePool.empty()

--- a/tests/variables/test_template_resolution.py
+++ b/tests/variables/test_template_resolution.py
@@ -1,11 +1,7 @@
-import ast
-import inspect
 from collections.abc import Sequence
-from pathlib import Path
 
 from graphon.runtime.read_only_wrappers import ReadOnlyVariablePoolWrapper
 from graphon.runtime.variable_pool import VariablePool
-from graphon.variables import template_resolution
 from graphon.variables.segments import Segment
 from graphon.variables.template_resolution import convert_template
 
@@ -42,38 +38,6 @@ class TestConvertTemplate:
         )
 
         assert rendered.text == "The start.name is Joe"
-
-    def test_uses_local_minimal_lookup_protocol(self) -> None:
-        module_path = Path(template_resolution.__file__)
-        parsed = ast.parse(module_path.read_text())
-
-        imports_read_only_pool = any(
-            isinstance(node, ast.ImportFrom)
-            and node.module == "graphon.runtime.graph_runtime_state_protocol"
-            and any(alias.name == "ReadOnlyVariablePool" for alias in node.names)
-            for node in parsed.body
-        )
-        assert not imports_read_only_pool
-
-        local_protocols = [
-            cls
-            for cls in vars(template_resolution).values()
-            if inspect.isclass(cls)
-            and cls.__module__ == template_resolution.__name__
-            and getattr(cls, "_is_protocol", False)
-        ]
-        assert len(local_protocols) == 1
-
-        protocol_cls = local_protocols[0]
-        assert protocol_cls.__name__.startswith("_")
-
-        protocol_members = [
-            name
-            for name, value in protocol_cls.__dict__.items()
-            if inspect.isfunction(value) and not name.startswith("__")
-        ]
-        assert protocol_members == ["get"]
-        assert getattr(protocol_cls.__dict__["get"], "__isabstractmethod__", False)
 
     def test_does_not_mutate_variable_dictionary(self) -> None:
         pool = VariablePool.empty()


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

## Related Issue

Closes #204

## Summary

### What changed

- extracted template expansion into `graphon.variables.template_resolution.convert_template(...)`
- migrated internal call sites away from `VariablePool.convert_template(...)`
- kept `ReadOnlyVariablePool` narrow instead of widening the protocol surface
- added regression coverage for the shared helper and for read-only consumers such as `ConditionProcessor`

### Motivation

The existing shape forced downstream integrations to downcast from `ReadOnlyVariablePool` to the concrete `VariablePool` just to expand `{{#node.var#}}` placeholders.

That was an ownership problem: template resolution is a read-only consumer algorithm over variable lookup, so it should not require callers to know whether the underlying pool is mutable.

### Alternative considered but rejected

I explicitly did not add `convert_template(...)` to `ReadOnlyVariablePool`.

That alternative would make the storage/read protocol own one specific template DSL, widening the contract for every implementation of the protocol.

This PR keeps the boundary narrower by moving template resolution into a shared helper that depends only on read access.

### Validation

- `just test`
- `just check`

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
