### PR TITLE
refactor(model-runtime)!: remove legacy model type aliases

### DIFF
--- a/src/graphon/model_runtime/entities/model_entities.py
+++ b/src/graphon/model_runtime/entities/model_entities.py
@@ -18,11 +18,6 @@ _ORIGIN_MODEL_TYPE_BY_MODEL_TYPE: dict[str, str] = {
     "tts": "tts",
 }
 
-_MODEL_TYPE_BY_ORIGIN_MODEL_TYPE: dict[str, str] = {
-    origin_model_type: model_type
-    for model_type, origin_model_type in _ORIGIN_MODEL_TYPE_BY_MODEL_TYPE.items()
-}
-
 
 class ModelType(StrEnum):
     """Enum class for model type."""
@@ -33,14 +28,6 @@ class ModelType(StrEnum):
     SPEECH2TEXT = auto()
     MODERATION = auto()
     TTS = auto()
-
-    @classmethod
-    def _missing_(cls, value: object) -> ModelType | None:
-        if isinstance(value, str):
-            model_type = _MODEL_TYPE_BY_ORIGIN_MODEL_TYPE.get(value)
-            if model_type is not None:
-                return cls(model_type)
-        return None
 
     def to_origin_model_type(self) -> str:
         """Map `ModelType` back to the provider-native model type string."""

--- a/tests/model_runtime/test_model_dispatch.py
+++ b/tests/model_runtime/test_model_dispatch.py
@@ -531,21 +531,34 @@ class _SpeechToTextRuntimeStub(_ProviderRuntimeStub):
 @pytest.mark.parametrize(
     ("raw_model_type", "expected_model_type"),
     [
-        ("text-generation", ModelType.LLM),
         (ModelType.LLM.value, ModelType.LLM),
-        ("embeddings", ModelType.TEXT_EMBEDDING),
         (ModelType.TEXT_EMBEDDING.value, ModelType.TEXT_EMBEDDING),
-        ("reranking", ModelType.RERANK),
+        (ModelType.RERANK.value, ModelType.RERANK),
         ("speech2text", ModelType.SPEECH2TEXT),
         ("moderation", ModelType.MODERATION),
         ("tts", ModelType.TTS),
     ],
 )
-def test_model_type_accepts_origin_model_type_aliases(
+def test_model_type_accepts_canonical_values(
     raw_model_type: str,
     expected_model_type: ModelType,
 ) -> None:
     assert ModelType(raw_model_type) == expected_model_type
+
+
+@pytest.mark.parametrize(
+    "legacy_model_type",
+    [
+        "text-generation",
+        "embeddings",
+        "reranking",
+    ],
+)
+def test_model_type_rejects_legacy_origin_model_type_aliases(
+    legacy_model_type: str,
+) -> None:
+    with pytest.raises(ValueError, match="is not a valid ModelType"):
+        ModelType(legacy_model_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #206

## Summary

Remove legacy provider-native model type alias parsing from `ModelType` now that the Dify legacy `model_type` migration window has completed.

This keeps canonical Graphon model type values accepted:

- `llm`
- `text-embedding`
- `rerank`
- `speech2text`
- `moderation`
- `tts`

It also keeps `ModelType.to_origin_model_type()` unchanged so Graphon can still map canonical model types to provider-native strings at the outbound provider boundary.

BREAKING CHANGE: `ModelType` no longer accepts legacy provider-native model type strings such as `text-generation`, `embeddings`, or `reranking`. Callers must pass canonical Graphon model type values instead.

Validation:

- `uv run pytest tests/model_runtime/test_model_dispatch.py -k 'model_type_rejects_legacy_origin_model_type_aliases or model_type_accepts_canonical_values or model_type_to_origin_model_type_uses_model_map'`
- `just test`
- `just check`

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] I filled in the ADR field using ADR 0001 as the source of truth
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation