### PR TITLE
fix: handle missing Jinja2 variables gracefully in LLM node

### DIFF
--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -1129,10 +1129,15 @@ class LLMNode(Node[LLMNodeData]):
 
         variables: dict[str, str] = {}
         for variable_selector in node_data.prompt_config.jinja2_variables or []:
-            variable = self._get_required_variable(variable_selector)
-            variables[variable_selector.variable] = self._stringify_jinja_variable(
-                variable,
+            variable = self.graph_runtime_state.variable_pool.get(
+                variable_selector.value_selector,
             )
+            if variable is not None:
+                variables[variable_selector.variable] = self._stringify_jinja_variable(
+                    variable,
+                )
+            else:
+                variables[variable_selector.variable] = ""
         return variables
 
     def _fetch_inputs(self, node_data: LLMNodeData) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Fixes langgenius/dify#38655

When an LLM node uses Jinja2 templates with variables that may not exist in the variable pool (e.g., because they come from a branch path that wasn't taken during workflow execution), `_fetch_jinja_inputs` should return empty strings for missing variables rather than raising `VariableNotFoundError`.

## Changes

- `src/graphon/nodes/llm/node.py`: Changed `_fetch_jinja_inputs` to use `variable_pool.get()` directly instead of `_get_required_variable()`. When a variable is not found in the pool, it defaults to an empty string instead of throwing `VariableNotFoundError`.

## Rationale

This is consistent with how `_render_jinja2_message` (in the same file) already handles missing variables: `variable.to_object() if variable else ""`. The Jinja2 template can use `{% if var is defined %}` to handle optional variables, but that check never gets reached because the code fails before rendering.