### PR TITLE
fix: skip missing jinja2 variables instead of raising LLMNodeError

### DIFF
--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -1129,7 +1129,14 @@ class LLMNode(Node[LLMNodeData]):
 
         variables: dict[str, str] = {}
         for variable_selector in node_data.prompt_config.jinja2_variables or []:
-            variable = self._get_required_variable(variable_selector)
+            variable = self.graph_runtime_state.variable_pool.get(
+                variable_selector.value_selector,
+            )
+            if variable is None:
+                # Variable not in pool — the Jinja2 template handles this
+                # gracefully with {% if variable is defined %}, so skip it
+                # rather than raising VariableNotFoundError.
+                continue
             variables[variable_selector.variable] = self._stringify_jinja_variable(
                 variable,
             )


### PR DESCRIPTION
Fixes langgenius/dify#38655

## Summary

When a Jinja2 variable referenced in `prompt_config.jinja2_variables` is not present in the variable pool (e.g. because a conditional branch was not taken), `_fetch_jinja_inputs` raises `VariableNotFoundError` and the workflow fails — even though the Jinja2 template already handles optional variables with constructs like `{% if variable is defined %}`.

## Root Cause

`_fetch_jinja_inputs` calls `_get_required_variable` which raises `VariableNotFoundError` when the variable pool returns `None`. The sibling code path `_render_jinja2_message` already handles this correctly by using `variable_pool.get()` and falling back to empty string.

## Fix

Replace the `_get_required_variable` call in `_fetch_jinja_inputs` with a direct `variable_pool.get()` and skip variables that are not in the pool. This aligns with how `_render_jinja2_message` already handles missing variables.

## Test plan

- Existing test `test_fetch_jinja_inputs_raises_for_missing_variable` in dify's test suite updated to expect the new (skip) behavior
- No regressions: `_fetch_jinja_inputs` is called during LLM node `_run()` — missing variables are simply omitted from the returned dict, which is used for input collection, not the Jinja2 rendering itself