### PR TITLE
feat: mask secrets in run-log serialization and HTTP request logs

### DIFF
--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -308,32 +308,19 @@ class Executor:
         self._log_data = log_data
 
     def _init_form_data_body(self, data: Sequence[BodyData]) -> None:
-        self.data = self._build_form_text_data(data)
-        self._log_data = self._build_form_text_log_data(data)
+        real_data: dict[str, str] = {}
+        log_data: dict[str, str] = {}
+        for item in data:
+            if item.type == "text":
+                key_group = convert_template(self.variable_pool, item.key)
+                val_group = convert_template(self.variable_pool, item.value)
+                real_data[key_group.text] = val_group.text
+                log_data[key_group.log] = val_group.log
+        self.data = real_data
+        self._log_data = log_data
         file_selectors = self._build_form_file_selectors(data)
         files_list = self._resolve_form_files(file_selectors)
         self.files = self._build_request_files(files_list)
-
-    def _build_form_text_data(self, data: Sequence[BodyData]) -> dict[str, str]:
-        return {
-            convert_template(
-                self.variable_pool,
-                item.key,
-            ).text: convert_template(self.variable_pool, item.value).text
-            for item in data
-            if item.type == "text"
-        }
-
-    def _build_form_text_log_data(self, data: Sequence[BodyData]) -> dict[str, str]:
-        """Log-safe copy of form text data: keys and values rendered via .log."""
-        return {
-            convert_template(
-                self.variable_pool,
-                item.key,
-            ).log: convert_template(self.variable_pool, item.value).log
-            for item in data
-            if item.type == "text"
-        }
 
     def _build_form_file_selectors(
         self,
@@ -595,8 +582,10 @@ class Executor:
         elif self.content:
             body_string = self._build_content_log_body()
         elif self.data and self.node_data.body.type == "x-www-form-urlencoded":
-            log_data = self._log_data if self._log_data is not None else self.data
-            body_string = urlencode(log_data)
+            if self._log_data is None:
+                msg = "_log_data not set; urlencoded body init always populates it"
+                raise RuntimeError(msg)
+            body_string = urlencode(self._log_data)
         elif self.data and self.node_data.body.type == "form-data":
             body_string = self._build_form_data_log_body(boundary)
         elif self.json:
@@ -606,11 +595,7 @@ class Executor:
                 else json.dumps(self.json)
             )
         elif self.node_data.body.type == "raw-text":
-            item = self._require_single_body_item(
-                self.node_data.body.data,
-                body_type="raw-text",
-            )
-            body_string = item.value
+            body_string = self._log_content if self._log_content is not None else ""
         return body_string
 
     def _has_loggable_files(self) -> bool:
@@ -653,9 +638,10 @@ class Executor:
 
     def _build_form_data_log_body(self, boundary: str) -> str:
         body_string = ""
-        # Use _log_data (secret-safe) if available, otherwise fall back to self.data.
-        display_data = self._log_data if self._log_data is not None else self.data
-        for key, value in (display_data or {}).items():
+        if self._log_data is None:
+            msg = "_log_data not set; form-data body init always populates it"
+            raise RuntimeError(msg)
+        for key, value in self._log_data.items():
             body_string += f"--{boundary}\r\n"
             body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
             body_string += f"{value}\r\n"

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -75,6 +75,17 @@ class Executor:
 
     boundary: str
 
+    # Log-safe copies of request fields; populated in _init_* methods.
+    # These are rendered by to_log() so that SecretVariable values are obfuscated
+    # while the real request fields (url, params, headers, content, data, json)
+    # retain the raw plaintext needed for the actual HTTP call.
+    _log_url: str
+    _log_params: list[tuple[str, str]] | None
+    _log_headers: dict[str, str]
+    _log_content: str | None
+    _log_data: Mapping[str, Any] | None
+    _log_json_text: str | None
+
     def __init__(
         self,
         *,
@@ -125,6 +136,14 @@ class Executor:
         self.files = None
         self.data = None
         self.json = None
+        # Log-safe copies - initialised to match real-field defaults;
+        # overwritten in _init_* once templates are resolved.
+        self._log_url = node_data.url
+        self._log_params = None
+        self._log_headers = {}
+        self._log_content = None
+        self._log_data = None
+        self._log_json_text = None
         self.max_retries = (
             max_retries
             if max_retries is not None
@@ -145,7 +164,9 @@ class Executor:
         self._init_body()
 
     def _init_url(self) -> None:
-        self.url = convert_template(self.variable_pool, self.node_data.url).text
+        url_group = convert_template(self.variable_pool, self.node_data.url)
+        self.url = url_group.text
+        self._log_url = url_group.log
 
         # check if url is a valid URL
         if not self.url:
@@ -162,6 +183,7 @@ class Executor:
         the variable value.
         """
         result = []
+        log_result = []
         for line in self.node_data.params.splitlines():
             if not (line := line.strip()):
                 continue
@@ -171,13 +193,15 @@ class Executor:
                 continue
 
             value_str = value[0].strip() if value else ""
-            result.append((
-                convert_template(self.variable_pool, key).text,
-                convert_template(self.variable_pool, value_str).text,
-            ))
+            key_group = convert_template(self.variable_pool, key)
+            value_group = convert_template(self.variable_pool, value_str)
+            result.append((key_group.text, value_group.text))
+            log_result.append((key_group.log, value_group.log))
 
         if result:
             self.params = result
+        if log_result:
+            self._log_params = log_result
 
     def _init_headers(self) -> None:
         r"""Convert the header string of frontend to a dictionary.
@@ -192,10 +216,18 @@ class Executor:
             'aa\n cc : dd'   -> {'aa': '', 'cc': 'dd'}
 
         """
-        headers = convert_template(self.variable_pool, self.node_data.headers).text
+        headers_group = convert_template(self.variable_pool, self.node_data.headers)
+        headers = headers_group.text
         self.headers = {
             key.strip(): (value[0].strip() if value else "")
             for line in headers.splitlines()
+            if line.strip()
+            for key, *value in [line.split(":", 1)]
+        }
+        headers_log = headers_group.log
+        self._log_headers = {
+            key.strip(): (value[0].strip() if value else "")
+            for line in headers_log.splitlines()
             if line.strip()
             for key, *value in [line.split(":", 1)]
         }
@@ -239,11 +271,15 @@ class Executor:
 
     def _init_raw_text_body(self, data: Sequence[BodyData]) -> None:
         item = self._require_single_body_item(data, body_type="raw-text")
-        self.content = convert_template(self.variable_pool, item.value).text
+        group = convert_template(self.variable_pool, item.value)
+        self.content = group.text
+        self._log_content = group.log
 
     def _init_json_body(self, data: Sequence[BodyData]) -> None:
         item = self._require_single_body_item(data, body_type="json")
-        json_string = convert_template(self.variable_pool, item.value).text
+        group = convert_template(self.variable_pool, item.value)
+        json_string = group.text
+        self._log_json_text = group.log
         try:
             repaired = repair_json(json_string)
             self.json = json.loads(repaired, strict=False)
@@ -261,16 +297,19 @@ class Executor:
         self.content = self._file_manager.download(file_variable.value)
 
     def _init_urlencoded_body(self, data: Sequence[BodyData]) -> None:
-        self.data = {
-            convert_template(
-                self.variable_pool,
-                item.key,
-            ).text: convert_template(self.variable_pool, item.value).text
-            for item in data
-        }
+        real_data: dict[str, str] = {}
+        log_data: dict[str, str] = {}
+        for item in data:
+            key_group = convert_template(self.variable_pool, item.key)
+            val_group = convert_template(self.variable_pool, item.value)
+            real_data[key_group.text] = val_group.text
+            log_data[key_group.log] = val_group.log
+        self.data = real_data
+        self._log_data = log_data
 
     def _init_form_data_body(self, data: Sequence[BodyData]) -> None:
         self.data = self._build_form_text_data(data)
+        self._log_data = self._build_form_text_log_data(data)
         file_selectors = self._build_form_file_selectors(data)
         files_list = self._resolve_form_files(file_selectors)
         self.files = self._build_request_files(files_list)
@@ -281,6 +320,17 @@ class Executor:
                 self.variable_pool,
                 item.key,
             ).text: convert_template(self.variable_pool, item.value).text
+            for item in data
+            if item.type == "text"
+        }
+
+    def _build_form_text_log_data(self, data: Sequence[BodyData]) -> dict[str, str]:
+        """Log-safe copy of form text data: keys and values rendered via .log."""
+        return {
+            convert_template(
+                self.variable_pool,
+                item.key,
+            ).log: convert_template(self.variable_pool, item.value).log
             for item in data
             if item.type == "text"
         }
@@ -342,6 +392,13 @@ class Executor:
     def _assembling_headers(self) -> dict[str, Any]:
         authorization = deepcopy(self.auth)
         headers = deepcopy(self.headers) or {}
+        headers.update(self._build_authorization_headers(authorization))
+        return self._apply_content_type_header(headers)
+
+    def _assembling_log_headers(self) -> dict[str, Any]:
+        """Like _assembling_headers() but starts from _log_headers."""
+        authorization = deepcopy(self.auth)
+        headers = deepcopy(self._log_headers) or {}
         headers.update(self._build_authorization_headers(authorization))
         return self._apply_content_type_header(headers)
 
@@ -473,7 +530,7 @@ class Executor:
         return self._validate_and_parse_response(response)
 
     def to_log(self) -> str:
-        url_parts = urlparse(self.url)
+        url_parts = urlparse(self._log_url)
         path = self._build_log_path(url_parts)
         raw = f"{self.method.upper()} {path} HTTP/1.1\r\n"
         raw += f"Host: {url_parts.netloc}\r\n"
@@ -492,19 +549,19 @@ class Executor:
 
     def _build_log_path(self, url_parts: ParseResult) -> str:
         path = url_parts.path or "/"
-        if self.params:
-            return path + f"?{urlencode(self.params)}"
+        if self._log_params:
+            return path + f"?{urlencode(self._log_params)}"
         if url_parts.query:
             return path + f"?{url_parts.query}"
         return path
 
     def _build_log_headers(self, boundary: str) -> dict[str, Any]:
-        headers = self._assembling_headers()
+        headers = self._assembling_log_headers()
         body = self.node_data.body
         if body is None:
             return headers
         if (
-            "content-type" not in (k.lower() for k in self.headers)
+            "content-type" not in (k.lower() for k in self._log_headers)
             and body.type in BODY_TYPE_TO_CONTENT_TYPE
         ):
             headers["Content-Type"] = BODY_TYPE_TO_CONTENT_TYPE[body.type]
@@ -538,11 +595,16 @@ class Executor:
         elif self.content:
             body_string = self._build_content_log_body()
         elif self.data and self.node_data.body.type == "x-www-form-urlencoded":
-            body_string = urlencode(self.data)
+            log_data = self._log_data if self._log_data is not None else self.data
+            body_string = urlencode(log_data)
         elif self.data and self.node_data.body.type == "form-data":
             body_string = self._build_form_data_log_body(boundary)
         elif self.json:
-            body_string = json.dumps(self.json)
+            body_string = (
+                self._log_json_text
+                if self._log_json_text is not None
+                else json.dumps(self.json)
+            )
         elif self.node_data.body.type == "raw-text":
             item = self._require_single_body_item(
                 self.node_data.body.data,
@@ -584,11 +646,16 @@ class Executor:
     def _build_content_log_body(self) -> str:
         if isinstance(self.content, bytes):
             return f"<binary_content: size={len(self.content)} bytes>"
+        # For raw-text bodies use the log-safe copy; fall back to content if not set.
+        if self._log_content is not None:
+            return str(self._log_content)
         return str(self.content)
 
     def _build_form_data_log_body(self, boundary: str) -> str:
         body_string = ""
-        for key, value in (self.data or {}).items():
+        # Use _log_data (secret-safe) if available, otherwise fall back to self.data.
+        display_data = self._log_data if self._log_data is not None else self.data
+        for key, value in (display_data or {}).items():
             body_string += f"--{boundary}\r\n"
             body_string += f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
             body_string += f"{value}\r\n"

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -276,6 +276,8 @@ class Executor:
         item = self._require_single_body_item(data, body_type="json")
         group = convert_template(self.variable_pool, item.value)
         json_string = group.text
+        # Raw masked template text (not re-normalized via json.dumps); self.json
+        # holds the parsed plaintext, so _log_json_text must never fall back to it.
         self._log_json_text = group.log
         try:
             repaired = repair_json(json_string)
@@ -585,11 +587,10 @@ class Executor:
         elif self.data and self.node_data.body.type == "form-data":
             body_string = self._build_form_data_log_body(boundary)
         elif self.json:
-            body_string = (
-                self._log_json_text
-                if self._log_json_text is not None
-                else json.dumps(self.json)
-            )
+            if self._log_json_text is None:
+                msg = "log json body requested before initialization"
+                raise RuntimeError(msg)
+            body_string = self._log_json_text
         elif self.node_data.body.type == "raw-text":
             body_string = self._log_content if self._log_content is not None else ""
         return body_string
@@ -627,10 +628,11 @@ class Executor:
     def _build_content_log_body(self) -> str:
         if isinstance(self.content, bytes):
             return f"<binary_content: size={len(self.content)} bytes>"
-        # For raw-text bodies use the log-safe copy; fall back to content if not set.
-        if self._log_content is not None:
-            return str(self._log_content)
-        return str(self.content)
+        # For raw-text bodies use the log-safe copy; fail closed if not set.
+        if self._log_content is None:
+            msg = "log content requested before initialization"
+            raise RuntimeError(msg)
+        return str(self._log_content)
 
     def _build_form_data_log_body(self, boundary: str) -> str:
         body_string = ""

--- a/src/graphon/nodes/http_request/executor.py
+++ b/src/graphon/nodes/http_request/executor.py
@@ -198,9 +198,9 @@ class Executor:
             result.append((key_group.text, value_group.text))
             log_result.append((key_group.log, value_group.log))
 
+        # result and log_result are appended in lockstep, so they are truthy together.
         if result:
             self.params = result
-        if log_result:
             self._log_params = log_result
 
     def _init_headers(self) -> None:
@@ -217,17 +217,14 @@ class Executor:
 
         """
         headers_group = convert_template(self.variable_pool, self.node_data.headers)
-        headers = headers_group.text
-        self.headers = {
+        self.headers = self._parse_header_string(headers_group.text)
+        self._log_headers = self._parse_header_string(headers_group.log)
+
+    @staticmethod
+    def _parse_header_string(headers: str) -> dict[str, str]:
+        return {
             key.strip(): (value[0].strip() if value else "")
             for line in headers.splitlines()
-            if line.strip()
-            for key, *value in [line.split(":", 1)]
-        }
-        headers_log = headers_group.log
-        self._log_headers = {
-            key.strip(): (value[0].strip() if value else "")
-            for line in headers_log.splitlines()
             if line.strip()
             for key, *value in [line.split(":", 1)]
         }
@@ -296,28 +293,29 @@ class Executor:
             raise FileFetchError(msg)
         self.content = self._file_manager.download(file_variable.value)
 
-    def _init_urlencoded_body(self, data: Sequence[BodyData]) -> None:
+    def _convert_body_kv(
+        self,
+        data: Sequence[BodyData],
+        *,
+        text_only: bool = False,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Resolve body items into parallel real and log-safe key/value dicts."""
         real_data: dict[str, str] = {}
         log_data: dict[str, str] = {}
         for item in data:
+            if text_only and item.type != "text":
+                continue
             key_group = convert_template(self.variable_pool, item.key)
             val_group = convert_template(self.variable_pool, item.value)
             real_data[key_group.text] = val_group.text
             log_data[key_group.log] = val_group.log
-        self.data = real_data
-        self._log_data = log_data
+        return real_data, log_data
+
+    def _init_urlencoded_body(self, data: Sequence[BodyData]) -> None:
+        self.data, self._log_data = self._convert_body_kv(data)
 
     def _init_form_data_body(self, data: Sequence[BodyData]) -> None:
-        real_data: dict[str, str] = {}
-        log_data: dict[str, str] = {}
-        for item in data:
-            if item.type == "text":
-                key_group = convert_template(self.variable_pool, item.key)
-                val_group = convert_template(self.variable_pool, item.value)
-                real_data[key_group.text] = val_group.text
-                log_data[key_group.log] = val_group.log
-        self.data = real_data
-        self._log_data = log_data
+        self.data, self._log_data = self._convert_body_kv(data, text_only=True)
         file_selectors = self._build_form_file_selectors(data)
         files_list = self._resolve_form_files(file_selectors)
         self.files = self._build_request_files(files_list)
@@ -376,16 +374,14 @@ class Executor:
             ),
         ]
 
-    def _assembling_headers(self) -> dict[str, Any]:
+    def _assembling_headers(
+        self,
+        source: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        # ``source`` defaults to the real request headers; pass ``_log_headers`` to
+        # assemble the log-safe (obfuscated) variant.
         authorization = deepcopy(self.auth)
-        headers = deepcopy(self.headers) or {}
-        headers.update(self._build_authorization_headers(authorization))
-        return self._apply_content_type_header(headers)
-
-    def _assembling_log_headers(self) -> dict[str, Any]:
-        """Like _assembling_headers() but starts from _log_headers."""
-        authorization = deepcopy(self.auth)
-        headers = deepcopy(self._log_headers) or {}
+        headers = deepcopy(self.headers if source is None else source) or {}
         headers.update(self._build_authorization_headers(authorization))
         return self._apply_content_type_header(headers)
 
@@ -543,7 +539,7 @@ class Executor:
         return path
 
     def _build_log_headers(self, boundary: str) -> dict[str, Any]:
-        headers = self._assembling_log_headers()
+        headers = self._assembling_headers(self._log_headers)
         body = self.node_data.body
         if body is None:
             return headers

--- a/src/graphon/variables/__init__.py
+++ b/src/graphon/variables/__init__.py
@@ -7,6 +7,7 @@ from .factory import (
 )
 from .input_entities import VariableEntity, VariableEntityType
 from .segment_group import SegmentGroup
+from .sensitivity import is_sensitive
 from .segments import (
     ArrayAnySegment,
     ArrayFileSegment,
@@ -78,5 +79,6 @@ __all__ = [
     "VariableEntityType",
     "build_segment",
     "build_segment_with_type",
+    "is_sensitive",
     "segment_to_variable",
 ]

--- a/src/graphon/variables/__init__.py
+++ b/src/graphon/variables/__init__.py
@@ -7,7 +7,6 @@ from .factory import (
 )
 from .input_entities import VariableEntity, VariableEntityType
 from .segment_group import SegmentGroup
-from .sensitivity import is_sensitive
 from .segments import (
     ArrayAnySegment,
     ArrayFileSegment,
@@ -23,6 +22,7 @@ from .segments import (
     Segment,
     StringSegment,
 )
+from .sensitivity import is_sensitive
 from .types import SegmentType
 from .variables import (
     ArrayAnyVariable,

--- a/src/graphon/variables/sensitivity.py
+++ b/src/graphon/variables/sensitivity.py
@@ -1,0 +1,16 @@
+from .segment_group import SegmentGroup
+from .segments import Segment
+from .variables import SecretVariable
+
+
+def is_sensitive(segment: Segment) -> bool:
+    """Return True if the segment is a secret or recursively contains one.
+
+    Used by the runtime serializer to decide whether to emit the masked
+    ``.log`` representation instead of the plaintext ``.value``.
+    """
+    if isinstance(segment, SecretVariable):
+        return True
+    if isinstance(segment, SegmentGroup):
+        return any(is_sensitive(child) for child in segment.value)
+    return False

--- a/src/graphon/variables/sensitivity.py
+++ b/src/graphon/variables/sensitivity.py
@@ -8,6 +8,10 @@ def is_sensitive(segment: Segment) -> bool:
 
     Used by the runtime serializer to decide whether to emit the masked
     ``.log`` representation instead of the plaintext ``.value``.
+
+    Returns:
+        True if the segment is a SecretVariable or a SegmentGroup that
+        contains at least one SecretVariable (at any depth), False otherwise.
     """
     if isinstance(segment, SecretVariable):
         return True

--- a/src/graphon/workflow_type_encoder.py
+++ b/src/graphon/workflow_type_encoder.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from graphon.file.models import File
 from graphon.variables.segments import Segment
+from graphon.variables.sensitivity import is_sensitive
 
 
 class WorkflowRuntimeTypeConverter:
@@ -32,6 +33,8 @@ class WorkflowRuntimeTypeConverter:
             case Decimal():
                 # Convert Decimal to float for JSON serialization
                 result = float(value)
+            case Segment() if is_sensitive(value):
+                result = value.log
             case Segment():
                 result = self.value_to_json_encodable_recursive(value.value)
             case File():

--- a/tests/http/test_executor_secret_masking.py
+++ b/tests/http/test_executor_secret_masking.py
@@ -10,6 +10,8 @@ from typing import Any, Literal
 
 import pytest
 
+from graphon.file.enums import FileTransferMethod, FileType
+from graphon.file.models import File
 from graphon.nodes.http_request.config import build_http_request_config
 from graphon.nodes.http_request.entities import (
     BodyData,
@@ -313,3 +315,58 @@ def test_no_secret_never_leaks_across_body_types(body_type: str) -> None:
         )
     log = executor.to_log()
     assert SECRET not in log, f"Secret leaked in to_log() for body_type={body_type!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: form-data with file + secret text field (Finding 2 lock-in)
+# ---------------------------------------------------------------------------
+
+
+def test_form_data_file_plus_secret_text_no_leak() -> None:
+    """Form-data with a real file and a secret text field must not leak the secret.
+
+    When files are present, _has_loggable_files() is True and _build_log_body takes
+    the file-log path; the text field (and its secret value) is omitted entirely.
+    This test locks in that the combination is safe - no secret leaks via to_log().
+    """
+    pool = _build_pool()
+    # Register a dummy remote-url file so the file selector resolves.
+    dummy_file = File(
+        file_type=FileType.DOCUMENT,
+        transfer_method=FileTransferMethod.REMOTE_URL,
+        remote_url="https://example.com/dummy.txt",
+        filename="dummy.txt",
+        mime_type="text/plain",
+    )
+    pool.add(["test_node", "test_file"], dummy_file)
+
+    body_data = [
+        BodyData(key="attachment", type="file", file=["test_node", "test_file"]),
+        BodyData(key="token", type="text", value="{{#env.API_TOKEN#}}"),
+    ]
+
+    class _FileManagerWithBytes:
+        def download(self, _f: Any, /) -> bytes:
+            return b"dummy file bytes"
+
+    executor = Executor(
+        node_data=HttpRequestNodeData(
+            title="Test HTTP",
+            method="post",
+            url="https://example.com",
+            authorization=HttpRequestNodeAuthorization(type="no-auth"),
+            headers="",
+            params="",
+            body=HttpRequestNodeBody(type="form-data", data=body_data),
+        ),
+        timeout=HttpRequestNodeTimeout(connect=10, read=60, write=60),
+        variable_pool=pool,
+        http_request_config=build_http_request_config(),
+        http_client=_StubHttpClient(),
+        file_manager=_FileManagerWithBytes(),
+    )
+    log = executor.to_log()
+    # Real request field keeps the raw secret in the text-field data dict.
+    assert executor.data == {"token": SECRET}
+    # The log must NOT contain the raw secret (file-log path omits text fields).
+    assert SECRET not in log

--- a/tests/http/test_executor_secret_masking.py
+++ b/tests/http/test_executor_secret_masking.py
@@ -80,11 +80,28 @@ def _build_pool() -> VariablePool:
 
 
 _Method = Literal[
-    "get", "post", "put", "patch", "delete", "head", "options",
-    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "HEAD",
+    "OPTIONS",
 ]
 _BodyType = Literal[
-    "none", "form-data", "x-www-form-urlencoded", "raw-text", "json", "binary",
+    "none",
+    "form-data",
+    "x-www-form-urlencoded",
+    "raw-text",
+    "json",
+    "binary",
 ]
 
 

--- a/tests/http/test_executor_secret_masking.py
+++ b/tests/http/test_executor_secret_masking.py
@@ -1,0 +1,299 @@
+"""Tests that secret variable values are masked in the HTTP executor's to_log() output.
+
+The real request fields (params, json, data, content, headers) retain the raw secret
+so the actual HTTP call is unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+
+from graphon.nodes.http_request.config import build_http_request_config
+from graphon.nodes.http_request.entities import (
+    BodyData,
+    HttpRequestNodeAuthorization,
+    HttpRequestNodeBody,
+    HttpRequestNodeData,
+    HttpRequestNodeTimeout,
+)
+from graphon.nodes.http_request.executor import Executor
+from graphon.runtime.variable_pool import VariablePool
+from graphon.variables import SecretVariable
+
+SECRET = "sk-supersecret-123456"  # noqa: S105
+# The obfuscated form per _obfuscated_token(): first 6 chars + 12 stars + last 2 chars.
+# len(SECRET) = 22 > 8, so: "sk-sup" + "************" + "56"
+OBFUSCATED = "sk-sup" + "*" * 12 + "56"
+# When the obfuscated token is percent-encoded (e.g. inside urlencode for params/body)
+# the '*' character becomes '%2A'.
+OBFUSCATED_URL = "sk-sup" + "%2A" * 12 + "56"
+
+
+class _FileManager:
+    def download(self, f: Any, /) -> bytes:
+        raise NotImplementedError
+
+
+class _StubHttpClient:
+    @property
+    def max_retries_exceeded_error(self) -> type[Exception]:
+        return RuntimeError
+
+    @property
+    def request_error(self) -> type[Exception]:
+        return RuntimeError
+
+    def get(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("GET", url, max_retries=max_retries, **kwargs)
+
+    def head(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("HEAD", url, max_retries=max_retries, **kwargs)
+
+    def post(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("POST", url, max_retries=max_retries, **kwargs)
+
+    def put(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("PUT", url, max_retries=max_retries, **kwargs)
+
+    def delete(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("DELETE", url, max_retries=max_retries, **kwargs)
+
+    def patch(self, url: str, max_retries: int = 0, **kwargs: Any) -> Any:
+        return self._raise("PATCH", url, max_retries=max_retries, **kwargs)
+
+    def _raise(self, method: str, url: str, **kwargs: Any) -> Any:
+        msg = f"unexpected {method} request in test stub: {url!r}, {kwargs!r}"
+        raise AssertionError(msg)
+
+
+def _build_pool() -> VariablePool:
+    """Build a VariablePool with a SecretVariable env variable API_TOKEN."""
+    return VariablePool.from_bootstrap(
+        environment_variables=[
+            SecretVariable(name="API_TOKEN", value=SECRET),
+        ],
+    )
+
+
+_Method = Literal[
+    "get", "post", "put", "patch", "delete", "head", "options",
+    "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS",
+]
+_BodyType = Literal[
+    "none", "form-data", "x-www-form-urlencoded", "raw-text", "json", "binary",
+]
+
+
+def _build_executor(
+    *,
+    method: _Method = "get",
+    url: str = "https://example.com",
+    params: str = "",
+    headers: str = "",
+    body_type: _BodyType = "none",
+    body_data: list[BodyData] | None = None,
+    body_str: str | None = None,
+) -> Executor:
+    """Construct an Executor for testing; injects a stub HTTP client."""
+    pool = _build_pool()
+    if body_data is None and body_str is not None:
+        body_data = [BodyData(key="", type="text", value=body_str)]
+    elif body_data is None:
+        body_data = []
+    return Executor(
+        node_data=HttpRequestNodeData(
+            title="Test HTTP",
+            method=method,
+            url=url,
+            authorization=HttpRequestNodeAuthorization(type="no-auth"),
+            headers=headers,
+            params=params,
+            body=HttpRequestNodeBody(type=body_type, data=body_data),
+        ),
+        timeout=HttpRequestNodeTimeout(connect=10, read=60, write=60),
+        variable_pool=pool,
+        http_request_config=build_http_request_config(),
+        http_client=_StubHttpClient(),
+        file_manager=_FileManager(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in query params
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_query_param_is_masked_in_log() -> None:
+    executor = _build_executor(params="token: {{#env.API_TOKEN#}}")
+    log = executor.to_log()
+    # Real request field keeps the raw secret
+    assert executor.params == [("token", SECRET)]
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    # The log contains the obfuscated token (percent-encoded inside a URL)
+    assert OBFUSCATED_URL in log
+
+
+def test_non_secret_query_param_log_is_unchanged() -> None:
+    executor = _build_executor(params="page: 1")
+    log = executor.to_log()
+    assert executor.params == [("page", "1")]
+    assert "page=1" in log
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in headers
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_non_auth_header_is_masked_in_log() -> None:
+    executor = _build_executor(headers="X-API-Key: {{#env.API_TOKEN#}}")
+    log = executor.to_log()
+    # Real request field keeps the raw secret
+    assert executor.headers.get("X-API-Key") == SECRET
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    assert OBFUSCATED in log
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in body - raw-text
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_raw_text_body_is_masked_in_log() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="raw-text",
+        body_str="api_key={{#env.API_TOKEN#}}",
+    )
+    log = executor.to_log()
+    # Real request field keeps the raw secret
+    assert executor.content == f"api_key={SECRET}"
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    assert OBFUSCATED in log
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in body - JSON
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_json_body_is_masked_in_log() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="json",
+        body_str='{"token": "{{#env.API_TOKEN#}}"}',
+    )
+    log = executor.to_log()
+    # Real request keeps the raw secret (parsed JSON)
+    assert executor.json == {"token": SECRET}
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    assert OBFUSCATED in log
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in body - x-www-form-urlencoded
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_urlencoded_body_is_masked_in_log() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="x-www-form-urlencoded",
+        body_data=[BodyData(key="token", type="text", value="{{#env.API_TOKEN#}}")],
+    )
+    log = executor.to_log()
+    # Real request keeps the raw secret
+    assert executor.data == {"token": SECRET}
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    # urlencode percent-encodes '*' as '%2A'
+    assert OBFUSCATED_URL in log
+
+
+# ---------------------------------------------------------------------------
+# Tests: secret in body - form-data
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_form_data_body_is_masked_in_log() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="form-data",
+        body_data=[BodyData(key="token", type="text", value="{{#env.API_TOKEN#}}")],
+    )
+    log = executor.to_log()
+    # Real request keeps the raw secret
+    assert executor.data == {"token": SECRET}
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    assert OBFUSCATED in log
+
+
+# ---------------------------------------------------------------------------
+# Regression: non-secret request log is produced faithfully
+# ---------------------------------------------------------------------------
+
+
+def test_non_secret_json_body_log_is_unchanged() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="json",
+        body_str='{"page": 1}',
+    )
+    log = executor.to_log()
+    assert executor.json == {"page": 1}
+    # The literal value should be visible in the log
+    assert "1" in log
+
+
+def test_non_secret_urlencoded_body_log_is_unchanged() -> None:
+    executor = _build_executor(
+        method="post",
+        body_type="x-www-form-urlencoded",
+        body_data=[BodyData(key="name", type="text", value="Alice")],
+    )
+    log = executor.to_log()
+    assert executor.data == {"name": "Alice"}
+    assert "name=Alice" in log
+
+
+@pytest.mark.parametrize(
+    "body_type",
+    ["none", "raw-text", "json", "x-www-form-urlencoded", "form-data"],
+)
+def test_no_secret_never_leaks_across_body_types(body_type: str) -> None:
+    """Parametric smoke test: secret must never appear in log for any body type."""
+    if body_type == "none":
+        executor = _build_executor(params="token: {{#env.API_TOKEN#}}")
+    elif body_type == "raw-text":
+        executor = _build_executor(
+            method="post",
+            body_type="raw-text",
+            body_str="{{#env.API_TOKEN#}}",
+        )
+    elif body_type == "json":
+        executor = _build_executor(
+            method="post",
+            body_type="json",
+            body_str='{"key": "{{#env.API_TOKEN#}}"}',
+        )
+    elif body_type == "x-www-form-urlencoded":
+        executor = _build_executor(
+            method="post",
+            body_type="x-www-form-urlencoded",
+            body_data=[BodyData(key="key", type="text", value="{{#env.API_TOKEN#}}")],
+        )
+    else:  # form-data
+        executor = _build_executor(
+            method="post",
+            body_type="form-data",
+            body_data=[BodyData(key="key", type="text", value="{{#env.API_TOKEN#}}")],
+        )
+    log = executor.to_log()
+    assert SECRET not in log, f"Secret leaked in to_log() for body_type={body_type!r}"

--- a/tests/http/test_executor_secret_masking.py
+++ b/tests/http/test_executor_secret_masking.py
@@ -240,6 +240,22 @@ def test_secret_in_form_data_body_is_masked_in_log() -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Tests: secret embedded in the URL itself
+# ---------------------------------------------------------------------------
+
+
+def test_secret_in_url_is_masked_in_log() -> None:
+    executor = _build_executor(url="https://api.example.com/{{#env.API_TOKEN#}}/data")
+    log = executor.to_log()
+    # Real request field keeps the raw secret
+    assert SECRET in executor.url
+    # The log must NOT contain the raw secret
+    assert SECRET not in log
+    # The obfuscated token (with '*') appears in the log path
+    assert OBFUSCATED in log
+
+
 def test_non_secret_json_body_log_is_unchanged() -> None:
     executor = _build_executor(
         method="post",

--- a/tests/variables/test_sensitivity.py
+++ b/tests/variables/test_sensitivity.py
@@ -1,0 +1,28 @@
+from graphon.variables import SecretVariable, SegmentGroup, StringSegment
+from graphon.variables.sensitivity import is_sensitive
+
+SECRET = "sk-1234567890abcdef"
+
+
+def test_secret_variable_is_sensitive():
+    assert is_sensitive(SecretVariable(value=SECRET, name="api_key")) is True
+
+
+def test_plain_string_segment_is_not_sensitive():
+    assert is_sensitive(StringSegment(value="hello")) is False
+
+
+def test_segment_group_with_secret_is_sensitive():
+    group = SegmentGroup(value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")])
+    assert is_sensitive(group) is True
+
+
+def test_segment_group_without_secret_is_not_sensitive():
+    group = SegmentGroup(value=[StringSegment(value="a"), StringSegment(value="b")])
+    assert is_sensitive(group) is False
+
+
+def test_nested_segment_group_with_secret_is_sensitive():
+    inner = SegmentGroup(value=[SecretVariable(value=SECRET, name="k")])
+    outer = SegmentGroup(value=[StringSegment(value="x"), inner])
+    assert is_sensitive(outer) is True

--- a/tests/variables/test_sensitivity.py
+++ b/tests/variables/test_sensitivity.py
@@ -1,28 +1,43 @@
-from graphon.variables import SecretVariable, SegmentGroup, StringSegment
+from graphon.variables import (
+    SecretVariable,
+    SegmentGroup,
+    StringSegment,
+)
+from graphon.variables import (
+    is_sensitive as is_sensitive_pkg,
+)
 from graphon.variables.sensitivity import is_sensitive
 
-SECRET = "sk-1234567890abcdef"
+SECRET = "sk-1234567890abcdef"  # noqa: S105
 
 
-def test_secret_variable_is_sensitive():
+def test_secret_variable_is_sensitive() -> None:
     assert is_sensitive(SecretVariable(value=SECRET, name="api_key")) is True
 
 
-def test_plain_string_segment_is_not_sensitive():
+def test_plain_string_segment_is_not_sensitive() -> None:
     assert is_sensitive(StringSegment(value="hello")) is False
 
 
-def test_segment_group_with_secret_is_sensitive():
-    group = SegmentGroup(value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")])
+def test_segment_group_with_secret_is_sensitive() -> None:
+    group = SegmentGroup(
+        value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")]
+    )
     assert is_sensitive(group) is True
 
 
-def test_segment_group_without_secret_is_not_sensitive():
+def test_segment_group_without_secret_is_not_sensitive() -> None:
     group = SegmentGroup(value=[StringSegment(value="a"), StringSegment(value="b")])
     assert is_sensitive(group) is False
 
 
-def test_nested_segment_group_with_secret_is_sensitive():
+def test_nested_segment_group_with_secret_is_sensitive() -> None:
     inner = SegmentGroup(value=[SecretVariable(value=SECRET, name="k")])
     outer = SegmentGroup(value=[StringSegment(value="x"), inner])
     assert is_sensitive(outer) is True
+
+
+def test_package_level_export_is_same_function() -> None:
+    secret = SecretVariable(value=SECRET, name="api_key")
+    assert is_sensitive_pkg(secret) is True
+    assert is_sensitive_pkg is is_sensitive

--- a/tests/variables/test_workflow_type_encoder_secret.py
+++ b/tests/variables/test_workflow_type_encoder_secret.py
@@ -1,28 +1,45 @@
 from graphon.variables import SecretVariable, SegmentGroup, StringSegment
 from graphon.workflow_type_encoder import WorkflowRuntimeTypeConverter
 
-SECRET = "sk-1234567890abcdef"
+SECRET = "sk-1234567890abcdef"  # noqa: S105
 MASKED = "sk-123" + "*" * 12 + "ef"  # _obfuscated_token(SECRET)
 
 
-def test_secret_variable_is_masked():
-    result = WorkflowRuntimeTypeConverter().to_json_encodable({"key": SecretVariable(value=SECRET, name="api_key")})
+def test_secret_variable_is_masked() -> None:
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({
+        "key": SecretVariable(value=SECRET, name="api_key")
+    })
     assert result == {"key": MASKED}
 
 
-def test_segment_group_masks_only_the_secret_part():
-    group = SegmentGroup(value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")])
+def test_segment_group_masks_only_the_secret_part() -> None:
+    group = SegmentGroup(
+        value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")]
+    )
     result = WorkflowRuntimeTypeConverter().to_json_encodable({"auth": group})
     assert result == {"auth": "Bearer " + MASKED}
 
 
-def test_secret_nested_in_list_is_masked():
-    result = WorkflowRuntimeTypeConverter().to_json_encodable({"items": [SecretVariable(value=SECRET, name="k")]})
+def test_secret_nested_in_list_is_masked() -> None:
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({
+        "items": [SecretVariable(value=SECRET, name="k")]
+    })
     assert result == {"items": [MASKED]}
 
 
-def test_non_secret_values_are_unchanged():
-    result = WorkflowRuntimeTypeConverter().to_json_encodable(
-        {"a": StringSegment(value="hello"), "b": [1, 2, "x"], "c": {"n": 3}}
-    )
+def test_non_secret_values_are_unchanged() -> None:
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({
+        "a": StringSegment(value="hello"),
+        "b": [1, 2, "x"],
+        "c": {"n": 3},
+    })
     assert result == {"a": "hello", "b": [1, 2, "x"], "c": {"n": 3}}
+
+
+def test_non_sensitive_segment_group_serializes_as_list() -> None:
+    # A non-sensitive SegmentGroup recurses into .value (list[Segment]),
+    # so each StringSegment further recurses into its .value (str).
+    # Result is a list of strings, NOT a joined string.
+    group = SegmentGroup(value=[StringSegment(value="a"), StringSegment(value="b")])
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({"data": group})
+    assert result == {"data": ["a", "b"]}

--- a/tests/variables/test_workflow_type_encoder_secret.py
+++ b/tests/variables/test_workflow_type_encoder_secret.py
@@ -1,0 +1,28 @@
+from graphon.variables import SecretVariable, SegmentGroup, StringSegment
+from graphon.workflow_type_encoder import WorkflowRuntimeTypeConverter
+
+SECRET = "sk-1234567890abcdef"
+MASKED = "sk-123" + "*" * 12 + "ef"  # _obfuscated_token(SECRET)
+
+
+def test_secret_variable_is_masked():
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({"key": SecretVariable(value=SECRET, name="api_key")})
+    assert result == {"key": MASKED}
+
+
+def test_segment_group_masks_only_the_secret_part():
+    group = SegmentGroup(value=[StringSegment(value="Bearer "), SecretVariable(value=SECRET, name="k")])
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({"auth": group})
+    assert result == {"auth": "Bearer " + MASKED}
+
+
+def test_secret_nested_in_list_is_masked():
+    result = WorkflowRuntimeTypeConverter().to_json_encodable({"items": [SecretVariable(value=SECRET, name="k")]})
+    assert result == {"items": [MASKED]}
+
+
+def test_non_secret_values_are_unchanged():
+    result = WorkflowRuntimeTypeConverter().to_json_encodable(
+        {"a": StringSegment(value="hello"), "b": [1, 2, "x"], "c": {"n": 3}}
+    )
+    assert result == {"a": "hello", "b": [1, 2, "x"], "c": {"n": 3}}


### PR DESCRIPTION
Prevents workflow secret values from leaking into run logs and the live stream at the serialization layer.

## Changes
- Add `is_sensitive(segment)` — true for a `SecretVariable`, or a `SegmentGroup` recursively containing one (`variables/sensitivity.py`).
- `WorkflowRuntimeTypeConverter` now emits the masked `.log` for sensitive segments instead of the plaintext `.value`. This one serializer feeds both run-log persistence and the live SSE stream downstream, so both surfaces are covered by a single change.
- HTTP node `to_log()` masks secrets in the logged URL, query params, non-auth headers, and every request body type (raw-text, JSON, urlencoded, form-data) — previously only the `Authorization` header was masked. The real outbound request is provably unchanged (log-only `_log_*` copies built from `.log`).

## Safety
- Fail-closed: log rendering raises rather than falling back to plaintext if a log copy is missing.
- Tests assert both directions — the log masks the secret **and** the real request field retains the raw value.

## Context
Part of a workflow secret-redaction effort. A companion `langgenius/dify` PR adds the app-layer value-scrub backstop; this graphon change is the type-aware masking layer that both persistence and the live stream inherit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
