### PR TITLE
fix(condition): assert_in/assert_not_in wrongly reject falsy values present in the list

### DIFF
--- a/src/graphon/utils/condition/processor.py
+++ b/src/graphon/utils/condition/processor.py
@@ -499,7 +499,7 @@ def _assert_not_null(*, value: Any) -> bool:
 
 
 def _assert_in(*, value: Any, expected: Any) -> bool:
-    if not value:
+    if value is None:
         return False
 
     match expected:
@@ -512,7 +512,7 @@ def _assert_in(*, value: Any, expected: Any) -> bool:
 
 
 def _assert_not_in(*, value: Any, expected: Any) -> bool:
-    if not value:
+    if value is None:
         return True
 
     match expected:

--- a/tests/utils/test_condition_processor.py
+++ b/tests/utils/test_condition_processor.py
@@ -125,6 +125,38 @@ def test_process_conditions_contains_supports_string_and_list_values() -> None:
     assert list_result.final_result is True
 
 
+def test_process_conditions_in_matches_falsy_value_present_in_list() -> None:
+    condition_processor = ConditionProcessor()
+    variable_pool = VariablePool()
+    variable_pool.add(["test_node_id", "choice"], "")
+
+    in_result = condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "choice"],
+                comparison_operator="in",
+                value=["", "a", "b"],
+            ),
+        ],
+        operator="and",
+    )
+    not_in_result = condition_processor.process_conditions(
+        variable_pool=variable_pool,
+        conditions=[
+            Condition(
+                variable_selector=["test_node_id", "choice"],
+                comparison_operator="not in",
+                value=["", "a", "b"],
+            ),
+        ],
+        operator="and",
+    )
+
+    assert in_result.final_result is True
+    assert not_in_result.final_result is False
+
+
 def test_process_conditions_resolves_templates_from_read_only_variable_pool() -> None:
     condition_processor = ConditionProcessor()
     variable_pool = VariablePool()


### PR DESCRIPTION
## Bug

`_assert_in`/`_assert_not_in` short-circuit on `if not value`, but this checks the truthiness of the value being tested for membership, not whether it's absent. A falsy value that is legitimately present in the expected list (e.g. an empty string in a picklist that allows an empty option) is silently rejected by `in` and silently accepted by `not in`, before the actual membership check ever runs.

Every other comparator in this file (`_assert_equal`, `_assert_greater_than`, `_assert_null`, etc.) guards with `if value is None`, not `if not value` — `_assert_in`/`_assert_not_in` are the only outliers.

## Fix

Match the file's own established pattern: guard on `value is None` instead of `not value`.

## Tests

- New test `test_process_conditions_in_matches_falsy_value_present_in_list` (via the real `ConditionProcessor.process_conditions` path, matching this file's existing test style): red before the fix, green after.
- Full `tests/utils/test_condition_processor.py` (5 tests) + `tests/nodes/if_else/` (24 tests, the node that consumes this processor) pass.
- Full test suite (604 tests) passes.
- `ruff check` / `ruff format --check` / `ty check` clean on the changed files.

## AI disclosure

Found, reproduced, and fixed with AI assistance (Claude Code), which noticed the inconsistency by comparing `_assert_in`/`_assert_not_in`'s guard against every other comparator function in the same file. I independently reproduced the pre-fix bug and the fix's correctness by running the tests directly before opening this PR.