### PR TITLE
fix: propagate fatal node failure source

### DIFF
--- a/src/graphon/entities/__init__.py
+++ b/src/graphon/entities/__init__.py
@@ -1,9 +1,11 @@
+from .graph_failure_source import GraphFailureSource
 from .graph_init_params import GraphInitParams
 from .workflow_execution import WorkflowExecution
 from .workflow_node_execution import WorkflowNodeExecution
 from .workflow_start_reason import WorkflowStartReason
 
 __all__ = [
+    "GraphFailureSource",
     "GraphInitParams",
     "WorkflowExecution",
     "WorkflowNodeExecution",

--- a/src/graphon/entities/graph_failure_source.py
+++ b/src/graphon/entities/graph_failure_source.py
@@ -1,0 +1,12 @@
+"""Identity of the node execution that caused a graph run to fail."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GraphFailureSource(BaseModel):
+    """Exact node execution responsible for a fatal graph failure."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    node_execution_id: str
+    node_id: str

--- a/src/graphon/enums.py
+++ b/src/graphon/enums.py
@@ -224,6 +224,7 @@ class WorkflowNodeExecutionMetadataKey(StrEnum):
     DATASOURCE_INFO = "datasource_info"
     TRIGGER_INFO = "trigger_info"
     COMPLETED_REASON = "completed_reason"  # completed reason for loop node
+    FAILURE_SOURCE = "failure_source"
 
 
 class WorkflowNodeExecutionStatus(StrEnum):

--- a/src/graphon/graph_engine/domain/graph_execution.py
+++ b/src/graphon/graph_engine/domain/graph_execution.py
@@ -46,6 +46,7 @@ class GraphExecutionState(BaseModel):
     pause_reasons: list[PauseReason] = Field(default_factory=list)
     error: GraphExecutionErrorState | None = Field(default=None)
     failure_source: GraphFailureSource | None = Field(default=None)
+    observed_failure_sources: list[GraphFailureSource] = Field(default_factory=list)
     exceptions_count: int = Field(default=0)
     node_executions: list[NodeExecutionState] = Field(
         default_factory=list[NodeExecutionState],
@@ -111,6 +112,7 @@ class GraphExecution:
     pause_reasons: list[PauseReason] = field(default_factory=list)
     error: Exception | None = None
     failure_source: GraphFailureSource | None = None
+    observed_failure_sources: list[GraphFailureSource] = field(default_factory=list)
     node_executions: dict[str, NodeExecution] = field(
         default_factory=dict[str, NodeExecution],
     )
@@ -155,7 +157,16 @@ class GraphExecution:
         *,
         failure_source: GraphFailureSource | None = None,
     ) -> None:
-        """Mark the graph execution as failed with an optional node source."""
+        """Record an observed source and preserve the first terminal failure."""
+        if (
+            failure_source is not None
+            and failure_source not in self.observed_failure_sources
+        ):
+            self.observed_failure_sources.append(failure_source)
+
+        if self.completed:
+            return
+
         self.error = error
         self.failure_source = failure_source
         self.completed = True

--- a/src/graphon/graph_engine/domain/graph_execution.py
+++ b/src/graphon/graph_engine/domain/graph_execution.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from graphon.entities.graph_failure_source import GraphFailureSource
 from graphon.entities.pause_reason import PauseReason
 from graphon.enums import NodeState
 
@@ -44,6 +45,7 @@ class GraphExecutionState(BaseModel):
     paused: bool = Field(default=False)
     pause_reasons: list[PauseReason] = Field(default_factory=list)
     error: GraphExecutionErrorState | None = Field(default=None)
+    failure_source: GraphFailureSource | None = Field(default=None)
     exceptions_count: int = Field(default=0)
     node_executions: list[NodeExecutionState] = Field(
         default_factory=list[NodeExecutionState],
@@ -108,6 +110,7 @@ class GraphExecution:
     paused: bool = False
     pause_reasons: list[PauseReason] = field(default_factory=list)
     error: Exception | None = None
+    failure_source: GraphFailureSource | None = None
     node_executions: dict[str, NodeExecution] = field(
         default_factory=dict[str, NodeExecution],
     )
@@ -146,9 +149,15 @@ class GraphExecution:
         self.paused = True
         self.pause_reasons.append(reason)
 
-    def fail(self, error: Exception) -> None:
-        """Mark the graph execution as failed."""
+    def fail(
+        self,
+        error: Exception,
+        *,
+        failure_source: GraphFailureSource | None = None,
+    ) -> None:
+        """Mark the graph execution as failed with an optional node source."""
         self.error = error
+        self.failure_source = failure_source
         self.completed = True
 
     def get_or_create_node_execution(self, node_id: str) -> NodeExecution:
@@ -202,6 +211,7 @@ class GraphExecution:
             paused=self.paused,
             pause_reasons=self.pause_reasons,
             error=_serialize_error(self.error),
+            failure_source=self.failure_source,
             exceptions_count=self.exceptions_count,
             node_executions=node_states,
         )
@@ -230,6 +240,7 @@ class GraphExecution:
         self.paused = state.paused
         self.pause_reasons = state.pause_reasons
         self.error = _deserialize_error(state.error)
+        self.failure_source = state.failure_source
         self.exceptions_count = state.exceptions_count
         self.node_executions = {
             item.node_id: NodeExecution(

--- a/src/graphon/graph_engine/domain/graph_execution.py
+++ b/src/graphon/graph_engine/domain/graph_execution.py
@@ -223,6 +223,7 @@ class GraphExecution:
             pause_reasons=self.pause_reasons,
             error=_serialize_error(self.error),
             failure_source=self.failure_source,
+            observed_failure_sources=self.observed_failure_sources,
             exceptions_count=self.exceptions_count,
             node_executions=node_states,
         )
@@ -252,6 +253,7 @@ class GraphExecution:
         self.pause_reasons = state.pause_reasons
         self.error = _deserialize_error(state.error)
         self.failure_source = state.failure_source
+        self.observed_failure_sources = list(state.observed_failure_sources)
         self.exceptions_count = state.exceptions_count
         self.node_executions = {
             item.node_id: NodeExecution(

--- a/src/graphon/graph_engine/event_management/event_handlers.py
+++ b/src/graphon/graph_engine/event_management/event_handlers.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from functools import singledispatchmethod
 from typing import final
 
+from graphon.entities.graph_failure_source import GraphFailureSource
 from graphon.enums import ErrorStrategy, NodeExecutionType, NodeState
 from graphon.graph.graph import Graph
 from graphon.graph_events.agent import NodeRunAgentLogEvent
@@ -263,7 +264,13 @@ class EventHandler:
             self.dispatch(result)
         else:
             # Abort execution
-            self._graph_execution.fail(RuntimeError(event.error))
+            self._graph_execution.fail(
+                RuntimeError(event.error),
+                failure_source=GraphFailureSource(
+                    node_execution_id=event.id,
+                    node_id=event.node_id,
+                ),
+            )
             self._event_collector.collect(event)
             self._state_manager.finish_execution(event.node_id)
 

--- a/src/graphon/graph_engine/graph_engine.py
+++ b/src/graphon/graph_engine/graph_engine.py
@@ -107,6 +107,7 @@ class _GraphRunLifecycle:
         event = GraphRunFailedEvent(
             error=str(error),
             exceptions_count=self.graph_execution.exceptions_count,
+            failure_source=self.graph_execution.failure_source,
         )
         self.event_manager.notify_layers(event)
         return event

--- a/src/graphon/graph_engine/graph_engine.py
+++ b/src/graphon/graph_engine/graph_engine.py
@@ -108,6 +108,9 @@ class _GraphRunLifecycle:
             error=str(error),
             exceptions_count=self.graph_execution.exceptions_count,
             failure_source=self.graph_execution.failure_source,
+            observed_failure_sources=list(
+                self.graph_execution.observed_failure_sources,
+            ),
         )
         self.event_manager.notify_layers(event)
         return event

--- a/src/graphon/graph_events/graph.py
+++ b/src/graphon/graph_events/graph.py
@@ -30,6 +30,10 @@ class GraphRunFailedEvent(BaseGraphEvent):
         default=None,
         description="node execution that caused the graph failure",
     )
+    observed_failure_sources: list[GraphFailureSource] = Field(
+        default_factory=list,
+        description="fatal node failures observed during fail-fast shutdown",
+    )
 
 
 class GraphRunPartialSucceededEvent(BaseGraphEvent):

--- a/src/graphon/graph_events/graph.py
+++ b/src/graphon/graph_events/graph.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from graphon.entities.graph_failure_source import GraphFailureSource
 from graphon.entities.pause_reason import PauseReason
 from graphon.entities.workflow_start_reason import WorkflowStartReason
 from graphon.graph_events.base import BaseGraphEvent
@@ -25,6 +26,10 @@ class GraphRunSucceededEvent(BaseGraphEvent):
 class GraphRunFailedEvent(BaseGraphEvent):
     error: str = Field(..., description="failed reason")
     exceptions_count: int = Field(description="exception count", default=0)
+    failure_source: GraphFailureSource | None = Field(
+        default=None,
+        description="node execution that caused the graph failure",
+    )
 
 
 class GraphRunPartialSucceededEvent(BaseGraphEvent):

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 from pydantic import BaseModel, Field
 from pydantic_core import to_jsonable_python
 
+from graphon.entities.graph_failure_source import GraphFailureSource
 from graphon.enums import NodeExecutionType, NodeState, NodeType
 from graphon.model_runtime.entities.llm_entities import LLMUsage
 from graphon.runtime.ready_queue import ReadyQueueProtocol
@@ -65,6 +66,7 @@ class GraphExecutionProtocol(Protocol):
     aborted: bool
     paused: bool
     error: Exception | None
+    failure_source: GraphFailureSource | None
     exceptions_count: int
     pause_reasons: list[PauseReason]
 
@@ -95,8 +97,13 @@ class GraphExecutionProtocol(Protocol):
         ...
 
     @abstractmethod
-    def fail(self, error: Exception) -> None:
-        """Record an unrecoverable error and end execution."""
+    def fail(
+        self,
+        error: Exception,
+        *,
+        failure_source: GraphFailureSource | None = None,
+    ) -> None:
+        """Record an unrecoverable error and optional node source."""
         ...
 
     @abstractmethod

--- a/src/graphon/runtime/graph_runtime_state.py
+++ b/src/graphon/runtime/graph_runtime_state.py
@@ -67,6 +67,7 @@ class GraphExecutionProtocol(Protocol):
     paused: bool
     error: Exception | None
     failure_source: GraphFailureSource | None
+    observed_failure_sources: list[GraphFailureSource]
     exceptions_count: int
     pause_reasons: list[PauseReason]
 

--- a/tests/graph_engine/test_raw_engine_events.py
+++ b/tests/graph_engine/test_raw_engine_events.py
@@ -201,11 +201,19 @@ def test_handled_node_failure_does_not_record_graph_failure_source() -> None:
 
 
 def test_graph_failed_event_publishes_recorded_failure_source() -> None:
-    source = GraphFailureSource(
+    first = GraphFailureSource(
         node_execution_id="execution-a",
         node_id="node-a",
     )
-    graph_execution = MagicMock(exceptions_count=1, failure_source=source)
+    second = GraphFailureSource(
+        node_execution_id="execution-b",
+        node_id="node-b",
+    )
+    graph_execution = MagicMock(
+        exceptions_count=2,
+        failure_source=first,
+        observed_failure_sources=[first, second],
+    )
     event_manager = MagicMock()
     lifecycle = _GraphRunLifecycle(
         graph_execution=cast(Any, graph_execution),
@@ -218,12 +226,17 @@ def test_graph_failed_event_publishes_recorded_failure_source() -> None:
 
     event = lifecycle._failed_event(RuntimeError("boom"))
 
-    assert event.failure_source == source
+    assert event.failure_source == first
+    assert event.observed_failure_sources == [first, second]
     event_manager.notify_layers.assert_called_once_with(event)
 
 
 def test_graph_failed_event_omits_unattributed_failure_source() -> None:
-    graph_execution = MagicMock(exceptions_count=0, failure_source=None)
+    graph_execution = MagicMock(
+        exceptions_count=0,
+        failure_source=None,
+        observed_failure_sources=[],
+    )
     lifecycle = _GraphRunLifecycle(
         graph_execution=cast(Any, graph_execution),
         event_manager=cast(Any, MagicMock()),

--- a/tests/graph_engine/test_raw_engine_events.py
+++ b/tests/graph_engine/test_raw_engine_events.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from graphon import graph_events, node_events
+from graphon.entities import GraphFailureSource
 from graphon.enums import BuiltinNodeTypes, NodeExecutionType
 from graphon.graph_engine.event_management.event_handlers import EventHandler
+from graphon.graph_engine.graph_engine import _GraphRunLifecycle
 from graphon.graph_events.node import (
     NodeRunReasoningChunkEvent,
     NodeRunStreamChunkEvent,
@@ -123,3 +125,114 @@ def test_event_handler_collects_traversal_events_before_node_success() -> None:
 
     collected_events = [call.args[0] for call in event_collector.collect.call_args_list]
     assert collected_events == [edge_event, success]
+
+
+def test_fatal_node_failure_records_exact_failure_source() -> None:
+    graph_execution = MagicMock()
+    graph_execution.get_or_create_node_execution.return_value = MagicMock()
+    error_handler = MagicMock()
+    error_handler.handle_node_failure.return_value = None
+    event_collector = MagicMock()
+    state_manager = MagicMock()
+    handler = EventHandler(
+        graph=cast(Any, MagicMock()),
+        graph_runtime_state=cast(Any, MagicMock()),
+        graph_execution=cast(Any, graph_execution),
+        event_collector=cast(Any, event_collector),
+        edge_processor=cast(Any, MagicMock()),
+        state_manager=cast(Any, state_manager),
+        error_handler=cast(Any, error_handler),
+    )
+    event = graph_events.NodeRunFailedEvent(
+        id="execution-a",
+        node_id="node-a",
+        node_type=BuiltinNodeTypes.CODE,
+        error="boom",
+        start_at=_now(),
+    )
+
+    handler.dispatch(event)
+
+    error = graph_execution.fail.call_args.args[0]
+    assert str(error) == "boom"
+    assert graph_execution.fail.call_args.kwargs == {
+        "failure_source": GraphFailureSource(
+            node_execution_id="execution-a",
+            node_id="node-a",
+        )
+    }
+
+
+def test_handled_node_failure_does_not_record_graph_failure_source() -> None:
+    graph_execution = MagicMock()
+    graph_execution.get_or_create_node_execution.return_value = MagicMock()
+    retry_event = graph_events.NodeRunRetryEvent(
+        id="execution-a",
+        node_id="node-a",
+        node_type=BuiltinNodeTypes.CODE,
+        node_title="Code",
+        start_at=_now(),
+        error="retrying",
+        retry_index=1,
+        in_iteration_id="iteration-a",
+    )
+    error_handler = MagicMock()
+    error_handler.handle_node_failure.return_value = retry_event
+    handler = EventHandler(
+        graph=cast(Any, MagicMock()),
+        graph_runtime_state=cast(Any, MagicMock()),
+        graph_execution=cast(Any, graph_execution),
+        event_collector=cast(Any, MagicMock()),
+        edge_processor=cast(Any, MagicMock()),
+        state_manager=cast(Any, MagicMock()),
+        error_handler=cast(Any, error_handler),
+    )
+    event = graph_events.NodeRunFailedEvent(
+        id="execution-a",
+        node_id="node-a",
+        node_type=BuiltinNodeTypes.CODE,
+        error="temporary failure",
+        start_at=_now(),
+    )
+
+    handler.dispatch(event)
+
+    graph_execution.fail.assert_not_called()
+
+
+def test_graph_failed_event_publishes_recorded_failure_source() -> None:
+    source = GraphFailureSource(
+        node_execution_id="execution-a",
+        node_id="node-a",
+    )
+    graph_execution = MagicMock(exceptions_count=1, failure_source=source)
+    event_manager = MagicMock()
+    lifecycle = _GraphRunLifecycle(
+        graph_execution=cast(Any, graph_execution),
+        event_manager=cast(Any, event_manager),
+        initialize_layers=MagicMock(),
+        start_execution=MagicMock(),
+        stop_execution=MagicMock(),
+        emit_terminal_events=MagicMock(),
+    )
+
+    event = lifecycle._failed_event(RuntimeError("boom"))
+
+    assert event.failure_source == source
+    event_manager.notify_layers.assert_called_once_with(event)
+
+
+def test_graph_failed_event_omits_unattributed_failure_source() -> None:
+    graph_execution = MagicMock(exceptions_count=0, failure_source=None)
+    lifecycle = _GraphRunLifecycle(
+        graph_execution=cast(Any, graph_execution),
+        event_manager=cast(Any, MagicMock()),
+        initialize_layers=MagicMock(),
+        start_execution=MagicMock(),
+        stop_execution=MagicMock(),
+        emit_terminal_events=MagicMock(),
+    )
+
+    event = lifecycle._failed_event(RuntimeError("infrastructure failed"))
+
+    assert event.failure_source is None

--- a/tests/graph_events/test_graph_run_failed_event.py
+++ b/tests/graph_events/test_graph_run_failed_event.py
@@ -1,0 +1,36 @@
+import pytest
+from pydantic import ValidationError
+
+from graphon.entities import GraphFailureSource
+from graphon.graph_events import GraphRunFailedEvent
+
+
+def test_graph_run_failed_event_carries_failure_source() -> None:
+    event = GraphRunFailedEvent(
+        error="upstream failed",
+        exceptions_count=1,
+        failure_source=GraphFailureSource(
+            node_execution_id="execution-a",
+            node_id="node-a",
+        ),
+    )
+
+    assert event.model_dump() == {
+        "error": "upstream failed",
+        "exceptions_count": 1,
+        "failure_source": {
+            "node_execution_id": "execution-a",
+            "node_id": "node-a",
+        },
+    }
+
+
+def test_graph_failure_source_rejects_partial_payload() -> None:
+    with pytest.raises(ValidationError):
+        GraphFailureSource.model_validate({"node_execution_id": "execution-a"})
+
+
+def test_graph_run_failed_event_defaults_to_no_failure_source() -> None:
+    event = GraphRunFailedEvent(error="infrastructure failed")
+
+    assert event.failure_source is None

--- a/tests/graph_events/test_graph_run_failed_event.py
+++ b/tests/graph_events/test_graph_run_failed_event.py
@@ -6,13 +6,15 @@ from graphon.graph_events import GraphRunFailedEvent
 
 
 def test_graph_run_failed_event_carries_failure_source() -> None:
+    source = GraphFailureSource(
+        node_execution_id="execution-a",
+        node_id="node-a",
+    )
     event = GraphRunFailedEvent(
         error="upstream failed",
         exceptions_count=1,
-        failure_source=GraphFailureSource(
-            node_execution_id="execution-a",
-            node_id="node-a",
-        ),
+        failure_source=source,
+        observed_failure_sources=[source],
     )
 
     assert event.model_dump() == {
@@ -22,6 +24,12 @@ def test_graph_run_failed_event_carries_failure_source() -> None:
             "node_execution_id": "execution-a",
             "node_id": "node-a",
         },
+        "observed_failure_sources": [
+            {
+                "node_execution_id": "execution-a",
+                "node_id": "node-a",
+            }
+        ],
     }
 
 
@@ -34,3 +42,4 @@ def test_graph_run_failed_event_defaults_to_no_failure_source() -> None:
     event = GraphRunFailedEvent(error="infrastructure failed")
 
     assert event.failure_source is None
+    assert event.observed_failure_sources == []

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from graphon.entities import GraphFailureSource
 from graphon.file import File, FileTransferMethod, FileType
 from graphon.graph_engine.domain.graph_execution import GraphExecution
 from graphon.graph_engine.ready_queue.in_memory import InMemoryReadyQueue
@@ -379,3 +380,26 @@ class TestGraphRuntimeState:
         assert restored_segment.value.id == "message-file-id"
         assert restored_segment.value.type == "document"
         assert restored_segment.value.reference == "upload-file-id"
+
+
+def test_graph_execution_snapshot_preserves_failure_source() -> None:
+    state = GraphRuntimeState(variable_pool=VariablePool(), start_at=time())
+    source = GraphFailureSource(
+        node_execution_id="execution-a",
+        node_id="node-a",
+    )
+    state.graph_execution.fail(RuntimeError("boom"), failure_source=source)
+
+    restored = GraphRuntimeState.from_snapshot(state.dumps())
+
+    assert restored.graph_execution.failure_source == source
+
+
+def test_graph_execution_loads_legacy_snapshot_without_failure_source() -> None:
+    execution = GraphExecution(workflow_id="wf")
+    payload = json.loads(execution.dumps())
+    payload.pop("failure_source", None)
+
+    execution.loads(json.dumps(payload))
+
+    assert execution.failure_source is None

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -395,6 +395,41 @@ def test_graph_execution_snapshot_preserves_failure_source() -> None:
     assert restored.graph_execution.failure_source == source
 
 
+def test_graph_execution_preserves_causal_failure_and_observes_later_failures() -> None:
+    execution = GraphExecution(workflow_id="wf")
+    first = GraphFailureSource(node_execution_id="execution-a", node_id="node-a")
+    second = GraphFailureSource(node_execution_id="execution-b", node_id="node-b")
+
+    execution.fail(RuntimeError("first"), failure_source=first)
+    execution.fail(RuntimeError("second"), failure_source=second)
+
+    assert str(execution.error) == "first"
+    assert execution.failure_source == first
+    assert execution.observed_failure_sources == [first, second]
+
+
+def test_graph_execution_deduplicates_observed_failure_sources() -> None:
+    execution = GraphExecution(workflow_id="wf")
+    source = GraphFailureSource(node_execution_id="execution-a", node_id="node-a")
+
+    execution.fail(RuntimeError("first"), failure_source=source)
+    execution.fail(RuntimeError("duplicate"), failure_source=source)
+
+    assert execution.observed_failure_sources == [source]
+
+
+def test_infrastructure_failure_remains_unattributed_after_late_node_failure() -> None:
+    execution = GraphExecution(workflow_id="wf")
+    source = GraphFailureSource(node_execution_id="execution-a", node_id="node-a")
+
+    execution.fail(RuntimeError("infrastructure"))
+    execution.fail(RuntimeError("node"), failure_source=source)
+
+    assert str(execution.error) == "infrastructure"
+    assert execution.failure_source is None
+    assert execution.observed_failure_sources == [source]
+
+
 def test_graph_execution_loads_legacy_snapshot_without_failure_source() -> None:
     execution = GraphExecution(workflow_id="wf")
     payload = json.loads(execution.dumps())

--- a/tests/runtime/test_graph_runtime_state.py
+++ b/tests/runtime/test_graph_runtime_state.py
@@ -382,17 +382,18 @@ class TestGraphRuntimeState:
         assert restored_segment.value.reference == "upload-file-id"
 
 
-def test_graph_execution_snapshot_preserves_failure_source() -> None:
+def test_graph_execution_snapshot_preserves_failure_attribution() -> None:
     state = GraphRuntimeState(variable_pool=VariablePool(), start_at=time())
-    source = GraphFailureSource(
-        node_execution_id="execution-a",
-        node_id="node-a",
-    )
-    state.graph_execution.fail(RuntimeError("boom"), failure_source=source)
+    first = GraphFailureSource(node_execution_id="execution-a", node_id="node-a")
+    second = GraphFailureSource(node_execution_id="execution-b", node_id="node-b")
+    state.graph_execution.fail(RuntimeError("first"), failure_source=first)
+    state.graph_execution.fail(RuntimeError("second"), failure_source=second)
 
     restored = GraphRuntimeState.from_snapshot(state.dumps())
 
-    assert restored.graph_execution.failure_source == source
+    assert str(restored.graph_execution.error) == "first"
+    assert restored.graph_execution.failure_source == first
+    assert restored.graph_execution.observed_failure_sources == [first, second]
 
 
 def test_graph_execution_preserves_causal_failure_and_observes_later_failures() -> None:
@@ -434,7 +435,9 @@ def test_graph_execution_loads_legacy_snapshot_without_failure_source() -> None:
     execution = GraphExecution(workflow_id="wf")
     payload = json.loads(execution.dumps())
     payload.pop("failure_source", None)
+    payload.pop("observed_failure_sources", None)
 
     execution.loads(json.dumps(payload))
 
     assert execution.failure_source is None
+    assert execution.observed_failure_sources == []


### PR DESCRIPTION
## Related Issue

Closes #220

## Summary

- Add an optional, strongly typed `GraphFailureSource` containing the fatal node execution and node identities.
- Record the source only when an unhandled node failure aborts the graph; handled failures and infrastructure failures remain unattributed.
- Preserve the source across graph runtime snapshots and publish it on `GraphRunFailedEvent` for downstream layers.
- Keep existing callers and legacy snapshots compatible by defaulting `failure_source` to `None`.

This is the Graphon half of a cross-repository fix. Companion PR: [langgenius/dify#39152](https://github.com/langgenius/dify/pull/39152). The Dify PR persists this source on collateral node executions, reconciles failed live-run state, and explains the causal failure in Web.

## Before-After
### Before

https://github.com/user-attachments/assets/4efbca9b-3ac0-402d-8a0f-3f0d0156c493


### After

https://github.com/user-attachments/assets/3efd74c8-8e50-499c-a0bb-13ff6cc1635d


### Validation

- `uv run pytest` — 612 passed.
- `uv run ruff format --check` — passed.
- `uv run ruff check` — passed.
- `uv run ty check` — passed.
- `uv run prek validate-config prek.toml` — passed.
- `uv lock --check` — passed.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation

From Codex
