### PR TITLE
feat(llm): expose model_provider and model_name as node outputs

### DIFF
--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -428,6 +428,8 @@ class LLMNode(Node[LLMNodeData]):
             finish_reason=finish_reason,
             reasoning_content=reasoning_content,
             structured_output=structured_output,
+            model_provider=model_provider,
+            model_name=model_name,
         )
         yield StreamChunkEvent(
             selector=[self._node_id, "text"],
@@ -726,12 +728,16 @@ class LLMNode(Node[LLMNodeData]):
         finish_reason: str | None,
         reasoning_content: str,
         structured_output: LLMStructuredOutput | None,
+        model_provider: str,
+        model_name: str,
     ) -> dict[str, Any]:
         outputs = {
             "text": clean_text,
             "reasoning_content": reasoning_content,
             "usage": jsonable_encoder(usage),
             "finish_reason": finish_reason,
+            "model_provider": model_provider or "",
+            "model_name": model_name or "",
         }
         if structured_output:
             outputs["structured_output"] = structured_output.structured_output

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -212,6 +212,50 @@ def test_run_emits_model_identity_in_node_result_inputs(
     assert completed_event.node_run_result.inputs["model_name"] == "gpt-4o"
 
 
+def test_run_emits_model_identity_in_node_result_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = _build_llm_node()
+
+    _stub_simple_prompt(monkeypatch, node)
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text="Hello back",
+                usage=LLMUsage.empty_usage(),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    events = list(node._run())
+    completed_event = next(
+        event for event in events if isinstance(event, StreamCompletedEvent)
+    )
+
+    assert completed_event.node_run_result.outputs["model_provider"] == "openai"
+    assert completed_event.node_run_result.outputs["model_name"] == "gpt-4o"
+
+
+def test_build_run_outputs_defaults_missing_model_identity_to_empty_strings() -> None:
+    node = _build_llm_node()
+
+    outputs = node._build_run_outputs(
+        clean_text="hi",
+        usage=LLMUsage.empty_usage(),
+        finish_reason=None,
+        reasoning_content="",
+        structured_output=None,
+        model_provider=cast(str, None),
+        model_name=cast(str, None),
+    )
+
+    assert outputs["model_provider"] == ""
+    assert outputs["model_name"] == ""
+    assert outputs["text"] == "hi"
+
+
 def test_polling_llm_start_can_succeed_immediately(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Important

1. [x] Make sure you have read our [contribution guidelines](https://github.com/langgenius/graphon/blob/main/CONTRIBUTING.md)
2. [x] Search existing issues and pull requests to confirm this change is not a duplicate
3. [x] Open or identify the issue this pull request resolves or advances
4. [x] Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. [x] Remember that the pull request title will become the squash merge commit message
6. [x] If CLA Assistant prompts you, sign [CLA.md](https://github.com/langgenius/graphon/blob/main/CLA.md) in the pull request conversation

## Related Issue

Advances #225

## Summary

Adds two top-level string outputs to the LLM node — `model_provider` and `model_name` — so downstream nodes can reference the generation's model identity.

**Use case.** I'm building a five-model comparison workflow: five parallel LLM nodes feed a judge node and an Answer node, and each response needs to be labelled with the model that produced it. There's no output variable carrying the model identity today, so the labels have to be **hardcoded as literal text** in the Answer node — which silently desyncs the moment a node's model is swapped. These outputs let the workflow label each response from the node's actual configuration.

**Implementation.** The pair is sourced from the model instance already in scope at output assembly — the same values `build_model_identity_inputs` already exposes to node *inputs*, reusing that naming convention rather than inventing `model`/`provider`. Falsy values coerce to empty strings so the outputs always carry both keys without raising. `self._model_instance` is typed non-optional and is already dereferenced one line earlier, so this introduces no new failure mode.

### Design choices — proposals, open to change

1. **Top-level, not nested under `usage`.** `usage` is metering data (tokens, prices, latency); model identity is a different kind of thing, and nesting would mean `{{#LLM.usage.model_name#}}` for the common case, with `usage` typed as an object making sub-field selection clumsier in the picker. That said, **`usage` is a legitimate alternative** — happy to move it there if you'd prefer.
2. **Two separate strings, not one combined identifier.** `ModelConfig` already stores `provider` and `name` separately and there's no precomputed combined form. Splitting also avoids the ambiguity of a bare model name, since two providers can serve same-named models. Happy to collapse to a single output if you'd rather keep the surface smaller.
3. **Names mirror the existing inputs.** Slightly more verbose than `model`, but consistent with what the codebase already calls these values.

### Companion frontend change

This alone won't surface the outputs in the variable picker — that list is hardcoded in `langgenius/dify`'s frontend (`LLM_OUTPUT_STRUCT`, the node's Output panel, and i18n). I'll open a companion PR there once this lands and a graphon release ships. Happy to do that whenever you're ready.

### Tests

Added to `tests/nodes/llm/test_node.py`, mirroring the existing `test_run_emits_model_identity_in_node_result_inputs`:

- an end-to-end test asserting both outputs carry the expected values
- a unit test for the empty-string fallback

`uv run pytest tests/nodes/llm/test_node.py` → 51 passed.

*Note: a full `uv sync` fails on ARM macOS building `llvmlite` (transitive via `unstructured` → `numba`), which is unrelated to the LLM node path. I ran the targeted suite with those packages skipped; CI uses Linux wheels, so this doesn't affect the build.*

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](https://github.com/langgenius/graphon/blob/main/CLA.md) in the pull request conversation

---

*Implemented with AI assistance (Claude) using a two-agent workflow, and reviewed by me before submitting.*