### PR TITLE
fix(runtime): support gevent-patched ready queues

### DIFF
--- a/src/graphon/graph_engine/ready_queue/in_memory.py
+++ b/src/graphon/graph_engine/ready_queue/in_memory.py
@@ -40,7 +40,9 @@ class InMemoryReadyQueue:
             maxsize: Maximum size of the queue (0 for unlimited)
 
         """
-        self._queue: queue.Queue[ReadyTask] = queue.Queue(maxsize=maxsize)
+        self._queue: queue.Queue[ReadyTask] = (
+            queue.Queue() if maxsize <= 0 else queue.Queue(maxsize=maxsize)
+        )
 
     def put(self, item: ReadyTask) -> None:
         """Add a task to the ready queue.
@@ -82,14 +84,17 @@ class InMemoryReadyQueue:
 
     def drain(self) -> list[ReadyTask]:
         """Remove and return all queued tasks in FIFO order."""
-        with self._queue.mutex:
-            items: list[ReadyTask] = list(self._queue.queue)
-            self._queue.queue.clear()
-            self._queue.unfinished_tasks -= len(items)
-            if items:
-                self._queue.not_full.notify_all()
-            if self._queue.unfinished_tasks == 0:
-                self._queue.all_tasks_done.notify_all()
+        # Queue has no public atomic drain API. Limit removals to the size observed
+        # at entry so newly unblocked producers are not chased; concurrent consumers
+        # can still make this a best-effort drain.
+        items: list[ReadyTask] = []
+        for _ in range(self._queue.qsize()):
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            items.append(item)
+            self._queue.task_done()
         return items
 
     def dumps(self) -> str:
@@ -99,12 +104,17 @@ class InMemoryReadyQueue:
             A JSON string containing the serialized queue state
 
         """
-        with self._queue.mutex:
-            items: list[ReadyTask] = list(self._queue.queue)
-        state = ReadyQueueState(
-            version="2.0",
-            items=tuple(items),
-        )
+        # Queue has no public snapshot API. This drain/restore cycle is not atomic;
+        # callers must quiesce producers and consumers while serializing.
+        items = self.drain()
+        try:
+            state = ReadyQueueState(
+                version="2.0",
+                items=tuple(items),
+            )
+        finally:
+            for item in items:
+                self._queue.put(item)
         return state.model_dump_json()
 
     def loads(self, data: str) -> None:
@@ -123,6 +133,9 @@ class InMemoryReadyQueue:
         else:
             items = state.items
 
+        # Replacing contents through public Queue operations is not atomic. Callers
+        # must quiesce producers and consumers; otherwise a partial restore may be
+        # observed, and bounded puts may block.
         self.drain()
 
         # Restore items

--- a/tests/graph_engine/test_cooperative_container_execution.py
+++ b/tests/graph_engine/test_cooperative_container_execution.py
@@ -2,6 +2,7 @@ import queue
 from collections.abc import Generator
 from datetime import UTC, datetime
 from threading import Event, Lock, Thread
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -165,6 +166,42 @@ def test_ready_queue_drain_notifies_waiting_bounded_queue_producers() -> None:
     assert unblocked
     assert not producer.is_alive()
     assert queue_.get(timeout=0.01) == second
+
+
+def test_ready_queue_uses_only_public_queue_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stdlib_queue = queue.Queue
+    backends: list[queue.Queue[object]] = []
+
+    def public_queue(maxsize: int = 0) -> SimpleNamespace:
+        backend: queue.Queue[object] = stdlib_queue(maxsize=maxsize)
+        backends.append(backend)
+        return SimpleNamespace(
+            get=backend.get,
+            get_nowait=backend.get_nowait,
+            put=backend.put,
+            qsize=backend.qsize,
+            task_done=backend.task_done,
+        )
+
+    monkeypatch.setattr(queue, "Queue", public_queue)
+    queue_ = InMemoryReadyQueue()
+    first = StartTask(frame_id="root", node_id="a")
+    second = StartTask(frame_id="child", node_id="b")
+    queue_.put(first)
+    queue_.put(second)
+
+    snapshot = queue_.dumps()
+
+    assert queue_.drain() == [first, second]
+    queue_.loads(snapshot)
+    assert queue_.drain() == [first, second]
+
+    join_thread = Thread(target=backends[0].join, daemon=True)
+    join_thread.start()
+    join_thread.join(timeout=1)
+    assert not join_thread.is_alive()
 
 
 def test_worker_suspends_and_resumes_container_invocation() -> None:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #232

## Summary

Use public Queue methods in the in-memory ready queue.

`dumps()` now drains and restores queued items. Producers and consumers must remain quiescent while it runs because Queue has no public atomic snapshot operation.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation