### PR TITLE
refactor(llm): centralize prompt construction and harden run state

### DIFF
--- a/src/graphon/nodes/llm/llm_utils.py
+++ b/src/graphon/nodes/llm/llm_utils.py
@@ -248,7 +248,7 @@ def fetch_prompt_messages(
     vision_detail: ImagePromptMessageContent.DETAIL,
     variable_pool: VariablePool,
     jinja2_variables: Sequence[VariableSelector],
-    context_files: list[File] | None = None,
+    context_files: Sequence[File] | None = None,
     jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
 ) -> tuple[Sequence[PromptMessage], Sequence[str] | None]:
     prompt_messages: list[PromptMessage] = []

--- a/src/graphon/nodes/llm/llm_utils.py
+++ b/src/graphon/nodes/llm/llm_utils.py
@@ -28,7 +28,7 @@ from graphon.model_runtime.memory.prompt_message_memory import PromptMessageMemo
 from graphon.nodes.base.entities import VariableSelector
 from graphon.prompt_entities import MemoryConfig
 from graphon.runtime.variable_pool import VariablePool
-from graphon.template_rendering import Jinja2TemplateRenderer
+from graphon.template_rendering import Jinja2TemplateRenderer, TemplateRenderError
 from graphon.variables.segments import (
     ArrayAnySegment,
     ArrayFileSegment,
@@ -207,13 +207,11 @@ def _filter_prompt_messages(
     filtered_prompt_messages: list[PromptMessage] = []
     for prompt_message in prompt_messages:
         if isinstance(prompt_message.content, list):
-            prompt_message_content: list[PromptMessageContentUnionTypes] = []
-            for content_item in prompt_message.content:
-                if not model_schema.supports_prompt_content_type(content_item.type):
-                    continue
-                prompt_message_content.append(content_item)
-            if not prompt_message_content:
-                continue
+            prompt_message_content = [
+                content_item
+                for content_item in prompt_message.content
+                if model_schema.supports_prompt_content_type(content_item.type)
+            ]
             if (
                 len(prompt_message_content) == 1
                 and prompt_message_content[0].type == PromptMessageContentType.TEXT
@@ -221,9 +219,9 @@ def _filter_prompt_messages(
                 prompt_message.content = prompt_message_content[0].data
             else:
                 prompt_message.content = prompt_message_content
-            filtered_prompt_messages.append(prompt_message)
-        elif not prompt_message.is_empty():
-            filtered_prompt_messages.append(prompt_message)
+        if prompt_message.is_empty():
+            continue
+        filtered_prompt_messages.append(prompt_message)
 
     if len(filtered_prompt_messages) == 0:
         msg = (
@@ -251,7 +249,7 @@ def fetch_prompt_messages(
     variable_pool: VariablePool,
     jinja2_variables: Sequence[VariableSelector],
     context_files: list[File] | None = None,
-    template_renderer: Jinja2TemplateRenderer | None = None,
+    jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
 ) -> tuple[Sequence[PromptMessage], Sequence[str] | None]:
     prompt_messages: list[PromptMessage] = []
     model_schema = fetch_model_schema(model_instance=model_instance)
@@ -265,7 +263,7 @@ def fetch_prompt_messages(
                     jinja2_variables=jinja2_variables,
                     variable_pool=variable_pool,
                     vision_detail_config=vision_detail,
-                    template_renderer=template_renderer,
+                    jinja2_template_renderer=jinja2_template_renderer,
                 ),
             )
             prompt_messages.extend(
@@ -290,7 +288,7 @@ def fetch_prompt_messages(
                         jinja2_variables=[],
                         variable_pool=variable_pool,
                         vision_detail_config=vision_detail,
-                        template_renderer=template_renderer,
+                        jinja2_template_renderer=jinja2_template_renderer,
                     ),
                 )
         case LLMNodeCompletionModelPromptTemplate():
@@ -300,7 +298,7 @@ def fetch_prompt_messages(
                     context=context,
                     jinja2_variables=jinja2_variables,
                     variable_pool=variable_pool,
-                    template_renderer=template_renderer,
+                    jinja2_template_renderer=jinja2_template_renderer,
                 ),
             )
 
@@ -345,7 +343,7 @@ def handle_list_messages(
     jinja2_variables: Sequence[VariableSelector],
     variable_pool: VariablePool,
     vision_detail_config: ImagePromptMessageContent.DETAIL,
-    template_renderer: Jinja2TemplateRenderer | None = None,
+    jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
 ) -> Sequence[PromptMessage]:
     prompt_messages: list[PromptMessage] = []
     for message in messages:
@@ -354,7 +352,7 @@ def handle_list_messages(
                 template=message.jinja2_text or "",
                 jinja2_variables=jinja2_variables,
                 variable_pool=variable_pool,
-                template_renderer=template_renderer,
+                jinja2_template_renderer=jinja2_template_renderer,
             )
             prompt_messages.append(
                 combine_message_content_with_role(
@@ -421,13 +419,13 @@ def render_jinja2_message(
     template: str,
     jinja2_variables: Sequence[VariableSelector],
     variable_pool: VariablePool,
-    template_renderer: Jinja2TemplateRenderer | None = None,
+    jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
 ) -> str:
     if not template:
         return ""
-    if template_renderer is None:
-        msg = "template_renderer is required for jinja2 prompt rendering"
-        raise ValueError(msg)
+    if jinja2_template_renderer is None:
+        msg = "LLM prompts require an injected jinja2_template_renderer."
+        raise TemplateRenderError(msg)
 
     jinja2_inputs: dict[str, Any] = {}
     for jinja2_variable in jinja2_variables:
@@ -435,7 +433,7 @@ def render_jinja2_message(
         jinja2_inputs[jinja2_variable.variable] = (
             variable.to_object() if variable else ""
         )
-    return template_renderer.render_template(template, jinja2_inputs)
+    return jinja2_template_renderer.render_template(template, jinja2_inputs)
 
 
 def handle_completion_template(
@@ -444,14 +442,14 @@ def handle_completion_template(
     context: str,
     jinja2_variables: Sequence[VariableSelector],
     variable_pool: VariablePool,
-    template_renderer: Jinja2TemplateRenderer | None = None,
+    jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
 ) -> Sequence[PromptMessage]:
     if template.edition_type == "jinja2":
         result_text = render_jinja2_message(
             template=template.jinja2_text or "",
             jinja2_variables=jinja2_variables,
             variable_pool=variable_pool,
-            template_renderer=template_renderer,
+            jinja2_template_renderer=jinja2_template_renderer,
         )
     else:
         template_text = template.text.replace(CONTEXT_PLACEHOLDER, context)

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -17,7 +17,6 @@ from graphon.enums import (
     WorkflowNodeExecutionMetadataKey,
     WorkflowNodeExecutionStatus,
 )
-from graphon.file import file_manager
 from graphon.file.enums import FileType
 from graphon.file.models import File
 from graphon.http import HttpClientProtocol
@@ -33,18 +32,13 @@ from graphon.model_runtime.entities.llm_entities import (
     LLMUsage,
 )
 from graphon.model_runtime.entities.message_entities import (
-    AssistantPromptMessage,
     ImagePromptMessageContent,
     MultiModalPromptMessageContent,
     PromptMessage,
     PromptMessageContentType,
     PromptMessageContentUnionTypes,
-    PromptMessageRole,
-    SystemPromptMessage,
     TextPromptMessageContent,
-    UserPromptMessage,
 )
-from graphon.model_runtime.entities.model_entities import ModelPropertyKey
 from graphon.model_runtime.memory.prompt_message_memory import PromptMessageMemory
 from graphon.model_runtime.utils.encoders import jsonable_encoder
 from graphon.node_events.base import (
@@ -76,17 +70,14 @@ from graphon.nodes.llm.runtime_protocols import (
 )
 from graphon.prompt_entities import MemoryConfig
 from graphon.runtime.graph_runtime_state import GraphRuntimeState
-from graphon.runtime.variable_pool import VariablePool
-from graphon.template_rendering import Jinja2TemplateRenderer, TemplateRenderError
+from graphon.template_rendering import Jinja2TemplateRenderer
 from graphon.variables.segments import (
     ArrayFileSegment,
     ArraySegment,
-    FileSegment,
     NoneSegment,
     ObjectSegment,
     StringSegment,
 )
-from graphon.variables.template_resolution import convert_template
 
 from . import llm_utils
 from .entities import (
@@ -98,9 +89,6 @@ from .exc import (
     InvalidContextStructureError,
     InvalidVariableTypeError,
     LLMNodeError,
-    MemoryRolePrefixRequiredError,
-    NoPromptFoundError,
-    TemplateTypeNotSupportError,
     VariableNotFoundError,
 )
 from .file_saver import LLMFileSaver
@@ -290,7 +278,7 @@ class LLMNode(Node[LLMNodeData]):
         node_inputs.update(
             llm_utils.build_model_identity_inputs(model_instance=model_instance),
         )
-        prompt_messages, stop = LLMNode.fetch_prompt_messages(
+        prompt_messages, stop = llm_utils.fetch_prompt_messages(
             sys_query=self._resolve_memory_query(),
             sys_files=files,
             context=collected_context.context or "",
@@ -1345,296 +1333,7 @@ class LLMNode(Node[LLMNodeData]):
 
         return None
 
-    @staticmethod
-    def fetch_prompt_messages(
-        *,
-        sys_query: str | None = None,
-        sys_files: Sequence[File],
-        context: str = "",
-        memory: PromptMessageMemory | None = None,
-        model_instance: LLMProtocol,
-        prompt_template: Sequence[LLMNodeChatModelMessage]
-        | LLMNodeCompletionModelPromptTemplate,
-        stop: Sequence[str] | None = None,
-        memory_config: MemoryConfig | None = None,
-        vision_enabled: bool = False,
-        vision_detail: ImagePromptMessageContent.DETAIL,
-        variable_pool: VariablePool,
-        jinja2_variables: Sequence[VariableSelector],
-        context_files: list[File] | None = None,
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> tuple[Sequence[PromptMessage], Sequence[str] | None]:
-        model_schema = llm_utils.fetch_model_schema(model_instance=model_instance)
-        prompt_messages = LLMNode._build_prompt_messages_from_template(
-            sys_query=sys_query,
-            context=context,
-            memory=memory,
-            model_instance=model_instance,
-            prompt_template=prompt_template,
-            memory_config=memory_config,
-            vision_detail=vision_detail,
-            variable_pool=variable_pool,
-            jinja2_variables=jinja2_variables,
-            jinja2_template_renderer=jinja2_template_renderer,
-        )
-        LLMNode._append_prompt_files(
-            prompt_messages=prompt_messages,
-            files=sys_files,
-            vision_enabled=vision_enabled,
-            vision_detail=vision_detail,
-        )
-        LLMNode._append_prompt_files(
-            prompt_messages=prompt_messages,
-            files=context_files,
-            vision_enabled=vision_enabled,
-            vision_detail=vision_detail,
-        )
-        filtered_prompt_messages = LLMNode._filter_prompt_messages(
-            prompt_messages=prompt_messages,
-            model_schema=model_schema,
-        )
-
-        if len(filtered_prompt_messages) == 0:
-            msg = (
-                "No prompt found in the LLM configuration. "
-                "Please ensure a prompt is properly configured before proceeding."
-            )
-            raise NoPromptFoundError(msg)
-
-        return filtered_prompt_messages, stop
-
-    @staticmethod
-    def _build_prompt_messages_from_template(
-        *,
-        sys_query: str | None,
-        context: str,
-        memory: PromptMessageMemory | None,
-        model_instance: LLMProtocol,
-        prompt_template: Sequence[LLMNodeChatModelMessage]
-        | LLMNodeCompletionModelPromptTemplate,
-        memory_config: MemoryConfig | None,
-        vision_detail: ImagePromptMessageContent.DETAIL,
-        variable_pool: VariablePool,
-        jinja2_variables: Sequence[VariableSelector],
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> list[PromptMessage]:
-        if isinstance(prompt_template, list):
-            return LLMNode._build_chat_prompt_messages(
-                messages=prompt_template,
-                sys_query=sys_query,
-                context=context,
-                memory=memory,
-                memory_config=memory_config,
-                model_instance=model_instance,
-                vision_detail=vision_detail,
-                variable_pool=variable_pool,
-                jinja2_variables=jinja2_variables,
-                jinja2_template_renderer=jinja2_template_renderer,
-            )
-
-        if isinstance(prompt_template, LLMNodeCompletionModelPromptTemplate):
-            return LLMNode._build_completion_prompt_messages(
-                sys_query=sys_query,
-                context=context,
-                memory=memory,
-                model_instance=model_instance,
-                prompt_template=prompt_template,
-                memory_config=memory_config,
-                variable_pool=variable_pool,
-                jinja2_variables=jinja2_variables,
-                jinja2_template_renderer=jinja2_template_renderer,
-            )
-
-        raise TemplateTypeNotSupportError(type_name=str(type(prompt_template)))
-
-    @staticmethod
-    def _build_chat_prompt_messages(
-        *,
-        messages: Sequence[LLMNodeChatModelMessage],
-        sys_query: str | None,
-        context: str,
-        memory: PromptMessageMemory | None,
-        memory_config: MemoryConfig | None,
-        model_instance: LLMProtocol,
-        vision_detail: ImagePromptMessageContent.DETAIL,
-        variable_pool: VariablePool,
-        jinja2_variables: Sequence[VariableSelector],
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> list[PromptMessage]:
-        prompt_messages = list(
-            LLMNode.handle_list_messages(
-                messages=messages,
-                context=context,
-                jinja2_variables=jinja2_variables,
-                variable_pool=variable_pool,
-                vision_detail_config=vision_detail,
-                jinja2_template_renderer=jinja2_template_renderer,
-            ),
-        )
-        prompt_messages.extend(
-            _handle_memory_chat_mode(
-                memory=memory,
-                memory_config=memory_config,
-                model_instance=model_instance,
-            ),
-        )
-        if not sys_query:
-            return prompt_messages
-
-        query_message = LLMNodeChatModelMessage(
-            text=sys_query,
-            role=PromptMessageRole.USER,
-            edition_type="basic",
-        )
-        prompt_messages.extend(
-            LLMNode.handle_list_messages(
-                messages=[query_message],
-                context="",
-                jinja2_variables=[],
-                variable_pool=variable_pool,
-                vision_detail_config=vision_detail,
-                jinja2_template_renderer=jinja2_template_renderer,
-            ),
-        )
-        return prompt_messages
-
-    @staticmethod
-    def _build_completion_prompt_messages(
-        *,
-        sys_query: str | None,
-        context: str,
-        memory: PromptMessageMemory | None,
-        model_instance: LLMProtocol,
-        prompt_template: LLMNodeCompletionModelPromptTemplate,
-        memory_config: MemoryConfig | None,
-        variable_pool: VariablePool,
-        jinja2_variables: Sequence[VariableSelector],
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> list[PromptMessage]:
-        prompt_messages = list(
-            _handle_completion_template(
-                template=prompt_template,
-                context=context,
-                jinja2_variables=jinja2_variables,
-                variable_pool=variable_pool,
-                jinja2_template_renderer=jinja2_template_renderer,
-            ),
-        )
-        memory_text = _handle_memory_completion_mode(
-            memory=memory,
-            memory_config=memory_config,
-            model_instance=model_instance,
-        )
-        LLMNode._merge_completion_memory(prompt_messages[0], memory_text)
-        if sys_query:
-            LLMNode._merge_completion_query(prompt_messages[0], sys_query)
-        return prompt_messages
-
-    @staticmethod
-    def _merge_completion_memory(
-        prompt_message: PromptMessage,
-        memory_text: str,
-    ) -> None:
-        prompt_content = prompt_message.content
-        if isinstance(prompt_content, str):
-            prompt_content = str(prompt_content)
-            if "#histories#" in prompt_content:
-                prompt_content = prompt_content.replace("#histories#", memory_text)
-            else:
-                prompt_content = memory_text + "\n" + prompt_content
-            prompt_message.content = prompt_content
-            return
-
-        if isinstance(prompt_content, list):
-            for content_item in prompt_content:
-                if not isinstance(content_item, TextPromptMessageContent):
-                    continue
-                if "#histories#" in content_item.data:
-                    content_item.data = content_item.data.replace(
-                        "#histories#",
-                        memory_text,
-                    )
-                else:
-                    content_item.data = memory_text + "\n" + content_item.data
-            return
-
-        msg = "Invalid prompt content type"
-        raise TypeError(msg)
-
-    @staticmethod
-    def _merge_completion_query(prompt_message: PromptMessage, sys_query: str) -> None:
-        prompt_content = prompt_message.content
-        if isinstance(prompt_content, str):
-            prompt_message.content = str(prompt_content).replace(
-                "#sys.query#",
-                sys_query,
-            )
-            return
-
-        if isinstance(prompt_content, list):
-            for content_item in prompt_content:
-                if isinstance(content_item, TextPromptMessageContent):
-                    content_item.data = sys_query + "\n" + content_item.data
-            return
-
-        msg = "Invalid prompt content type"
-        raise TypeError(msg)
-
-    @staticmethod
-    def _append_prompt_files(
-        *,
-        prompt_messages: list[PromptMessage],
-        files: Sequence[File] | None,
-        vision_enabled: bool,
-        vision_detail: ImagePromptMessageContent.DETAIL,
-    ) -> None:
-        if not vision_enabled or not files:
-            return
-
-        file_prompts = [
-            file_manager.to_prompt_message_content(
-                file,
-                image_detail_config=vision_detail,
-            )
-            for file in files
-        ]
-        if (
-            prompt_messages
-            and isinstance(prompt_messages[-1], UserPromptMessage)
-            and isinstance(prompt_messages[-1].content, list)
-        ):
-            prompt_messages[-1] = UserPromptMessage(
-                content=file_prompts + prompt_messages[-1].content,
-            )
-            return
-
-        prompt_messages.append(UserPromptMessage(content=file_prompts))
-
-    @staticmethod
-    def _filter_prompt_messages(
-        *,
-        prompt_messages: Sequence[PromptMessage],
-        model_schema: Any,
-    ) -> list[PromptMessage]:
-        filtered_prompt_messages = []
-        for prompt_message in prompt_messages:
-            if isinstance(prompt_message.content, list):
-                prompt_message_content = [
-                    content_item
-                    for content_item in prompt_message.content
-                    if model_schema.supports_prompt_content_type(content_item.type)
-                ]
-                if (
-                    len(prompt_message_content) == 1
-                    and prompt_message_content[0].type == PromptMessageContentType.TEXT
-                ):
-                    prompt_message.content = prompt_message_content[0].data
-                else:
-                    prompt_message.content = prompt_message_content
-            if prompt_message.is_empty():
-                continue
-            filtered_prompt_messages.append(prompt_message)
-        return filtered_prompt_messages
+    fetch_prompt_messages = staticmethod(llm_utils.fetch_prompt_messages)
 
     @classmethod
     @override
@@ -1803,159 +1502,6 @@ class LLMNode(Node[LLMNodeData]):
                 },
             },
         }
-
-    @staticmethod
-    def handle_list_messages(
-        *,
-        messages: Sequence[LLMNodeChatModelMessage],
-        context: str,
-        jinja2_variables: Sequence[VariableSelector],
-        variable_pool: VariablePool,
-        vision_detail_config: ImagePromptMessageContent.DETAIL,
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> Sequence[PromptMessage]:
-        prompt_messages: list[PromptMessage] = []
-        for message in messages:
-            prompt_messages.extend(
-                LLMNode._build_prompt_messages_for_message(
-                    message=message,
-                    context=context,
-                    jinja2_variables=jinja2_variables,
-                    variable_pool=variable_pool,
-                    vision_detail_config=vision_detail_config,
-                    jinja2_template_renderer=jinja2_template_renderer,
-                ),
-            )
-        return prompt_messages
-
-    @staticmethod
-    def _build_prompt_messages_for_message(
-        *,
-        message: LLMNodeChatModelMessage,
-        context: str,
-        jinja2_variables: Sequence[VariableSelector],
-        variable_pool: VariablePool,
-        vision_detail_config: ImagePromptMessageContent.DETAIL,
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> list[PromptMessage]:
-        if message.edition_type == "jinja2":
-            return [
-                LLMNode._build_jinja_prompt_message(
-                    message=message,
-                    jinja2_variables=jinja2_variables,
-                    variable_pool=variable_pool,
-                    jinja2_template_renderer=jinja2_template_renderer,
-                ),
-            ]
-        return LLMNode._build_basic_prompt_messages(
-            message=message,
-            context=context,
-            variable_pool=variable_pool,
-            vision_detail_config=vision_detail_config,
-        )
-
-    @staticmethod
-    def _build_jinja_prompt_message(
-        *,
-        message: LLMNodeChatModelMessage,
-        jinja2_variables: Sequence[VariableSelector],
-        variable_pool: VariablePool,
-        jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-    ) -> PromptMessage:
-        result_text = _render_jinja2_message(
-            template=message.jinja2_text or "",
-            jinja2_variables=jinja2_variables,
-            variable_pool=variable_pool,
-            jinja2_template_renderer=jinja2_template_renderer,
-        )
-        return _combine_message_content_with_role(
-            contents=[TextPromptMessageContent(data=result_text)],
-            role=message.role,
-        )
-
-    @staticmethod
-    def _build_basic_prompt_messages(
-        *,
-        message: LLMNodeChatModelMessage,
-        context: str,
-        variable_pool: VariablePool,
-        vision_detail_config: ImagePromptMessageContent.DETAIL,
-    ) -> list[PromptMessage]:
-        template = message.text.replace(llm_utils.CONTEXT_PLACEHOLDER, context)
-        segment_group = convert_template(variable_pool, template)
-        prompt_messages: list[PromptMessage] = []
-        plain_text = segment_group.text
-        if plain_text:
-            prompt_messages.append(
-                _combine_message_content_with_role(
-                    contents=[TextPromptMessageContent(data=plain_text)],
-                    role=message.role,
-                ),
-            )
-
-        file_contents = LLMNode._collect_multimodal_file_contents(
-            segment_group.value,
-            vision_detail_config=vision_detail_config,
-        )
-        if file_contents:
-            prompt_messages.append(
-                _combine_message_content_with_role(
-                    contents=file_contents,
-                    role=message.role,
-                ),
-            )
-        return prompt_messages
-
-    @staticmethod
-    def _collect_multimodal_file_contents(
-        segments: Sequence[Any],
-        *,
-        vision_detail_config: ImagePromptMessageContent.DETAIL,
-    ) -> list[PromptMessageContentUnionTypes]:
-        file_contents: list[PromptMessageContentUnionTypes] = []
-        for segment in segments:
-            file_contents.extend(
-                LLMNode._segment_to_prompt_message_contents(
-                    segment,
-                    vision_detail_config=vision_detail_config,
-                ),
-            )
-        return file_contents
-
-    @staticmethod
-    def _segment_to_prompt_message_contents(
-        segment: Any,
-        *,
-        vision_detail_config: ImagePromptMessageContent.DETAIL,
-    ) -> list[PromptMessageContentUnionTypes]:
-        if isinstance(segment, ArrayFileSegment):
-            return [
-                file_manager.to_prompt_message_content(
-                    file,
-                    image_detail_config=vision_detail_config,
-                )
-                for file in segment.value
-                if file.type
-                in frozenset((
-                    FileType.IMAGE,
-                    FileType.VIDEO,
-                    FileType.AUDIO,
-                    FileType.DOCUMENT,
-                ))
-            ]
-        if isinstance(segment, FileSegment) and segment.value.type in frozenset((
-            FileType.IMAGE,
-            FileType.VIDEO,
-            FileType.AUDIO,
-            FileType.DOCUMENT,
-        )):
-            return [
-                file_manager.to_prompt_message_content(
-                    segment.value,
-                    image_detail_config=vision_detail_config,
-                ),
-            ]
-        return []
 
     @staticmethod
     def handle_blocking_result(
@@ -2149,174 +1695,8 @@ class LLMNode(Node[LLMNodeData]):
         return self._model_instance
 
 
-def _combine_message_content_with_role(
-    *,
-    contents: str | list[PromptMessageContentUnionTypes] | None = None,
-    role: PromptMessageRole,
-) -> PromptMessage:
-    match role:
-        case PromptMessageRole.USER:
-            return UserPromptMessage(content=contents)
-        case PromptMessageRole.ASSISTANT:
-            return AssistantPromptMessage(content=contents)
-        case PromptMessageRole.SYSTEM:
-            return SystemPromptMessage(content=contents)
-        case PromptMessageRole.TOOL:
-            msg = f"Role {role} is not supported"
-            raise NotImplementedError(msg)
-        case _:
-            assert_never(role)
-
-
 def _format_to_extension_override(format_name: str) -> str | None:
     extension = format_name.strip().lstrip(".")
     if not extension:
         return None
     return f".{extension}"
-
-
-def _render_jinja2_message(
-    *,
-    template: str,
-    jinja2_variables: Sequence[VariableSelector],
-    variable_pool: VariablePool,
-    jinja2_template_renderer: Jinja2TemplateRenderer | None,
-) -> str:
-    if not template:
-        return ""
-
-    jinja2_inputs = {}
-    for jinja2_variable in jinja2_variables:
-        variable = variable_pool.get(jinja2_variable.value_selector)
-        jinja2_inputs[jinja2_variable.variable] = (
-            variable.to_object() if variable else ""
-        )
-    if jinja2_template_renderer is None:
-        msg = (
-            "LLMNode requires an injected jinja2_template_renderer for jinja2 prompts."
-        )
-        raise TemplateRenderError(msg)
-    return jinja2_template_renderer.render_template(template, jinja2_inputs)
-
-
-def _calculate_rest_token(
-    *,
-    prompt_messages: list[PromptMessage],
-    model_instance: LLMProtocol,
-) -> int:
-    rest_tokens = 2000
-    runtime_model_schema = llm_utils.fetch_model_schema(model_instance=model_instance)
-    runtime_model_parameters = model_instance.parameters
-
-    model_context_tokens = runtime_model_schema.model_properties.get(
-        ModelPropertyKey.CONTEXT_SIZE,
-    )
-    if model_context_tokens:
-        curr_message_tokens = model_instance.get_llm_num_tokens(prompt_messages)
-
-        max_tokens = 0
-        for parameter_rule in runtime_model_schema.parameter_rules:
-            if parameter_rule.name == "max_tokens" or (
-                parameter_rule.use_template
-                and parameter_rule.use_template == "max_tokens"
-            ):
-                max_tokens = (
-                    runtime_model_parameters.get(parameter_rule.name)
-                    or runtime_model_parameters.get(str(parameter_rule.use_template))
-                    or 0
-                )
-
-        rest_tokens = model_context_tokens - max_tokens - curr_message_tokens
-        rest_tokens = max(rest_tokens, 0)
-
-    return rest_tokens
-
-
-def _handle_memory_chat_mode(
-    *,
-    memory: PromptMessageMemory | None,
-    memory_config: MemoryConfig | None,
-    model_instance: LLMProtocol,
-) -> Sequence[PromptMessage]:
-    memory_messages: Sequence[PromptMessage] = []
-    # Get messages from memory for chat model
-    if memory and memory_config:
-        rest_tokens = _calculate_rest_token(
-            prompt_messages=[],
-            model_instance=model_instance,
-        )
-        memory_messages = memory.get_history_prompt_messages(
-            max_token_limit=rest_tokens,
-            message_limit=memory_config.window.size
-            if memory_config.window.enabled
-            else None,
-        )
-    return memory_messages
-
-
-def _handle_memory_completion_mode(
-    *,
-    memory: PromptMessageMemory | None,
-    memory_config: MemoryConfig | None,
-    model_instance: LLMProtocol,
-) -> str:
-    memory_text = ""
-    # Get history text from memory for completion model
-    if memory and memory_config:
-        rest_tokens = _calculate_rest_token(
-            prompt_messages=[],
-            model_instance=model_instance,
-        )
-        if not memory_config.role_prefix:
-            msg = "Memory role prefix is required for completion model."
-            raise MemoryRolePrefixRequiredError(msg)
-        memory_text = llm_utils.fetch_memory_text(
-            memory=memory,
-            max_token_limit=rest_tokens,
-            message_limit=memory_config.window.size
-            if memory_config.window.enabled
-            else None,
-            human_prefix=memory_config.role_prefix.user,
-            ai_prefix=memory_config.role_prefix.assistant,
-        )
-    return memory_text
-
-
-def _handle_completion_template(
-    *,
-    template: LLMNodeCompletionModelPromptTemplate,
-    context: str,
-    jinja2_variables: Sequence[VariableSelector],
-    variable_pool: VariablePool,
-    jinja2_template_renderer: Jinja2TemplateRenderer | None = None,
-) -> Sequence[PromptMessage]:
-    """Handle completion template processing outside of LLMNode class.
-
-    Args:
-        template: The completion model prompt template
-        context: Context string
-        jinja2_variables: Variables for jinja2 template rendering
-        variable_pool: Variable pool for template conversion
-        jinja2_template_renderer: Optional renderer for jinja2 templates
-
-    Returns:
-        Sequence of prompt messages
-
-    """
-    prompt_messages = []
-    if template.edition_type == "jinja2":
-        result_text = _render_jinja2_message(
-            template=template.jinja2_text or "",
-            jinja2_variables=jinja2_variables,
-            variable_pool=variable_pool,
-            jinja2_template_renderer=jinja2_template_renderer,
-        )
-    else:
-        template_text = template.text.replace(llm_utils.CONTEXT_PLACEHOLDER, context)
-        result_text = convert_template(variable_pool, template_text).text
-    prompt_message = _combine_message_content_with_role(
-        contents=[TextPromptMessageContent(data=result_text)],
-        role=PromptMessageRole.USER,
-    )
-    prompt_messages.append(prompt_message)
-    return prompt_messages

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -363,10 +363,7 @@ class LLMNode(Node[LLMNodeData]):
             prompt_messages=prompt_messages,
             stop=stop,
         )
-        usage = LLMUsage.empty_usage()
-        finish_reason = None
-        reasoning_content = ""
-        clean_text = ""
+        completed_event: ModelInvokeCompletedEvent | None = None
         structured_output: LLMStructuredOutput | None = None
 
         for event in generator:
@@ -382,18 +379,25 @@ class LLMNode(Node[LLMNodeData]):
                 continue
 
             if not isinstance(event, ModelInvokeCompletedEvent):
-                continue
+                msg = f"Unexpected LLM invocation event: {type(event).__name__}"
+                raise LLMNodeError(msg)
 
-            usage = event.usage
-            usage_holder["value"] = usage
-            finish_reason = event.finish_reason
-            reasoning_content = event.reasoning_content or ""
-            clean_text = self._extract_clean_text(event.text)
-            if event.structured_output:
+            completed_event = event
+            if completed_event.structured_output:
                 structured_output = LLMStructuredOutput(
-                    structured_output=event.structured_output,
+                    structured_output=completed_event.structured_output,
                 )
             break
+
+        if completed_event is None:
+            msg = "LLM invocation ended without a completion event"
+            raise LLMNodeError(msg)
+
+        usage = completed_event.usage
+        usage_holder["value"] = usage
+        finish_reason = completed_event.finish_reason
+        reasoning_content = completed_event.reasoning_content or ""
+        clean_text = self._extract_clean_text(completed_event.text)
 
         node_inputs.update(
             llm_utils.build_model_identity_inputs(model_instance=self._model_instance),

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -103,17 +103,17 @@ _MULTIMODAL_OUTPUT_FILE_TYPES: Mapping[PromptMessageContentType, FileType] = {
 }
 
 
-@dataclass
+@dataclass(frozen=True)
 class _CollectedRunContext:
     context: str | None = None
-    context_files: list[File] = field(default_factory=list)
+    context_files: Sequence[File] = field(default_factory=tuple)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _PreparedRunPrompt:
-    prompt_messages: Sequence[PromptMessage] = field(default_factory=tuple)
-    stop: Sequence[str] | None = None
-    model_instance: LLMProtocol | None = None
+    prompt_messages: Sequence[PromptMessage]
+    stop: Sequence[str] | None
+    model_instance: LLMProtocol
 
 
 @dataclass
@@ -194,13 +194,8 @@ class LLMNode(Node[LLMNodeData]):
         usage_holder = {"value": LLMUsage.empty_usage()}
 
         try:
-            prepared_prompt = _PreparedRunPrompt()
-            yield from self._prepare_run_prompt(
+            prepared_prompt = yield from self._prepare_run_prompt(
                 node_inputs=node_inputs,
-                prepared_prompt=prepared_prompt,
-            )
-            model_instance = self._require_model_instance(
-                prepared_prompt=prepared_prompt,
             )
 
             yield from self._yield_run_completion(
@@ -210,8 +205,8 @@ class LLMNode(Node[LLMNodeData]):
                 usage_holder=usage_holder,
                 prompt_messages=prepared_prompt.prompt_messages,
                 stop=prepared_prompt.stop,
-                model_provider=model_instance.provider,
-                model_name=model_instance.model_name,
+                model_provider=prepared_prompt.model_instance.provider,
+                model_name=prepared_prompt.model_instance.model_name,
             )
         except ValueError as exc:
             yield StreamCompletedEvent(
@@ -241,11 +236,10 @@ class LLMNode(Node[LLMNodeData]):
         self,
         *,
         node_inputs: dict[str, Any],
-        prepared_prompt: _PreparedRunPrompt,
     ) -> Generator[
         NodeEventBase,
         None,
-        None,
+        _PreparedRunPrompt,
     ]:
         self.node_data.prompt_template = self._transform_chat_messages(
             self.node_data.prompt_template,
@@ -264,10 +258,8 @@ class LLMNode(Node[LLMNodeData]):
         if files:
             node_inputs["#files#"] = [file.to_dict() for file in files]
 
-        collected_context = _CollectedRunContext()
-        yield from self._collect_run_context(
+        collected_context = yield from self._collect_run_context(
             node_inputs=node_inputs,
-            collected_context=collected_context,
         )
         model_instance = self._prepare_model_instance()
         node_inputs.update(
@@ -289,39 +281,34 @@ class LLMNode(Node[LLMNodeData]):
             context_files=collected_context.context_files,
             jinja2_template_renderer=self._jinja2_template_renderer,
         )
-        prepared_prompt.prompt_messages = prompt_messages
-        prepared_prompt.stop = stop
-        prepared_prompt.model_instance = model_instance
-
-    @staticmethod
-    def _require_model_instance(
-        *,
-        prepared_prompt: _PreparedRunPrompt,
-    ) -> LLMProtocol:
-        if prepared_prompt.model_instance is None:
-            msg = "model instance was not prepared"
-            raise AssertionError(msg)
-        return prepared_prompt.model_instance
+        return _PreparedRunPrompt(  # ruff:ignore[return-in-generator]
+            prompt_messages=prompt_messages,
+            stop=stop,
+            model_instance=model_instance,
+        )
 
     def _collect_run_context(
         self,
         *,
         node_inputs: dict[str, Any],
-        collected_context: _CollectedRunContext,
-    ) -> Generator[NodeEventBase, None, None]:
-        context_generator = self._fetch_context(node_data=self.node_data)
-        if context_generator is not None:
-            for event in context_generator:
-                collected_context.context = event.context
-                collected_context.context_files = event.context_files or []
-                yield event
+    ) -> Generator[NodeEventBase, None, _CollectedRunContext]:
+        context = None
+        context_files: Sequence[File] = ()
+        for event in self._fetch_context(node_data=self.node_data):
+            context = event.context
+            context_files = event.context_files or ()
+            yield event
 
-        if collected_context.context:
-            node_inputs["#context#"] = collected_context.context
-        if collected_context.context_files:
+        if context:
+            node_inputs["#context#"] = context
+        if context_files:
             node_inputs["#context_files#"] = [
-                file.model_dump() for file in collected_context.context_files
+                file.model_dump() for file in context_files
             ]
+        return _CollectedRunContext(  # ruff:ignore[return-in-generator]
+            context=context,
+            context_files=context_files,
+        )
 
     def _prepare_model_instance(self) -> LLMProtocol:
         model_instance = self._model_instance
@@ -584,16 +571,6 @@ class LLMNode(Node[LLMNodeData]):
         if isinstance(result, LLMPollingResult):
             return result
         return LLMPollingResult.model_validate(result)
-
-    def _resolve_required_workflow_run_id(self) -> str:
-        segment = self.graph_runtime_state.variable_pool.get(("sys", "workflow_run_id"))
-        if segment is not None and segment.text:
-            return segment.text
-        run_context_value = self.get_run_context_value("workflow_run_id")
-        if isinstance(run_context_value, str) and run_context_value:
-            return run_context_value
-        msg = "LLM polling requires workflow_run_id"
-        raise LLMNodeError(msg)
 
     @staticmethod
     def _updated_polling_deadline(

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -134,10 +134,6 @@ class _StreamingInvokeState:
 class LLMNode(Node[LLMNodeData]):
     node_type = BuiltinNodeTypes.LLM
 
-    # Instance attributes specific to LLMNode.
-    # Output variable for file
-    _file_outputs: list[File]
-
     _llm_file_saver: LLMFileSaver
     _retriever_attachment_loader: RetrieverAttachmentLoaderProtocol | None
     _prompt_message_serializer: PromptMessageSerializerProtocol
@@ -171,9 +167,6 @@ class LLMNode(Node[LLMNodeData]):
             graph_init_params=graph_init_params,
             graph_runtime_state=graph_runtime_state,
         )
-        # LLM file outputs, used for MultiModal outputs.
-        self._file_outputs = []
-
         _ = credentials_provider, model_factory, http_client
         self._model_instance = model_instance
         self._memory = memory
@@ -197,6 +190,7 @@ class LLMNode(Node[LLMNodeData]):
     def _run(self) -> Generator:
         node_inputs: dict[str, Any] = {}
         process_data: dict[str, Any] = {}
+        file_outputs: list[File] = []
         usage_holder = {"value": LLMUsage.empty_usage()}
 
         try:
@@ -212,6 +206,7 @@ class LLMNode(Node[LLMNodeData]):
             yield from self._yield_run_completion(
                 node_inputs=node_inputs,
                 process_data=process_data,
+                file_outputs=file_outputs,
                 usage_holder=usage_holder,
                 prompt_messages=prepared_prompt.prompt_messages,
                 stop=prepared_prompt.stop,
@@ -255,8 +250,8 @@ class LLMNode(Node[LLMNodeData]):
         self.node_data.prompt_template = self._transform_chat_messages(
             self.node_data.prompt_template,
         )
-        inputs = self._fetch_inputs(node_data=self.node_data)
-        inputs.update(self._fetch_jinja_inputs(node_data=self.node_data))
+        node_inputs.update(self._fetch_inputs(node_data=self.node_data))
+        node_inputs.update(self._fetch_jinja_inputs(node_data=self.node_data))
 
         files = (
             llm_utils.fetch_files(
@@ -356,6 +351,7 @@ class LLMNode(Node[LLMNodeData]):
         *,
         node_inputs: dict[str, Any],
         process_data: dict[str, Any],
+        file_outputs: list[File],
         usage_holder: dict[str, LLMUsage],
         prompt_messages: Sequence[PromptMessage],
         stop: Sequence[str] | None,
@@ -363,6 +359,7 @@ class LLMNode(Node[LLMNodeData]):
         model_name: str,
     ) -> Generator[NodeEventBase, None, None]:
         generator = self._invoke_llm_for_run(
+            file_outputs=file_outputs,
             prompt_messages=prompt_messages,
             stop=stop,
         )
@@ -416,6 +413,7 @@ class LLMNode(Node[LLMNodeData]):
             finish_reason=finish_reason,
             reasoning_content=reasoning_content,
             structured_output=structured_output,
+            file_outputs=file_outputs,
         )
         yield StreamChunkEvent(
             selector=[self._node_id, "text"],
@@ -440,6 +438,7 @@ class LLMNode(Node[LLMNodeData]):
     def _invoke_llm_for_run(
         self,
         *,
+        file_outputs: list[File],
         prompt_messages: Sequence[PromptMessage],
         stop: Sequence[str] | None,
     ) -> Generator[NodeEventBase | LLMStructuredOutput, None, None]:
@@ -452,12 +451,13 @@ class LLMNode(Node[LLMNodeData]):
                 structured_output_enabled=self.node_data.structured_output_enabled,
                 structured_output=self.node_data.structured_output,
                 file_saver=self._llm_file_saver,
-                file_outputs=self._file_outputs,
+                file_outputs=file_outputs,
                 node_id=self._node_id,
                 reasoning_format=self.node_data.reasoning_format,
             )
 
         return self._invoke_llm_with_polling(
+            file_outputs=file_outputs,
             polling_model=polling_model,
             prompt_messages=prompt_messages,
             stop=stop,
@@ -471,6 +471,7 @@ class LLMNode(Node[LLMNodeData]):
     def _invoke_llm_with_polling(
         self,
         *,
+        file_outputs: list[File],
         polling_model: LLMPollingCapableProtocol,
         prompt_messages: Sequence[PromptMessage],
         stop: Sequence[str] | None,
@@ -521,7 +522,7 @@ class LLMNode(Node[LLMNodeData]):
                     yield from LLMNode.handle_invoke_result(
                         invoke_result=polling_result.result,
                         file_saver=self._llm_file_saver,
-                        file_outputs=self._file_outputs,
+                        file_outputs=file_outputs,
                         node_id=self._node_id,
                         model_instance=self._model_instance,
                         reasoning_format=self.node_data.reasoning_format,
@@ -714,6 +715,7 @@ class LLMNode(Node[LLMNodeData]):
         finish_reason: str | None,
         reasoning_content: str,
         structured_output: LLMStructuredOutput | None,
+        file_outputs: list[File],
     ) -> dict[str, Any]:
         outputs = {
             "text": clean_text,
@@ -723,8 +725,8 @@ class LLMNode(Node[LLMNodeData]):
         }
         if structured_output:
             outputs["structured_output"] = structured_output.structured_output
-        if self._file_outputs:
-            outputs["files"] = ArrayFileSegment(value=self._file_outputs)
+        if file_outputs:
+            outputs["files"] = ArrayFileSegment(value=file_outputs)
         return outputs
 
     @staticmethod
@@ -1208,11 +1210,11 @@ class LLMNode(Node[LLMNodeData]):
     ) -> None:
         for variable_selector in variable_selectors:
             variable = self._get_required_variable(variable_selector)
-            if isinstance(variable, NoneSegment):
-                if skip_none:
-                    continue
-                inputs[variable_selector.variable] = ""
-            inputs[variable_selector.variable] = variable.to_object()
+            if skip_none and isinstance(variable, NoneSegment):
+                continue
+            inputs[variable_selector.variable] = (
+                "" if isinstance(variable, NoneSegment) else variable.to_object()
+            )
 
     @staticmethod
     def _extract_memory_query_variable_selectors(

--- a/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
+++ b/src/graphon/nodes/parameter_extractor/parameter_extractor_node.py
@@ -40,7 +40,6 @@ from graphon.nodes.llm.entities import (
     LLMNodeChatModelMessage,
     LLMNodeCompletionModelPromptTemplate,
 )
-from graphon.nodes.llm.node import LLMNode
 from graphon.nodes.llm.runtime_protocols import (
     LLMProtocol,
     PromptMessageSerializerProtocol,
@@ -1151,7 +1150,7 @@ class ParameterExtractorNode(Node[ParameterExtractorNodeData]):
         context: str | None = "",
         image_detail_config: ImagePromptMessageContent.DETAIL | None = None,
     ) -> list[PromptMessage]:
-        prompt_messages, _ = LLMNode.fetch_prompt_messages(
+        prompt_messages, _ = llm_utils.fetch_prompt_messages(
             sys_query="",
             sys_files=files,
             context=context or "",

--- a/src/graphon/nodes/question_classifier/question_classifier_node.py
+++ b/src/graphon/nodes/question_classifier/question_classifier_node.py
@@ -337,7 +337,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             vision_detail=self.node_data.vision.configs.detail,
             variable_pool=self.graph_runtime_state.variable_pool,
             jinja2_variables=[],
-            template_renderer=self._template_renderer,
+            jinja2_template_renderer=self._template_renderer,
         )
 
     def _invoke_classifier(
@@ -512,7 +512,7 @@ class QuestionClassifierNode(Node[QuestionClassifierNodeData]):
             vision_detail=node_data.vision.configs.detail,
             variable_pool=self.graph_runtime_state.variable_pool,
             jinja2_variables=[],
-            template_renderer=self._template_renderer,
+            jinja2_template_renderer=self._template_renderer,
         )
         rest_tokens = 2000
 

--- a/tests/nodes/llm/test_llm_utils.py
+++ b/tests/nodes/llm/test_llm_utils.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from graphon.model_runtime.entities.message_entities import (
+    ImagePromptMessageContent,
+    PromptMessageRole,
+)
+from graphon.nodes.llm import llm_utils
+from graphon.nodes.llm.entities import LLMNodeChatModelMessage
+from graphon.nodes.llm.exc import NoPromptFoundError
+from graphon.template_rendering import TemplateRenderError
+
+from ...helpers import build_variable_pool
+
+
+def _model_instance() -> MagicMock:
+    model_schema = MagicMock()
+    model_schema.supports_prompt_content_type.return_value = True
+    return MagicMock(get_model_schema=MagicMock(return_value=model_schema))
+
+
+def test_fetch_prompt_messages_renders_basic_variables_and_context() -> None:
+    prompt_messages, stop = llm_utils.fetch_prompt_messages(
+        prompt_template=[
+            LLMNodeChatModelMessage(
+                text="Hello {{#start.name#}} from {{#context#}}",
+                role=PromptMessageRole.USER,
+                edition_type="basic",
+            ),
+        ],
+        sys_files=[],
+        context="Graphon",
+        model_instance=_model_instance(),
+        stop=["done"],
+        vision_detail=ImagePromptMessageContent.DETAIL.HIGH,
+        variable_pool=build_variable_pool(
+            variables=[(("start", "name"), "Ada")],
+        ),
+        jinja2_variables=[],
+    )
+
+    assert prompt_messages[0].content == "Hello Ada from Graphon"
+    assert stop == ["done"]
+
+
+def test_fetch_prompt_messages_rejects_empty_jinja_prompt() -> None:
+    with pytest.raises(NoPromptFoundError):
+        llm_utils.fetch_prompt_messages(
+            prompt_template=[
+                LLMNodeChatModelMessage(
+                    text="",
+                    jinja2_text="",
+                    role=PromptMessageRole.USER,
+                    edition_type="jinja2",
+                ),
+            ],
+            sys_files=[],
+            model_instance=_model_instance(),
+            vision_detail=ImagePromptMessageContent.DETAIL.HIGH,
+            variable_pool=build_variable_pool(),
+            jinja2_variables=[],
+        )
+
+
+def test_fetch_prompt_messages_requires_jinja_renderer() -> None:
+    with pytest.raises(TemplateRenderError):
+        llm_utils.fetch_prompt_messages(
+            prompt_template=[
+                LLMNodeChatModelMessage(
+                    text="",
+                    jinja2_text="{{ value }}",
+                    role=PromptMessageRole.USER,
+                    edition_type="jinja2",
+                ),
+            ],
+            sys_files=[],
+            model_instance=_model_instance(),
+            vision_detail=ImagePromptMessageContent.DETAIL.HIGH,
+            variable_pool=build_variable_pool(),
+            jinja2_variables=[],
+        )

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -182,9 +182,8 @@ def _stub_simple_prompt(monkeypatch: pytest.MonkeyPatch, node: LLMNode) -> None:
     monkeypatch.setattr(node, "_fetch_jinja_inputs", lambda **_: {})
     monkeypatch.setattr(node, "_collect_run_context", lambda **_: iter(()))
     monkeypatch.setattr(
-        LLMNode,
-        "fetch_prompt_messages",
-        staticmethod(lambda **_: ([], None)),
+        "graphon.nodes.llm.node.llm_utils.fetch_prompt_messages",
+        lambda **_: ([], None),
     )
 
 

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -304,6 +304,34 @@ def test_run_does_not_reuse_file_outputs_after_failure(
     assert "files" not in second_completed.node_run_result.outputs
 
 
+@pytest.mark.parametrize(
+    ("invoke_events", "expected_error"),
+    [
+        ([], "without a completion event"),
+        ([NodeEventBase()], "Unexpected LLM invocation event: NodeEventBase"),
+    ],
+)
+def test_run_rejects_invalid_invocation_event_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+    invoke_events: list[NodeEventBase],
+    expected_error: str,
+) -> None:
+    node = _build_llm_node()
+    _stub_simple_prompt(monkeypatch, node)
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.LLMNode.invoke_llm",
+        lambda **_: iter(invoke_events),
+    )
+
+    completed_event = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+
+    assert completed_event.node_run_result.status == WorkflowNodeExecutionStatus.FAILED
+    assert completed_event.node_run_result.error_type == "LLMNodeError"
+    assert expected_error in completed_event.node_run_result.error
+
+
 def test_polling_llm_start_can_succeed_immediately(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -181,7 +181,7 @@ def _build_llm_node(
 def _stub_simple_prompt(monkeypatch: pytest.MonkeyPatch, node: LLMNode) -> None:
     monkeypatch.setattr(node, "_fetch_inputs", lambda **_: {})
     monkeypatch.setattr(node, "_fetch_jinja_inputs", lambda **_: {})
-    monkeypatch.setattr(node, "_collect_run_context", lambda **_: iter(()))
+    monkeypatch.setattr(node, "_fetch_context", lambda **_: iter(()))
     monkeypatch.setattr(
         "graphon.nodes.llm.node.llm_utils.fetch_prompt_messages",
         lambda **_: ([], None),

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -123,6 +123,7 @@ def _stream_results(
 def _build_llm_node(
     *,
     model_instance: object | None = None,
+    prompt_text: str = "Hello",
     variables: Sequence[tuple[Sequence[str], Any]] = (),
     workflow_run_id: str | None = "wr-test",
     run_context: dict[str, Any] | None = None,
@@ -154,7 +155,7 @@ def _build_llm_node(
             "prompt_template": [
                 {
                     "role": "user",
-                    "text": "Hello",
+                    "text": prompt_text,
                 }
             ],
             "context": {"enabled": False},
@@ -211,6 +212,96 @@ def test_run_emits_model_identity_in_node_result_inputs(
 
     assert completed_event.node_run_result.inputs["model_provider"] == "openai"
     assert completed_event.node_run_result.inputs["model_name"] == "gpt-4o"
+
+
+def test_run_records_resolved_prompt_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = _build_llm_node(
+        prompt_text="{{#source.value#}}",
+        variables=[(("source", "value"), "recorded")],
+    )
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.llm_utils.fetch_prompt_messages",
+        lambda **_: ([], None),
+    )
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text="ok",
+                usage=LLMUsage.empty_usage(),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    completed_event = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+
+    assert completed_event.node_run_result.inputs["#source.value#"] == "recorded"
+
+
+def test_fetch_inputs_normalizes_none_to_empty_string() -> None:
+    node = _build_llm_node(
+        prompt_text="{{#source.value#}}",
+        variables=[(("source", "value"), None)],
+    )
+
+    assert node._fetch_inputs(node.node_data) == {"#source.value#": ""}
+
+
+def test_run_does_not_reuse_file_outputs_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved_file = File(
+        file_id="saved",
+        file_type=FileType.VIDEO,
+        transfer_method=FileTransferMethod.TOOL_FILE,
+        reference="saved",
+        filename="video.mp4",
+        extension=".mp4",
+        mime_type="video/mp4",
+        size=1,
+    )
+    attempts = 0
+
+    def invoke(
+        **kwargs: Any,
+    ) -> Generator[
+        NodeEventBase | LLMStructuredOutput,
+        None,
+        None,
+    ]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            kwargs["file_outputs"].append(saved_file)
+            msg = "retry"
+            raise LLMNodeError(msg)
+        yield ModelInvokeCompletedEvent(
+            text="ok",
+            usage=LLMUsage.empty_usage(),
+            finish_reason="stop",
+        )
+
+    node = _build_llm_node()
+    _stub_simple_prompt(monkeypatch, node)
+    monkeypatch.setattr("graphon.nodes.llm.node.LLMNode.invoke_llm", invoke)
+
+    first_completed = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+    second_completed = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+
+    assert first_completed.node_run_result.status == WorkflowNodeExecutionStatus.FAILED
+    assert (
+        second_completed.node_run_result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    )
+    assert "files" not in second_completed.node_run_result.outputs
 
 
 def test_polling_llm_start_can_succeed_immediately(


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #240

## Summary

- Make `llm_utils` the canonical prompt-message construction path for LLM-related nodes, removing the duplicate implementation from `LLMNode`.
- Scope generated files and resolved input data to each run so state cannot leak between invocations.
- Require an invocation completion event before a run can succeed.
- Return prepared prompt state directly and remove unused control-flow code.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
