### PR TITLE
feat(model-runtime): retain credential form schema help from manifests

### DIFF
--- a/src/graphon/dsl/slim/package_loader.py
+++ b/src/graphon/dsl/slim/package_loader.py
@@ -390,6 +390,7 @@ class SlimPackageLoader:
             variable=str(value["variable"]),
             label=self._convert_i18n(value.get("label")),
             type=form_type,
+            help=self._convert_optional_i18n(value.get("help")),
             required=bool(value.get("required", True)),
             default=value.get("default"),
             options=[

--- a/src/graphon/model_runtime/entities/provider_entities.py
+++ b/src/graphon/model_runtime/entities/provider_entities.py
@@ -52,6 +52,7 @@ class CredentialFormSchema(BaseModel):
     variable: str
     label: I18nObject
     type: FormType
+    help: I18nObject | None = None
     required: bool = True
     default: str | None = None
     options: list[FormOption] | None = None

--- a/tests/dsl/test_slim_package_loader.py
+++ b/tests/dsl/test_slim_package_loader.py
@@ -142,3 +142,113 @@ def _write_multi_provider_plugin(plugin_root: Path) -> None:
             + "\n",
             encoding="utf-8",
         )
+
+
+def test_slim_package_loader_retains_credential_help(tmp_path: Path) -> None:
+    """The slim loader must carry a manifest's per-field `help` through.
+
+    `_convert_credential_form_schema` builds `CredentialFormSchema` field by
+    field, so adding the field to the entity alone is not enough on this path —
+    this test covers that second drop point.
+    """
+    plugin_root = tmp_path / "plugin"
+    _write_credential_help_plugin(plugin_root)
+
+    binding = SlimProviderBinding(
+        plugin_id="author/fake:0.0.1@test",
+        provider="help-provider",
+        plugin_root=plugin_root,
+    )
+    loader = SlimPackageLoader(
+        SlimConfig(
+            bindings=[binding],
+            local=SlimLocalSettings(folder=tmp_path / "plugins"),
+        ),
+    )
+
+    loaded = loader.load(binding)
+    credential_schema = loaded.provider_entity.provider_credential_schema
+    assert credential_schema is not None
+    form_schemas = {
+        schema.variable: schema for schema in credential_schema.credential_form_schemas
+    }
+
+    assert form_schemas["api_key"].help is not None
+    assert form_schemas["api_key"].help.en_us == "Find this in the provider console."
+    assert form_schemas["api_key"].help.zh_hans == "在提供商控制台中查找。"
+    # A field without `help` still loads, unchanged.
+    assert form_schemas["api_base"].help is None
+
+
+def _write_credential_help_plugin(plugin_root: Path) -> None:
+    (plugin_root / "_assets").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "provider").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "models" / "llm").mkdir(parents=True, exist_ok=True)
+
+    (plugin_root / "manifest.yaml").write_text(
+        textwrap.dedent(
+            """
+            plugins:
+              models:
+                - provider/help.yaml
+            """,
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (plugin_root / "_assets" / "icon.svg").write_text(
+        "<svg xmlns='http://www.w3.org/2000/svg'></svg>\n",
+        encoding="utf-8",
+    )
+    (plugin_root / "provider" / "help.yaml").write_text(
+        textwrap.dedent(
+            """
+            provider: help-provider
+            label:
+              en_US: Help Provider
+            icon_small:
+              en_US: icon.svg
+            supported_model_types:
+              - llm
+            configurate_methods:
+              - predefined-model
+            models:
+              llm:
+                predefined:
+                  - models/llm/help-chat.yaml
+            provider_credential_schema:
+              credential_form_schemas:
+                - variable: api_key
+                  label:
+                    en_US: API Key
+                  type: secret-input
+                  required: true
+                  help:
+                    en_US: Find this in the provider console.
+                    zh_Hans: 在提供商控制台中查找。
+                - variable: api_base
+                  label:
+                    en_US: API Base
+                  type: text-input
+                  required: false
+            """,
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (plugin_root / "models" / "llm" / "help-chat.yaml").write_text(
+        textwrap.dedent(
+            """
+            model: help-chat
+            label:
+              en_US: Help Chat Model
+            model_type: llm
+            fetch_from: predefined-model
+            model_properties:
+              mode: chat
+              context_size: 8192
+            """,
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )

--- a/tests/model_runtime/test_provider_entities.py
+++ b/tests/model_runtime/test_provider_entities.py
@@ -1,0 +1,61 @@
+from graphon.model_runtime.entities.provider_entities import (
+    CredentialFormSchema,
+    FormType,
+    ProviderCredentialSchema,
+)
+
+
+def test_credential_form_schema_retains_help_from_manifest() -> None:
+    """A manifest's per-field `help` must survive unmarshal.
+
+    `dify-plugin-daemon#774` made the daemon return `help` on model-provider
+    credential fields. Without an explicit field here, pydantic's default
+    `extra="ignore"` discards the key and no consumer can ever see it.
+    """
+    schema = CredentialFormSchema.model_validate({
+        "variable": "api_key",
+        "label": {"en_US": "API Key"},
+        "type": "secret-input",
+        "help": {
+            "en_US": "Get your API key from the provider console.",
+            "zh_Hans": "从提供商控制台获取密钥。",
+        },
+        "required": True,
+    })
+
+    assert schema.help is not None
+    assert schema.help.en_us == "Get your API key from the provider console."
+    assert schema.help.zh_hans == "从提供商控制台获取密钥。"
+    assert schema.model_dump()["help"]["en_US"] == (
+        "Get your API key from the provider console."
+    )
+
+
+def test_credential_form_schema_help_is_optional() -> None:
+    """A manifest that parses today must keep parsing unchanged."""
+    schema = CredentialFormSchema.model_validate({
+        "variable": "api_base",
+        "label": {"en_US": "API Base"},
+        "type": FormType.TEXT_INPUT,
+    })
+
+    assert schema.help is None
+
+
+def test_provider_credential_schema_retains_nested_help() -> None:
+    """`help` survives when nested inside a provider credential schema."""
+    credential_schema = ProviderCredentialSchema.model_validate({
+        "credential_form_schemas": [
+            {
+                "variable": "api_key",
+                "label": {"en_US": "API Key"},
+                "type": "secret-input",
+                "help": {"en_US": "Found under Settings → API."},
+            },
+        ],
+    })
+
+    assert credential_schema.credential_form_schemas[0].help is not None
+    assert credential_schema.credential_form_schemas[0].help.en_us == (
+        "Found under Settings → API."
+    )


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

No graphon issue exists for this. This PR is the graphon half of a cross-repo change whose first half has already merged: **langgenius/dify-plugin-daemon#774** (merged 2026-08-04). I searched graphon's open and merged PRs and its issues for `provider_entities`, `CredentialFormSchema` and credential `help` and found no duplicate — happy to open a tracking issue first if maintainers prefer that order.

## Summary

**A plugin manifest's per-field `help` currently cannot reach any consumer, because graphon discards it.**

The chain, in order:

1. **Merged.** `dify-plugin-daemon#774` added `Help` to the daemon's `ModelProviderCredentialFormSchema`, so a manifest's per-field `help` now survives unmarshal in the daemon and reaches the management-API declaration.
2. **This PR.** graphon's `CredentialFormSchema` has no `help` field. It sets no `ConfigDict`, so pydantic v2's default `extra="ignore"` applies and the key is dropped **silently** on unmarshal. Whatever the daemon sends, graphon throws it away.
3. **Still unfiled.** The Dify frontend needs to map `help` → `tooltip` for model-provider credentials. That work is blocked until this lands, since today the value never gets far enough to be mapped.

### The change

Two lines.

**`CredentialFormSchema` gains `help: I18nObject | None = None`.** This mirrors a shape this codebase already uses: `ParameterRule` in `model_runtime/entities/model_entities.py` already carries `help: I18nObject | None = None`, in the same position relative to `label` and `type`. `I18nObject` was already imported in `provider_entities.py`.

**The slim package loader forwards the key.** `SlimPackageLoader._convert_credential_form_schema` builds `CredentialFormSchema` field by field from the raw manifest dict rather than validating it, so it dropped `help` independently of the entity definition — adding the field alone would have left this path still silently discarding the value. The added line is identical in form to what `_convert_parameter_rule` in the same file already does for `ParameterRule.help`: `help=self._convert_optional_i18n(value.get("help"))`.

I traced the parsed schema to its other consumers to check for any further drop point. `schema_validators/common_validator.py` accesses fields by attribute name only, and `ProviderCredentialSchema` / `ModelCredentialSchema` simply hold `list[CredentialFormSchema]`; neither enumerates fields positionally or exhaustively, so neither is disturbed by an added optional field and neither drops the value. **After these two lines there is no remaining drop point inside graphon.**

### Scope and limits

- **Additive and optional.** `help` defaults to `None`; `_convert_optional_i18n` returns `None` for a missing key. **A manifest that parses today parses identically and behaves identically.** No required field, no changed default, no new validation that could reject anything.
- **`url` deliberately omitted.** #774 also added `URL` for daemon parity, and its body offered to drop it if maintainers preferred the minimal change. Nothing in graphon consumes a per-field credential `url`; the provider-level help link is already modelled separately as `ProviderHelpEntity {title, url}` on `ProviderEntity.help`. Adding an unused per-field `url` would introduce a second convention for the same concept. Glad to add it if you want exact parity.
- **This does not complete the feature.** Step 3 above (the frontend `help` → `tooltip` mapping) is still unfiled and lives in the Dify repo. This PR unblocks it.

### Tests

- `tests/model_runtime/test_provider_entities.py` (new) — a manifest fragment carrying `help` round-trips through `CredentialFormSchema` and is retained, including when nested inside `ProviderCredentialSchema`; and a fragment with no `help` still parses with `help is None`.
- `tests/dsl/test_slim_package_loader.py` — a plugin manifest declaring `help` on one credential field and not on another loads through `SlimPackageLoader` with the value retained on the first and `None` on the second.

Each of the two source lines was verified load-bearing by reverting it in isolation and confirming the corresponding tests fail, then restoring. Full suite: **706 passed, 0 failed** (702 before this change, plus the 4 added here). `ruff format --check`, `ruff check` and `ty check` all clean.

*Disclosure: this change was prepared with AI assistance (Claude). I have reviewed the diff, the end-to-end trace and the test results myself and take responsibility for their correctness.*

## Checklist

- [ ] This pull request links the issue it resolves or advances — *no graphon issue exists; it advances the merged `dify-plugin-daemon#774`, linked above. Will file one if preferred.*
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation