### PR TITLE
fix(tts)!: propagate output MIME type

### DIFF
--- a/src/graphon/model_runtime/model_providers/base/tts_model.py
+++ b/src/graphon/model_runtime/model_providers/base/tts_model.py
@@ -3,7 +3,11 @@ from collections.abc import Iterable, Mapping
 
 from graphon.model_runtime.entities.model_entities import ModelType
 from graphon.model_runtime.model_providers.base.ai_model import AIModel
-from graphon.model_runtime.protocols.tts_runtime import TTSModelRuntime, TTSModelVoice
+from graphon.model_runtime.protocols.tts_runtime import (
+    TTSChunk,
+    TTSModelRuntime,
+    TTSModelVoice,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +25,8 @@ class TTSModel(AIModel[TTSModelRuntime]):
         voice: str,
         *,
         request_metadata: Mapping[str, object] | None = None,
-    ) -> Iterable[bytes]:
-        """Invoke the TTS model and return an audio byte stream."""
+    ) -> Iterable[TTSChunk]:
+        """Invoke the TTS model and return an audio stream."""
         try:
             return self.model_runtime.invoke_tts(
                 provider=self.provider,

--- a/src/graphon/model_runtime/protocols/tts_runtime.py
+++ b/src/graphon/model_runtime/protocols/tts_runtime.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any, Protocol, TypedDict, runtime_checkable
 
 from graphon.model_runtime.protocols.provider_runtime import ModelProviderRuntime
+
+
+@dataclass(frozen=True, slots=True)
+class TTSChunk:
+    """Audio chunk returned by TTS model runtimes."""
+
+    data: bytes
+    mime_type: str | None
 
 
 class TTSModelVoice(TypedDict):
@@ -28,7 +37,7 @@ class TTSModelRuntime(ModelProviderRuntime, Protocol):
         content_text: str,
         voice: str,
         request_metadata: Mapping[str, object] | None = None,
-    ) -> Iterable[bytes]: ...
+    ) -> Iterable[TTSChunk]: ...
 
     @abstractmethod
     def get_tts_model_voices(

--- a/tests/model_runtime/test_model_dispatch.py
+++ b/tests/model_runtime/test_model_dispatch.py
@@ -61,7 +61,7 @@ from graphon.model_runtime.model_providers.model_provider_factory import (
     ModelProviderFactory,
 )
 from graphon.model_runtime.protocols.llm_runtime import LLMModelRuntime
-from graphon.model_runtime.protocols.tts_runtime import TTSModelVoice
+from graphon.model_runtime.protocols.tts_runtime import TTSChunk, TTSModelVoice
 
 
 class _ProviderRuntimeStub:
@@ -447,9 +447,9 @@ class _TTSRuntimeStub(_ProviderRuntimeStub):
         content_text: str,
         voice: str,
         request_metadata: Mapping[str, object] | None = None,
-    ) -> list[bytes]:
+    ) -> list[TTSChunk]:
         _ = provider, model, credentials, content_text, voice, request_metadata
-        return [b"audio"]
+        return [TTSChunk(data=b"audio", mime_type="audio/wav")]
 
     def get_tts_model_voices(
         self,
@@ -801,7 +801,8 @@ def test_tts_model_accepts_tts_only_runtime_surface() -> None:
             content_text="hello",
             voice="nova",
         ),
-    ) == [b"audio"]
+    ) == [TTSChunk(data=b"audio", mime_type="audio/wav")]
+    assert TTSChunk(data=b"legacy", mime_type=None).mime_type is None
     assert model.get_tts_model_voices(
         model="voice-model",
         credentials={},


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #252

## Summary

- Add an immutable `TTSChunk` value object carrying audio bytes and an explicit optional MIME type.
- Change the TTS runtime protocol and model wrapper from `Iterable[bytes]` to `Iterable[TTSChunk]`.
- Cover MIME propagation and legacy missing-MIME representation in the existing TTS dispatch test.
- Verify the change with `just test` (730 passed) and `just check`.

This is a breaking runtime protocol change because TTS chunks are no longer raw `bytes`.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation