### PR TITLE
fix(response-stream): close unfinished streams on NodeRunExceptionEvent

### DIFF
--- a/src/graphon/graph_engine/filters/response_stream.py
+++ b/src/graphon/graph_engine/filters/response_stream.py
@@ -267,6 +267,8 @@ class ResponseStreamFilter:
             case GraphEdgeSkippedEvent():
                 output = []
             case NodeRunSucceededEvent() | NodeRunExceptionEvent():
+                if isinstance(event, NodeRunExceptionEvent):
+                    self._close_streams_for_node(event.node_id)
                 output = [*self._try_flush(), event]
             case _:
                 output = [event]
@@ -553,6 +555,20 @@ class ResponseStreamFilter:
         if self._pass_unmatched_chunks:
             return [event]
         return []
+
+    def _close_streams_for_node(self, node_id: NodeID) -> None:
+        """Close open streams for a node that finished via exception.
+
+        When a node fails (e.g. error_strategy=DEFAULT_VALUE) after streaming
+        partial output, the terminal ``is_final`` chunk is never emitted, so
+        buffered streams stay open and the response session wedges. Closing
+        them lets ``_try_flush`` drain remaining chunks and complete the
+        segment. Streams that never received chunks are left untouched so the
+        variable-pool fallback can still emit default values.
+        """
+        for selector in list(self._stream_buffers.events.keys()):
+            if selector[0] == node_id:
+                self._stream_buffers.close(list(selector))
 
     def _handle_reasoning_chunk(
         self,

--- a/tests/graph_engine/test_response_stream_filter.py
+++ b/tests/graph_engine/test_response_stream_filter.py
@@ -12,6 +12,7 @@ from graphon.filters import (
 )
 from graphon.graph_events.graph import GraphRunStartedEvent
 from graphon.graph_events.node import (
+    NodeRunExceptionEvent,
     NodeRunReasoningChunkEvent,
     NodeRunRetryEvent,
     NodeRunStartedEvent,
@@ -542,6 +543,96 @@ def test_response_stream_filter_does_not_mix_buffered_chunks_with_final_value() 
 
     chunks = [event for event in output if isinstance(event, NodeRunStreamChunkEvent)]
     assert [event.chunk for event in chunks] == ["Quiet", " Night", " Thought"]
+
+
+def test_response_stream_filter_flushes_streamed_chunks_after_exception() -> None:
+    """When a node fails after streaming chunks (error_strategy=DEFAULT_VALUE),
+    the filter should close the unfinished stream so already-streamed chunks
+    are flushed and the response session can complete instead of wedging.
+    """
+    graph = _variable_response_graph()
+    variable_pool = VariablePool()
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph, variable_pool))
+
+    started = NodeRunStartedEvent(
+        id="source-run",
+        node_id="source",
+        node_type=BuiltinNodeTypes.CODE,
+        node_title="Source",
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    # Simulate the LLM streaming partial output before crashing — no is_final
+    # chunk is ever emitted because the node raised.
+    chunk1 = _stream_chunk("Hello", is_final=False)
+    chunk2 = _stream_chunk(" World", is_final=False)
+    exception = NodeRunExceptionEvent(
+        id="source-run",
+        node_id="source",
+        node_type=BuiltinNodeTypes.CODE,
+        error="model crashed mid-stream",
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+
+    list(event_filter.on_event(GraphRunStartedEvent()))
+    assert list(event_filter.on_event(started)) == [started]
+    # Activate the session so buffered chunks start flushing.
+    list(event_filter.on_event(_edge_taken()))
+    out1 = list(event_filter.on_event(chunk1))
+    out2 = list(event_filter.on_event(chunk2))
+    assert [e.chunk for e in out1 if isinstance(e, NodeRunStreamChunkEvent)] == [
+        "Hello"
+    ]
+    assert [e.chunk for e in out2 if isinstance(e, NodeRunStreamChunkEvent)] == [
+        " World"
+    ]
+    # ErrorHandler writes default values to the variable pool before the
+    # NodeRunExceptionEvent reaches the filter.
+    variable_pool.add(["source", "answer"], StringSegment(value="default"))
+    # Without the fix the session wedges here: the stream is neither closed nor
+    # eligible for the variable-pool fallback (has_stream_events is True).
+    output = list(event_filter.on_event(exception))
+
+    # The session should have completed (no longer stuck on the open segment).
+    assert event_filter._active_session is None
+    assert exception in output
+
+
+def test_response_stream_filter_emits_default_value_when_no_chunks_streamed() -> None:
+    """When a node fails before streaming any chunk, the default value written
+    to the variable pool by the error handler should be emitted as the chunk.
+    """
+    graph = _variable_response_graph()
+    variable_pool = VariablePool()
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph, variable_pool))
+
+    started = NodeRunStartedEvent(
+        id="source-run",
+        node_id="source",
+        node_type=BuiltinNodeTypes.CODE,
+        node_title="Source",
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    exception = NodeRunExceptionEvent(
+        id="source-run",
+        node_id="source",
+        node_type=BuiltinNodeTypes.CODE,
+        error="model crashed before first token",
+        start_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+
+    list(event_filter.on_event(GraphRunStartedEvent()))
+    assert list(event_filter.on_event(started)) == [started]
+    list(event_filter.on_event(_edge_taken()))
+    # ErrorHandler writes default values to the variable pool before the
+    # NodeRunExceptionEvent reaches the filter.
+    variable_pool.add(["source", "answer"], StringSegment(value="fallback"))
+    output = list(event_filter.on_event(exception))
+
+    chunks = [event for event in output if isinstance(event, NodeRunStreamChunkEvent)]
+    assert [event.chunk for event in chunks] == ["fallback"]
+    assert event_filter._active_session is None
 
 
 def test_response_stream_filter_uses_retry_execution_id_for_scalar_value() -> None:


### PR DESCRIPTION
## Related Issue

This fixes the streaming regression reported in [langgenius/dify#40865](https://github.com/langgenius/dify/issues/40865): when a node with exception handling (error_strategy=DEFAULT_VALUE or FAIL_BRANCH) fails after streaming partial output, the streaming output wedges and never completes.

## Summary

When a node fails mid-stream, the terminal `is_final=True` chunk is never emitted. The `ResponseStreamFilter` then gets stuck: the stream is neither closed nor eligible for the variable-pool fallback (because `has_stream_events` is `True`), so the response session never completes and downstream segments are never processed.

The fix closes any open streams for the failed node when a `NodeRunExceptionEvent` arrives, allowing `_try_flush` to drain remaining chunks and complete the segment. Streams that never received chunks are left untouched so the variable-pool fallback can still emit default values.

## Changes

- **`src/graphon/graph_engine/filters/response_stream.py`**: Added `_close_streams_for_node()` method, called from `on_event()` when handling `NodeRunExceptionEvent`.
- **`tests/graph_engine/test_response_stream_filter.py`**: Two new tests:
  - `test_response_stream_filter_flushes_streamed_chunks_after_exception`: verifies that already-streamed chunks are flushed and the session completes when a node fails mid-stream.
  - `test_response_stream_filter_emits_default_value_when_no_chunks_streamed`: verifies that the default value from the variable pool is emitted when a node fails before streaming any chunks.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)