### PR TITLE
feat: add multi-select input variable type

### DIFF
--- a/src/graphon/variables/input_entities.py
+++ b/src/graphon/variables/input_entities.py
@@ -26,6 +26,7 @@ class VariableEntityType(StrEnum):
     FILE = "file"
     FILE_LIST = "file-list"
     CHECKBOX = "checkbox"
+    MULTI_SELECT = "multi-select"
     JSON_OBJECT = "json_object"
 
 

--- a/tests/variables/test_input_entities.py
+++ b/tests/variables/test_input_entities.py
@@ -24,6 +24,30 @@ def _make_payload(json_schema: Any) -> dict[str, Any]:
     }
 
 
+def _make_multi_select_payload() -> dict[str, Any]:
+    return {
+        "variable": "machines",
+        "label": "Machines",
+        "type": "multi-select",
+        "required": True,
+        "options": ["A", "B", "C"],
+    }
+
+
+class TestMultiSelect:
+    def test_accepts_multi_select_input(self) -> None:
+        entity = VariableEntity.model_validate(_make_multi_select_payload())
+
+        assert entity.type == VariableEntityType.MULTI_SELECT
+        assert list(entity.options) == ["A", "B", "C"]
+        assert entity.required is True
+
+    def test_serializes_multi_select_input_type(self) -> None:
+        entity = VariableEntity.model_validate(_make_multi_select_payload())
+
+        assert entity.model_dump(mode="json")["type"] == "multi-select"
+
+
 class TestValidateJsonSchema:
     def test_accepts_dict_input(self) -> None:
         entity = VariableEntity.model_validate(_make_payload(_VALID_SCHEMA))


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Related to langgenius/dify#40575

## Summary

Add a new `MULTI_SELECT` member to `VariableEntityType` so consumers can represent user inputs that allow selecting multiple predefined values.

This is a prerequisite for supporting native multi-select / checkbox-group inputs in Dify Start Nodes.

The change only introduces the input variable type. Existing Graphon `array[string]` runtime support is reused, so no new segment type or runtime behavior is introduced.

### Changes

- Add `VariableEntityType.MULTI_SELECT = "multi-select"`
- Add validation coverage for multi-select `VariableEntity`
- Add serialization coverage to ensure the wire value remains `"multi-select"`

### Tests

Targeted tests:

`tests/variables/test_input_entities.py`

Result:

`14 passed`

Also verified:

- `VariableEntity.model_validate()` accepts `"multi-select"`
- `model_dump(mode="json")` serializes the type as `"multi-select"`
- existing `SegmentType.ARRAY_STRING` support handles typed empty arrays

## Checklist

- [x] This pull request links the issue it advances
- [x] I have added tests for the change
- [x] The change is backward compatible