### PR TITLE
feat: preserve opaque_body provider state on prompt messages and LLM results

### DIFF
--- a/src/graphon/model_runtime/entities/message_entities.py
+++ b/src/graphon/model_runtime/entities/message_entities.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from enum import StrEnum, auto
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, JsonValue, field_serializer, field_validator
 
 
 class PromptMessageRole(StrEnum):
@@ -59,6 +59,7 @@ class PromptMessageContent(ABC, BaseModel):
     """Model class for prompt message content."""
 
     type: PromptMessageContentType
+    opaque_body: JsonValue | None = None
 
 
 class TextPromptMessageContent(PromptMessageContent):
@@ -258,6 +259,7 @@ class AssistantPromptMessage(PromptMessage):
 
     role: PromptMessageRole = PromptMessageRole.ASSISTANT
     tool_calls: list[ToolCall] = []
+    opaque_body: JsonValue | None = None
 
     def is_empty(self) -> bool:
         """Check whether the assistant message has no content or tool calls."""

--- a/src/graphon/model_runtime/model_providers/base/large_language_model.py
+++ b/src/graphon/model_runtime/model_providers/base/large_language_model.py
@@ -4,6 +4,8 @@ import uuid
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 
+from pydantic import JsonValue
+
 from graphon.model_runtime.callbacks.base_callback import Callback
 from graphon.model_runtime.callbacks.logging_callback import LoggingCallback
 from graphon.model_runtime.entities.llm_entities import (
@@ -122,6 +124,7 @@ class _LLMChunkAccumulator:
     usage: LLMUsage = field(default_factory=LLMUsage.empty_usage)
     system_fingerprint: str | None = None
     tool_calls: list[AssistantPromptMessage.ToolCall] = field(default_factory=list)
+    opaque_body: JsonValue | None = None
 
     def consume_all(self, chunks: Iterator[LLMResultChunk]) -> None:
         for chunk in chunks:
@@ -135,6 +138,8 @@ class _LLMChunkAccumulator:
             self.usage = chunk.delta.usage
         if chunk.system_fingerprint:
             self.system_fingerprint = chunk.system_fingerprint
+        if chunk.delta.message.opaque_body is not None:
+            self.opaque_body = chunk.delta.message.opaque_body
 
     def _consume_content(self, chunk: LLMResultChunk) -> None:
         content = chunk.delta.message.content
@@ -155,6 +160,7 @@ class _LLMChunkAccumulator:
             message=AssistantPromptMessage(
                 content=self.content or self.content_list,
                 tool_calls=self.tool_calls,
+                opaque_body=self.opaque_body,
             ),
             usage=self.usage,
             system_fingerprint=self.system_fingerprint,
@@ -167,6 +173,7 @@ class _StreamingInvokeAccumulator:
     message_content: list[PromptMessageContentUnionTypes] = field(default_factory=list)
     usage: LLMUsage | None = None
     system_fingerprint: str | None = None
+    opaque_body: JsonValue | None = None
 
     def consume(self, chunk: LLMResultChunk) -> None:
         self._consume_content(chunk.delta.message.content)
@@ -175,6 +182,8 @@ class _StreamingInvokeAccumulator:
             self.usage = chunk.delta.usage
         if chunk.system_fingerprint:
             self.system_fingerprint = chunk.system_fingerprint
+        if chunk.delta.message.opaque_body is not None:
+            self.opaque_body = chunk.delta.message.opaque_body
 
     def _consume_content(
         self,
@@ -196,7 +205,10 @@ class _StreamingInvokeAccumulator:
         return LLMResult(
             model=self.real_model,
             prompt_messages=prompt_messages,
-            message=AssistantPromptMessage(content=self.message_content),
+            message=AssistantPromptMessage(
+                content=self.message_content,
+                opaque_body=self.opaque_body,
+            ),
             usage=self.usage or LLMUsage.empty_usage(),
             system_fingerprint=self.system_fingerprint,
         )

--- a/tests/model_runtime/test_large_language_model_non_stream_result.py
+++ b/tests/model_runtime/test_large_language_model_non_stream_result.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import Any
 
 from graphon.model_runtime.entities.llm_entities import (
     LLMResult,
@@ -24,8 +25,13 @@ def _make_chunk(
     tool_calls: list[AssistantPromptMessage.ToolCall] | None = None,
     usage: LLMUsage | None = None,
     system_fingerprint: str | None = None,
+    opaque_body: Any | None = None,
 ) -> LLMResultChunk:
-    message = AssistantPromptMessage(content=content, tool_calls=tool_calls or [])
+    message = AssistantPromptMessage(
+        content=content,
+        tool_calls=tool_calls or [],
+        opaque_body=opaque_body,
+    )
     delta = LLMResultChunkDelta(index=0, message=message, usage=usage)
     return LLMResultChunk(
         model=model,
@@ -149,6 +155,63 @@ def test__normalize_non_stream_runtime_result__empty_iterator_defaults() -> None
     assert result.message.tool_calls == []
     assert result.usage == LLMUsage.empty_usage()
     assert result.system_fingerprint is None
+
+
+def test_non_stream_result_preserves_opaque_body() -> None:
+    prompt_messages = [UserPromptMessage(content="hi")]
+    opaque_body = {
+        "assistant_blocks": [{"type": "thinking", "signature": "sig-1"}],
+    }
+    chunk = _make_chunk(
+        content="hello",
+        usage=LLMUsage.empty_usage(),
+        opaque_body=opaque_body,
+    )
+
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=iter([chunk]),
+    )
+
+    assert result.message.opaque_body == opaque_body
+
+
+def test_non_stream_result_opaque_body_last_non_none_wins() -> None:
+    prompt_messages = [UserPromptMessage(content="hi")]
+    chunks = iter([
+        _make_chunk(
+            content="a",
+            usage=LLMUsage.empty_usage(),
+            opaque_body={"snapshot": 1},
+        ),
+        _make_chunk(content="b", usage=LLMUsage.empty_usage()),
+        _make_chunk(
+            content="c",
+            usage=LLMUsage.empty_usage(),
+            opaque_body={"snapshot": 2},
+        ),
+    ])
+
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=chunks,
+    )
+
+    assert result.message.opaque_body == {"snapshot": 2}
+
+
+def test_non_stream_result_opaque_body_defaults_to_none() -> None:
+    prompt_messages = [UserPromptMessage(content="hi")]
+
+    result = normalize_non_stream_runtime_result(
+        model="test-model",
+        prompt_messages=prompt_messages,
+        result=iter([_make_chunk(content="hello", usage=LLMUsage.empty_usage())]),
+    )
+
+    assert result.message.opaque_body is None
 
 
 def test__normalize_non_stream_runtime_result__accumulates_all_chunks() -> None:

--- a/tests/model_runtime/test_message_entities.py
+++ b/tests/model_runtime/test_message_entities.py
@@ -1,4 +1,10 @@
+from graphon.model_runtime.entities.llm_entities import (
+    LLMResultChunk,
+    LLMResultChunkDelta,
+    LLMUsage,
+)
 from graphon.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
     ImagePromptMessageContent,
     TextPromptMessageContent,
     UserPromptMessage,
@@ -29,5 +35,76 @@ def test_prompt_message_normalizes_dict_content_items_for_serialization() -> Non
     assert isinstance(message.content, list)
     assert isinstance(message.content[0], TextPromptMessageContent)
     assert message.model_dump(mode="json")["content"] == [
-        {"type": "text", "data": "hello"},
+        {"type": "text", "data": "hello", "opaque_body": None},
     ]
+
+
+def test_assistant_prompt_message_opaque_body_defaults_to_none() -> None:
+    message = AssistantPromptMessage(content="ok")
+
+    assert message.opaque_body is None
+
+
+def test_assistant_prompt_message_opaque_body_survives_json_round_trip() -> None:
+    opaque_body = {
+        "assistant_blocks": [{"type": "thinking", "signature": "sig-1"}],
+    }
+    message = AssistantPromptMessage(content="ok", opaque_body=opaque_body)
+
+    restored = AssistantPromptMessage.model_validate_json(message.model_dump_json())
+
+    assert restored.opaque_body == opaque_body
+
+
+def test_assistant_prompt_message_accepts_payload_without_opaque_body() -> None:
+    message = AssistantPromptMessage.model_validate(
+        {"role": "assistant", "content": "ok", "tool_calls": []},
+    )
+
+    assert message.opaque_body is None
+
+
+def test_prompt_message_content_opaque_body_survives_json_round_trip() -> None:
+    content = TextPromptMessageContent(
+        data="hello",
+        opaque_body={"thought_signature": "sig-1"},
+    )
+    message = AssistantPromptMessage(content=[content])
+
+    restored = AssistantPromptMessage.model_validate_json(message.model_dump_json())
+
+    assert isinstance(restored.content, list)
+    assert isinstance(restored.content[0], TextPromptMessageContent)
+    assert restored.content[0].opaque_body == {"thought_signature": "sig-1"}
+
+
+def test_prompt_message_content_accepts_dict_with_opaque_body() -> None:
+    message = UserPromptMessage.model_validate(
+        {"content": [{"type": "text", "data": "hello", "opaque_body": {"key": "v"}}]},
+    )
+
+    assert isinstance(message.content, list)
+    assert isinstance(message.content[0], TextPromptMessageContent)
+    assert message.content[0].opaque_body == {"key": "v"}
+
+
+def test_llm_result_chunk_json_round_trip_preserves_opaque_body() -> None:
+    """Simulate the plugin daemon -> core deserialization boundary."""
+    opaque_body = {
+        "assistant_blocks": [
+            {"type": "thinking", "thinking": "...", "signature": "sig-1"},
+            {"type": "redacted_thinking", "data": "enc-1"},
+        ],
+    }
+    chunk = LLMResultChunk(
+        model="test-model",
+        delta=LLMResultChunkDelta(
+            index=0,
+            message=AssistantPromptMessage(content="ok", opaque_body=opaque_body),
+            usage=LLMUsage.empty_usage(),
+        ),
+    )
+
+    restored = LLMResultChunk.model_validate_json(chunk.model_dump_json())
+
+    assert restored.delta.message.opaque_body == opaque_body

--- a/tests/model_runtime/test_streaming_invoke_accumulator.py
+++ b/tests/model_runtime/test_streaming_invoke_accumulator.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from graphon.model_runtime.entities.llm_entities import (
+    LLMResultChunk,
+    LLMResultChunkDelta,
+    LLMUsage,
+)
+from graphon.model_runtime.entities.message_entities import (
+    AssistantPromptMessage,
+    UserPromptMessage,
+)
+from graphon.model_runtime.model_providers.base.large_language_model import (
+    _StreamingInvokeAccumulator,
+)
+
+
+def _make_chunk(
+    *,
+    content: str | None,
+    opaque_body: Any | None = None,
+    usage: LLMUsage | None = None,
+) -> LLMResultChunk:
+    message = AssistantPromptMessage(
+        content=content,
+        tool_calls=[],
+        opaque_body=opaque_body,
+    )
+    delta = LLMResultChunkDelta(index=0, message=message, usage=usage)
+    return LLMResultChunk(model="test-model", delta=delta)
+
+
+def test_streaming_invoke_accumulator_preserves_opaque_body() -> None:
+    accumulator = _StreamingInvokeAccumulator(real_model="test-model")
+    opaque_body = {
+        "assistant_blocks": [{"type": "thinking", "signature": "sig-1"}],
+    }
+
+    accumulator.consume(_make_chunk(content="hello"))
+    accumulator.consume(_make_chunk(content=" world", opaque_body=opaque_body))
+
+    result = accumulator.to_result(prompt_messages=[UserPromptMessage(content="hi")])
+
+    assert result.message.opaque_body == opaque_body
+
+
+def test_streaming_invoke_accumulator_opaque_body_defaults_to_none() -> None:
+    accumulator = _StreamingInvokeAccumulator(real_model="test-model")
+
+    accumulator.consume(_make_chunk(content="hello"))
+
+    result = accumulator.to_result(prompt_messages=[UserPromptMessage(content="hi")])
+
+    assert result.message.opaque_body is None
+
+
+def test_streaming_invoke_accumulator_none_chunk_does_not_clobber_snapshot() -> None:
+    accumulator = _StreamingInvokeAccumulator(real_model="test-model")
+    opaque_body = {
+        "assistant_blocks": [{"type": "redacted_thinking", "data": "enc-1"}],
+    }
+
+    accumulator.consume(_make_chunk(content="a", opaque_body=opaque_body))
+    accumulator.consume(_make_chunk(content="b"))
+
+    result = accumulator.to_result(prompt_messages=[UserPromptMessage(content="hi")])
+
+    assert result.message.opaque_body == opaque_body


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #260

## Summary

Plugin LLM results can carry provider round-trip state in `opaque_body` (e.g. signed/encrypted Claude thinking blocks, Gemini `thought_signature`). The plugin SDK (`dify_plugin >= 0.10.0`) defines the field on both `AssistantPromptMessage` and `PromptMessageContent`, and the plugin daemon passes it through to Dify core — but graphon dropped it in two places:

- **Entities**: `AssistantPromptMessage` / `PromptMessageContent` had no `opaque_body` field, so the daemon → core Pydantic boundary silently discarded it during `LLMResultChunk` / `LLMResult` validation.
- **Result accumulators**: `_LLMChunkAccumulator` and `_StreamingInvokeAccumulator` rebuilt the assistant message from content + tool calls only, dropping the field even when chunks carried it (affects non-stream normalization of stream-only models and streaming callback bookkeeping).

This change:

- Adds `opaque_body: JsonValue | None = None` to `AssistantPromptMessage` and `PromptMessageContent`, mirroring the plugin SDK field name, type, and default exactly (message-level for reasoning state; content-block-level for per-part state such as Gemini `thought_signature`).
- Carries the field through both accumulators with complete-snapshot semantics: the last non-`None` chunk wins, and later `None` chunks do not clobber a captured snapshot.
- Adds tests: entity JSON round-trips (including a simulated daemon → core boundary via `LLMResultChunk.model_validate_json`), backward compatibility for payloads without the field, and accumulator preservation for both stream and non-stream paths.

Compatibility notes:

- Backward compatible: payloads without the field still validate (`None` default); no behavior change for providers that do not use the field.
- Serialized content blocks now include `opaque_body: null` when unset, matching the plugin SDK's existing serialization behavior at the daemon boundary.
- Known remaining drop sites intentionally left out of scope: the slim runtime result collector (`dsl/slim/llm.py`), workflow LLM node prompt reconstruction (`nodes/llm/llm_utils.py`), and parameter extractor message building — none of them are on the agent-loop path this issue covers.

Context: [langgenius/dify#41092](https://github.com/langgenius/dify/issues/41092) (Claude extended thinking dropped between Agent tool-use rounds), plugin-side counterpart [langgenius/dify-official-plugins#3715](https://github.com/langgenius/dify-official-plugins/pull/3715), prior core attempt [langgenius/dify#31566](https://github.com/langgenius/dify/pull/31566).

Validation: `uv run pytest` (742 passed), `uv lock --check`, `uv run ruff format --check`, `uv run ruff check`, `uv run ty check` all green. I will sign the CLA if CLA Assistant prompts.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
