### PR TITLE
perf(response-stream): prune unreachable paths and cache blocking edges

### DIFF
--- a/src/graphon/engine/filter/builtin/response_stream/filter.py
+++ b/src/graphon/engine/filter/builtin/response_stream/filter.py
@@ -394,8 +394,15 @@ class ResponseStreamFilter:
 
         variable_selectors = self._get_response_variable_selectors(response_node_id)
         all_complete_paths = self._find_all_paths(root_node_id, response_node_id)
+        blocking_cache: dict[_EdgeID, bool] = {}
         return [
-            _Path(edges=self._get_blocking_edges(path, variable_selectors))
+            _Path(
+                edges=self._get_blocking_edges(
+                    path,
+                    variable_selectors,
+                    blocking_cache,
+                )
+            )
             for path in all_complete_paths
         ]
 
@@ -418,36 +425,66 @@ class ResponseStreamFilter:
         current_path: list[_EdgeID] | None = None,
         visited: set[_NodeID] | None = None,
     ) -> list[list[_EdgeID]]:
-        current_path = current_path or []
-        visited = visited or set()
-        if current_node_id == target_node_id:
-            return [current_path.copy()]
+        graph = self._bound_graph
+        reverse: dict[_NodeID, list[_NodeID]] = {}
+        for node_id in graph.nodes:
+            for edge in graph.get_outgoing_edges(node_id):
+                reverse.setdefault(edge.head, []).append(node_id)
 
-        next_visited = {current_node_id, *visited}
-        paths: list[list[_EdgeID]] = []
-        for edge in self._bound_graph.get_outgoing_edges(current_node_id):
-            if edge.head in next_visited:
-                continue
-            paths.extend(
-                self._find_all_paths(
-                    edge.head,
-                    target_node_id,
-                    [*current_path, edge.id],
-                    next_visited,
-                ),
-            )
-        return paths
+        reachable = {target_node_id}
+        pending = [target_node_id]
+        while pending:
+            node_id = pending.pop()
+            predecessors = [
+                predecessor
+                for predecessor in reverse.get(node_id, ())
+                if predecessor not in reachable
+            ]
+            reachable.update(predecessors)
+            pending.extend(predecessors)
+
+        path_seed = [] if current_path is None else current_path
+        visited_seed = set() if visited is None else visited
+
+        def walk(
+            node_id: _NodeID,
+            path: list[_EdgeID],
+            seen: set[_NodeID],
+        ) -> list[list[_EdgeID]]:
+            if node_id == target_node_id:
+                return [path.copy()]
+            if node_id not in reachable:
+                return []
+
+            next_seen = {node_id, *seen}
+            return [
+                nested_path
+                for edge in graph.get_outgoing_edges(node_id)
+                if edge.head in reachable and edge.head not in next_seen
+                for nested_path in walk(edge.head, [*path, edge.id], next_seen)
+            ]
+
+        return walk(current_node_id, path_seed, visited_seed)
 
     def _get_blocking_edges(
         self,
         path: list[_EdgeID],
         variable_selectors: set[_Selector],
+        blocking_cache: dict[_EdgeID, bool] | None = None,
     ) -> list[_EdgeID]:
-        return [
-            edge_id
-            for edge_id in path
-            if self._is_blocking_edge(edge_id, variable_selectors)
-        ]
+        if blocking_cache is None:
+            blocking_cache = {}
+
+        blocking_edges: list[_EdgeID] = []
+        for edge_id in path:
+            if edge_id not in blocking_cache:
+                blocking_cache[edge_id] = self._is_blocking_edge(
+                    edge_id,
+                    variable_selectors,
+                )
+            if blocking_cache[edge_id]:
+                blocking_edges.append(edge_id)
+        return blocking_edges
 
     def _is_blocking_edge(
         self,

--- a/src/graphon/engine/filter/builtin/response_stream/filter.py
+++ b/src/graphon/engine/filter/builtin/response_stream/filter.py
@@ -394,6 +394,7 @@ class ResponseStreamFilter:
 
         variable_selectors = self._get_response_variable_selectors(response_node_id)
         all_complete_paths = self._find_all_paths(root_node_id, response_node_id)
+        # Selectors are fixed for this response; never share the cache across builds.
         blocking_cache: dict[_EdgeID, bool] = {}
         return [
             _Path(
@@ -426,6 +427,7 @@ class ResponseStreamFilter:
         visited: set[_NodeID] | None = None,
     ) -> list[list[_EdgeID]]:
         graph = self._bound_graph
+        # Use the forward traversal's topology, without evaluating runtime conditions.
         reverse: dict[_NodeID, list[_NodeID]] = {}
         for node_id in graph.nodes:
             for edge in graph.get_outgoing_edges(node_id):

--- a/tests/engine/test_response_stream_filter_performance.py
+++ b/tests/engine/test_response_stream_filter_performance.py
@@ -1,0 +1,257 @@
+import random
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+
+from graphon.engine.filter import ResponseStreamFilter
+from graphon.enums import NodeExecutionType
+from graphon.nodes.base.template import Template, VariableSegment
+from tests.engine.test_response_stream_filter import (
+    _context,
+    _TestEdge,
+    _TestGraph,
+    _TestNode,
+)
+
+
+class _CountingGraph(_TestGraph):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.outgoing_calls: list[str] = []
+
+    def get_outgoing_edges(self, node_id: str) -> Sequence[_TestEdge]:
+        self.outgoing_calls.append(node_id)
+        return super().get_outgoing_edges(node_id)
+
+
+def _reference_paths(
+    graph: _TestGraph,
+    current_node_id: str,
+    target_node_id: str,
+    current_path: list[str] | None = None,
+    visited: set[str] | None = None,
+) -> list[list[str]]:
+    """Enumerate paths with an independent DFS, without reverse pruning."""
+    stack = [
+        (
+            current_node_id,
+            [] if current_path is None else current_path.copy(),
+            set() if visited is None else visited.copy(),
+        )
+    ]
+    paths: list[list[str]] = []
+    while stack:
+        node_id, path, seen = stack.pop()
+        if node_id == target_node_id:
+            paths.append(path)
+            continue
+
+        next_seen = {node_id, *seen}
+        outgoing = list(graph.get_outgoing_edges(node_id))
+        for edge in reversed(outgoing):
+            if edge.head in next_seen:
+                continue
+            stack.append((edge.head, [*path, edge.id], next_seen.copy()))
+    return paths
+
+
+def _diamond_with_dead_branch(*, layers: int = 6) -> _CountingGraph:
+    nodes = {node_id: _TestNode(node_id) for node_id in ("root", "live", "dead")}
+    nodes["answer"] = _TestNode(
+        "answer",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["root", "answer"])]),
+    )
+    edges = {
+        edge.id: edge
+        for edge in (
+            _TestEdge("root-live", "root", "live"),
+            _TestEdge("root-dead", "root", "dead"),
+            _TestEdge("live-answer", "live", "answer"),
+        )
+    }
+    current_node_id = "dead"
+    for layer in range(layers):
+        left_node_id = f"dead-{layer}-left"
+        right_node_id = f"dead-{layer}-right"
+        merge_node_id = f"dead-{layer}-merge"
+        nodes.update({
+            left_node_id: _TestNode(left_node_id),
+            right_node_id: _TestNode(right_node_id),
+            merge_node_id: _TestNode(merge_node_id),
+        })
+        for edge in (
+            _TestEdge(
+                f"{current_node_id}-left",
+                current_node_id,
+                left_node_id,
+            ),
+            _TestEdge(
+                f"{current_node_id}-right",
+                current_node_id,
+                right_node_id,
+            ),
+            _TestEdge(
+                f"{left_node_id}-merge",
+                left_node_id,
+                merge_node_id,
+            ),
+            _TestEdge(
+                f"{right_node_id}-merge",
+                right_node_id,
+                merge_node_id,
+            ),
+        ):
+            edges[edge.id] = edge
+        current_node_id = merge_node_id
+
+    return _CountingGraph(
+        nodes=nodes,
+        edges=edges,
+        root_node_id="root",
+    )
+
+
+def test_response_filter_does_not_expand_dead_branches() -> None:
+    graph = _diamond_with_dead_branch()
+    baseline_paths = _reference_paths(graph, "root", "answer")
+    baseline_expansions = len(graph.outgoing_calls)
+    graph.outgoing_calls.clear()
+    event_filter = ResponseStreamFilter()
+
+    event_filter.initialize(_context(graph))
+
+    assert baseline_paths == [["root-live", "live-answer"]]
+    assert len(graph.outgoing_calls) < baseline_expansions
+
+
+def test_response_filter_classifies_each_path_edge_once_per_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes = {
+        node_id: _TestNode(node_id) for node_id in ("root", "left", "right", "merge")
+    }
+    nodes["answer"] = _TestNode(
+        "answer",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["root", "answer"])]),
+    )
+    edges = {
+        edge.id: edge
+        for edge in (
+            _TestEdge("root-left", "root", "left"),
+            _TestEdge("root-right", "root", "right"),
+            _TestEdge("left-merge", "left", "merge"),
+            _TestEdge("right-merge", "right", "merge"),
+            _TestEdge("merge-answer", "merge", "answer"),
+        )
+    }
+    graph = _TestGraph(
+        nodes=nodes,
+        edges=edges,
+        root_node_id="root",
+    )
+    event_filter = ResponseStreamFilter()
+    calls: list[str] = []
+    original = event_filter._is_blocking_edge
+
+    def classify_once(edge_id: str, selectors: set[tuple[str, ...]]) -> bool:
+        calls.append(edge_id)
+        return original(edge_id, selectors)
+
+    monkeypatch.setattr(event_filter, "_is_blocking_edge", classify_once)
+
+    event_filter.initialize(_context(graph))
+
+    assert calls == [
+        "root-left",
+        "left-merge",
+        "merge-answer",
+        "root-right",
+        "right-merge",
+    ]
+
+
+def _random_cyclic_graph(seed: int) -> _TestGraph:
+    rng = random.Random(seed)  # ruff: ignore[suspicious-non-cryptographic-random-usage] - deterministic test graph generation
+    node_ids = [f"n{index}" for index in range(6)]
+    edge_pairs = [
+        ("n0", "n1"),
+        ("n1", "n2"),
+        ("n2", "n1"),
+        ("n2", "n5"),
+    ]
+    used_pairs = set(edge_pairs)
+    for tail in node_ids:
+        for head in node_ids:
+            if (tail, head) not in used_pairs and rng.random() < 0.22:
+                edge_pairs.append((tail, head))
+                used_pairs.add((tail, head))
+
+    nodes = {node_id: _TestNode(node_id) for node_id in node_ids}
+    nodes["n5"] = _TestNode(
+        "n5",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["n0", "answer"])]),
+    )
+    edges = {
+        f"edge-{index}": _TestEdge(f"edge-{index}", tail, head)
+        for index, (tail, head) in enumerate(edge_pairs)
+    }
+    return _TestGraph(nodes=nodes, edges=edges, root_node_id="n0")
+
+
+@pytest.mark.parametrize("seed", range(24))
+def test_response_filter_paths_match_reference_dfs_for_cyclic_graphs(
+    seed: int,
+) -> None:
+    graph = _random_cyclic_graph(seed)
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    actual = event_filter._find_all_paths("n0", "n5")
+    expected = _reference_paths(graph, "n0", "n5")
+
+    assert actual == expected
+
+
+def test_response_filter_preserves_seed_path_and_visited_nodes() -> None:
+    nodes = {node_id: _TestNode(node_id) for node_id in ("root", "cycle", "branch")}
+    nodes["answer"] = _TestNode(
+        "answer",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["root", "answer"])]),
+    )
+    edges = {
+        edge.id: edge
+        for edge in (
+            _TestEdge("root-cycle", "root", "cycle"),
+            _TestEdge("cycle-root", "cycle", "root"),
+            _TestEdge("cycle-branch", "cycle", "branch"),
+            _TestEdge("branch-answer", "branch", "answer"),
+        )
+    }
+    graph = _TestGraph(nodes=nodes, edges=edges, root_node_id="root")
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    actual = event_filter._find_all_paths(
+        "root",
+        "answer",
+        current_path=["seed-edge"],
+        visited={"root"},
+    )
+    expected = _reference_paths(
+        graph,
+        "root",
+        "answer",
+        current_path=["seed-edge"],
+        visited={"root"},
+    )
+
+    assert (
+        actual
+        == expected
+        == [["seed-edge", "root-cycle", "cycle-branch", "branch-answer"]]
+    )

--- a/tests/engine/test_response_stream_filter_performance.py
+++ b/tests/engine/test_response_stream_filter_performance.py
@@ -5,13 +5,14 @@ from typing import Any
 import pytest
 
 from graphon.engine.filter import ResponseStreamFilter
-from graphon.enums import NodeExecutionType
+from graphon.enums import NodeExecutionType, NodeState
 from graphon.nodes.base.template import Template, VariableSegment
 from tests.engine.test_response_stream_filter import (
     _context,
     _TestEdge,
     _TestGraph,
     _TestNode,
+    _variable_response_graph,
 )
 
 
@@ -111,6 +112,151 @@ def _diamond_with_dead_branch(*, layers: int = 6) -> _CountingGraph:
         edges=edges,
         root_node_id="root",
     )
+
+
+def test_response_filter_paths_keep_parallel_edges_with_distinct_source_handles() -> (
+    None
+):
+    root = _TestNode("root")
+    answer = _TestNode(
+        "answer",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["root", "answer"])]),
+    )
+    success_edge = _TestEdge("root-success", "root", "answer")
+    success_edge.source_handle = "success"
+    failure_edge = _TestEdge("root-failure", "root", "answer")
+    failure_edge.source_handle = "failure"
+    graph = _TestGraph(
+        nodes={"root": root, "answer": answer},
+        edges={
+            success_edge.id: success_edge,
+            failure_edge.id: failure_edge,
+        },
+        root_node_id="root",
+    )
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    assert {success_edge.source_handle, failure_edge.source_handle} == {
+        "success",
+        "failure",
+    }
+    assert event_filter._find_all_paths("root", "answer") == [
+        ["root-success"],
+        ["root-failure"],
+    ]
+
+
+def test_response_filter_paths_keep_skipped_edge_for_otherwise_reachable_target() -> (
+    None
+):
+    root = _TestNode("root")
+    live = _TestNode("live")
+    answer = _TestNode(
+        "answer",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[VariableSegment(selector=["root", "answer"])]),
+    )
+    skipped_edge = _TestEdge("root-skipped", "root", "answer")
+    skipped_edge.state = NodeState.SKIPPED
+    graph = _TestGraph(
+        nodes={"root": root, "live": live, "answer": answer},
+        edges={
+            skipped_edge.id: skipped_edge,
+            "root-live": _TestEdge("root-live", "root", "live"),
+            "live-answer": _TestEdge("live-answer", "live", "answer"),
+        },
+        root_node_id="root",
+    )
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    assert event_filter._find_all_paths("root", "answer") == [
+        ["root-skipped"],
+        ["root-live", "live-answer"],
+    ]
+
+
+def test_response_filter_builds_selector_specific_blocking_paths_per_response() -> None:
+    nodes = {
+        "root": _TestNode("root"),
+        "shared": _TestNode("shared"),
+        "merge": _TestNode("merge"),
+        "other": _TestNode("other"),
+        "answer-a": _TestNode(
+            "answer-a",
+            execution_type=NodeExecutionType.RESPONSE,
+            template=Template(
+                segments=[VariableSegment(selector=["shared", "answer"])],
+            ),
+        ),
+        "answer-b": _TestNode(
+            "answer-b",
+            execution_type=NodeExecutionType.RESPONSE,
+            template=Template(
+                segments=[VariableSegment(selector=["other", "answer"])],
+            ),
+        ),
+    }
+    graph = _TestGraph(
+        nodes=nodes,
+        edges={
+            "root-shared": _TestEdge("root-shared", "root", "shared"),
+            "shared-merge": _TestEdge("shared-merge", "shared", "merge"),
+            "merge-answer-a": _TestEdge("merge-answer-a", "merge", "answer-a"),
+            "merge-answer-b": _TestEdge("merge-answer-b", "merge", "answer-b"),
+            "root-other": _TestEdge("root-other", "root", "other"),
+            "other-answer-b": _TestEdge("other-answer-b", "other", "answer-b"),
+        },
+        root_node_id="root",
+    )
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    assert [path.edges for path in event_filter._paths_maps["answer-a"]] == [
+        ["shared-merge"],
+    ]
+    assert [path.edges for path in event_filter._paths_maps["answer-b"]] == [
+        [],
+        ["other-answer-b"],
+    ]
+
+
+def test_response_filter_reinitialization_recomputes_selector_dependent_blocking() -> (
+    None
+):
+    first_graph = _variable_response_graph(selector=["source", "answer"])
+    second_graph = _variable_response_graph(selector=["other", "answer"])
+    event_filter = ResponseStreamFilter()
+
+    event_filter.initialize(_context(first_graph))
+    assert [path.edges for path in event_filter._paths_maps["answer"]] == [["edge-1"]]
+
+    event_filter.initialize(_context(second_graph))
+    assert [path.edges for path in event_filter._paths_maps["answer"]] == [[]]
+
+
+def test_response_filter_find_all_paths_handles_root_target_with_backedge() -> None:
+    root = _TestNode(
+        "root",
+        execution_type=NodeExecutionType.RESPONSE,
+        template=Template(segments=[]),
+    )
+    branch = _TestNode("branch")
+    graph = _TestGraph(
+        nodes={"root": root, "branch": branch},
+        edges={
+            "root-branch": _TestEdge("root-branch", "root", "branch"),
+            "branch-root": _TestEdge("branch-root", "branch", "root"),
+        },
+        root_node_id="root",
+    )
+    event_filter = ResponseStreamFilter()
+    event_filter.initialize(_context(graph))
+
+    assert event_filter._find_all_paths("root", "root") == [[]]
+    assert event_filter._find_all_paths("branch", "root") == [["branch-root"]]
 
 
 def test_response_filter_does_not_expand_dead_branches() -> None:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Refs langgenius/dify#41851. Also related to langgenius/dify#38852.

## Summary

Response-stream initialization prepares paths before the first graph-start event.
For each response node, the current DFS explores branches that cannot reach it;
branch/merge-heavy graphs can therefore incur exponential useless traversal.
Blocking-edge classification is also repeated for edges shared by many paths.

This change:

- Prunes forward traversal using reverse reachability for the target response.
- Caches blocking-edge classification only within one response calculation.
- Preserves complete-path ordering, multiplicity, cycle avoidance and blocking-path order.
- Leaves streaming event handling, snapshot state and graph scheduling unchanged.

The regression tests use synthetic graphs only: no private workflows, prompts,
credentials, customer data or infrastructure identifiers are included.

### Evidence and Limits

The equivalent backport was measured on Dify 1.15.0 / Graphon 0.5.3 before adapting
it to this repository's current main. A 157-node, 203-edge graph with nine response
nodes produced exactly the same 49,182 ordered blocking paths before and after.
A matched initialization comparison improved from 6.709 s to 0.409 s. Five direct
staging API requests subsequently started in 0.705-1.669 s, completed without node
exceptions, and preserved multi-turn recall and a tool-driven authentication-entry
branch. These are diagnostic samples, not a capacity/p95 benchmark or timings for
the current-main test runner.

Complete-path enumeration can still be exponential when all those paths genuinely
reach the target. This PR deliberately retains that representation; it does not
claim to fix every workflow latency source.

Synthetic operation counts are separate from those wall-clock samples: a
22-node/27-edge dead-branch graph makes 255 adjacency calls before and 24 after
(22 reverse-index scans plus two forward expansions), returning one identical
complete path. A shared-edge diamond classifies five distinct edges instead of
six path-edge occurrences. Peak live path-object count and peak memory have not
been measured; no peak-memory reduction is claimed.

### Correctness Contracts

Both traversals use the same configured `get_outgoing_edges()` topology. Runtime
edge state and conditional handles do not filter that method; variable selectors
affect blocking classification, not path eligibility. Pruning does not introduce
early condition evaluation. A reverse-reachability superset remains conservative;
excluding any edge available to forward traversal would violate the contract.

The blocking cache is local to one `_build_paths_map()` call, with a fixed graph
and response selector set. It is not shared across response nodes, retained across
initializations, or serialized into snapshots.

No Dify dependency bump is included. After a Graphon release, Dify can consume the
fix through its normal dependency update; this PR should not prematurely close
the Dify tracking issue.

### Validation

Validated on Python 3.12.11 against main at `788086fe16ab46b2ba290bb48873b6145862377c`:

- `pytest -n 2 --tb=short`: 798 passed.
- Existing and new response-filter tests: 62 passed.
- `uv lock --check`, `ruff format --check`, `ruff check --no-fix`, and `ty check`: passed (the recipe-equivalent checks; `just` is not installed locally).
- The synthetic dead-branch regression reduces outgoing-edge lookups from 255 to 24 without wall-clock thresholds.
- 24 deterministic cyclic graphs are compared against an independent unpruned DFS, including exact path order; seeded path/visited-state behavior is also checked.
- Review follow-up adds explicit parallel conditional handles, skipped-edge topology, response-specific selectors/reachability, selector changes across reinitialization, and root/back-edge paths. Assertions cover exact paths and blocking decisions.

The upstream Python 3.12/3.13 CI matrix remains the final platform check.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
