### PR TITLE
fix(engine): scope layer contexts to worker execution segments

### DIFF
--- a/src/graphon/engine/layer/README.md
+++ b/src/graphon/engine/layer/README.md
@@ -12,6 +12,15 @@ Base class with optional lifecycle hooks for layers.
 - `on_graph_start()` - Execution start hook
 - `on_event()` - Process all events
 - `on_graph_end()` - Execution end hook
+- `node_run_context(node, parent_execution_id=...)` - Context manager activated
+  for each worker task, including every container resume. Entry and exit always
+  occur in the same worker context, even on suspension or failure. The parent ID
+  is the direct container's node execution ID, or `None` for root-frame nodes.
+- `on_node_run_start(node)` / `on_node_run_end(node, error, result_event)` - Logical
+  node lifetime hooks. A container may suspend between these hooks and finish on
+  another worker. Keep tracing spans alive across suspension, but activate their
+  context only inside `node_run_context`; do not carry context tokens between
+  logical lifetime hooks. These contexts are not included in runtime snapshots.
 
 ## Usage
 

--- a/src/graphon/engine/layer/base.py
+++ b/src/graphon/engine/layer/base.py
@@ -4,6 +4,8 @@ This module defines the lifecycle hooks and shared runtime binding used by layer
 that intercept and respond to Engine events.
 """
 
+from contextlib import AbstractContextManager, nullcontext
+
 from graphon.engine.command.protocol import CommandChannel
 from graphon.engine_events.base import (
     EngineEvent,
@@ -97,11 +99,39 @@ class Layer:
 
         """
 
+    def node_run_context(
+        self,
+        node: Node,
+        *,
+        parent_execution_id: str | None = None,
+    ) -> AbstractContextManager[None]:
+        """Activate context for one worker task, including container resumes.
+
+        Entered before node hooks and exited on completion, suspension, or error
+        in the same worker context. A suspended container keeps its logical
+        execution ID, but each resume gets a fresh context manager. Keep context
+        tokens inside this manager, not between ``on_node_run_start`` and
+        ``on_node_run_end``, which may run on different workers.
+
+        ``parent_execution_id`` identifies the directly owning container's node
+        execution (including custom containers), or is ``None`` in the root
+        frame. It is independent of graph-local node IDs. Context manager errors
+        are logged and isolated like other layer hooks; managers cannot suppress
+        node execution errors.
+
+        Returns:
+            A new context manager for this worker task.
+
+        """
+        _ = node
+        _ = parent_execution_id
+        return nullcontext()
+
     def on_node_run_start(self, node: Node) -> None:
         """Called immediately before a node begins execution.
 
         Layers can override to inject behavior (e.g., start spans)
-        prior to node execution.
+        prior to node execution. This is not called again on container resume.
         The node's execution ID is available via `node._node_execution_id` and will be
         consistent with all events emitted by this node execution.
 
@@ -119,6 +149,8 @@ class Layer:
     ) -> None:
         """Called after a node finishes execution.
 
+        A suspended container does not finish until its final resume, which can
+        run on a different worker from ``on_node_run_start``.
         The node's execution ID is available via `node._node_execution_id` and matches
         the `id` field in all events emitted by this node execution.
 

--- a/src/graphon/engine/worker/worker.py
+++ b/src/graphon/engine/worker/worker.py
@@ -6,9 +6,10 @@ to the dispatch queue for the dispatcher to process.
 
 import logging
 import queue
+import sys
 import threading
 from collections.abc import Iterator, Sequence
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import final, override
@@ -220,7 +221,13 @@ class Worker(threading.Thread):
         error: Exception | None = None
         result_event: NodeEvent | None = None
         suspended = False
-        with self._execution_context:
+        with self._execution_context, ExitStack() as contexts:
+            if self._layers:
+                parent_execution_id = self._parent_execution_id()
+                for layer in self._layers:
+                    contexts.enter_context(
+                        self._node_run_context(layer, node, parent_execution_id),
+                    )
             if invocation_id is None:
                 self._invoke_node_run_start_hooks(node)
             try:
@@ -237,6 +244,51 @@ class Worker(threading.Thread):
             finally:
                 if not suspended:
                     self._invoke_node_run_end_hooks(node, error, result_event)
+
+    def _parent_execution_id(self) -> str | None:
+        if self._current_frame_id == ROOT_FRAME_ID:
+            return None
+        root_state = self._frame_registry[ROOT_FRAME_ID].state
+        frame_state = root_state.get_container_frame(self._current_frame_id)
+        parent_run = root_state.get_container_run(frame_state.parent_invocation_id)
+        parent_state = self._frame_registry[parent_run.frame_id].state
+        return parent_state.graph_execution.get_or_create_node_execution(
+            frame_id=parent_run.frame_id,
+            node_id=parent_run.node_id,
+        ).execution_id
+
+    @contextmanager
+    def _node_run_context(
+        self,
+        layer: Layer,
+        node: Node,
+        parent_execution_id: str | None,
+    ) -> Iterator[None]:
+        try:
+            context = layer.node_run_context(
+                node, parent_execution_id=parent_execution_id
+            )
+            # Isolate activation failures separately from errors raised by the node.
+            context.__enter__()  # ruff: ignore[unnecessary-dunder-call]
+        except Exception:
+            logger.exception(
+                "Layer %s failed entering node_run_context for node %s",
+                type(layer).__name__,
+                node.id,
+            )
+            yield
+            return
+        try:
+            yield
+        finally:
+            try:
+                context.__exit__(*sys.exc_info())
+            except Exception:
+                logger.exception(
+                    "Layer %s failed exiting node_run_context for node %s",
+                    type(layer).__name__,
+                    node.id,
+                )
 
     def _consume_node_events(
         self,

--- a/tests/engine/test_cooperative_container_execution.py
+++ b/tests/engine/test_cooperative_container_execution.py
@@ -1,7 +1,9 @@
 import queue
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import UTC, datetime
-from threading import Event, Lock, Thread
+from threading import Event, Lock, Thread, current_thread
 from types import SimpleNamespace
 from typing import cast
 
@@ -81,6 +83,39 @@ class _RecordingLayer(Layer):
     def __init__(self) -> None:
         super().__init__()
         self.end_events: list[NodeEvent | None] = []
+        self.active_execution: ContextVar[str | None] = ContextVar(
+            "active_execution", default=None
+        )
+        self.context_events: list[tuple[str, str, str | None]] = []
+        self.hook_contexts: list[str | None] = []
+
+    @contextmanager
+    def node_run_context(
+        self,
+        node: Node,
+        *,
+        parent_execution_id: str | None = None,
+    ) -> Iterator[None]:
+        assert self.active_execution.get() is None
+        token = self.active_execution.set(node.execution_id)
+        self.context_events.append((
+            "enter",
+            current_thread().name,
+            parent_execution_id,
+        ))
+        try:
+            yield
+        finally:
+            self.active_execution.reset(token)
+            self.context_events.append((
+                "exit",
+                current_thread().name,
+                self.active_execution.get(),
+            ))
+
+    def on_node_run_start(self, node: Node) -> None:
+        _ = node
+        self.hook_contexts.append(self.active_execution.get())
 
     def on_graph_start(self) -> None:
         return
@@ -100,6 +135,7 @@ class _RecordingLayer(Layer):
         _ = node
         _ = error
         self.end_events.append(result_event)
+        self.hook_contexts.append(self.active_execution.get())
 
 
 def test_ready_queue_round_trips_start_and_resume_tasks() -> None:
@@ -193,7 +229,10 @@ def test_ready_queue_uses_only_public_queue_api(
     assert not join_thread.is_alive()
 
 
-def test_worker_suspends_and_resumes_container_invocation() -> None:
+@pytest.mark.parametrize("resume_fails", [False, True])
+def test_worker_suspends_and_resumes_container_invocation(resume_fails: bool) -> None:  # ruff: ignore[too-many-statements, too-many-locals]
+    layer = _RecordingLayer()
+
     class ContainerNode:
         id = "loop"
         node_type = BuiltinNodeTypes.LOOP
@@ -203,6 +242,7 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
         def __init__(self) -> None:
             self.await_was_reached = False
             self.body_after_await_was_consumed = False
+            self.contexts: list[str | None] = []
 
         def bind_execution_id(self, execution_id: str) -> None:
             self.execution_id = execution_id
@@ -210,6 +250,7 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
         def run(
             self,
         ) -> Generator[NodeEvent | LoopFrameRequest, object, None]:
+            self.contexts.append(layer.active_execution.get())
             started_at = datetime.now(UTC).replace(tzinfo=None)
             yield NodeRunStartedEvent(
                 id=self.execution_id,
@@ -236,6 +277,10 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
             result: ContainerRunResult,
             started_at: datetime,
         ) -> Generator[NodeEvent | LoopFrameRequest, None, None]:
+            self.contexts.append(layer.active_execution.get())
+            if resume_fails:
+                msg = "resume failed"
+                raise RuntimeError(msg)
             assert isinstance(result, ContainerExecutionResult)
             node_run_result = NodeRunResult(
                 status=result.node_run_result.status,
@@ -281,7 +326,6 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
             runtime_state=runtime_state,
         ),
     )
-    layer = _RecordingLayer()
     task_acquisition_enabled = Event()
     task_acquisition_enabled.set()
     worker = Worker(
@@ -312,7 +356,25 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
         assert node_execution.execution_id == started.event.id
         assert run_state.started_at == started.event.start_at
         assert layer.end_events == []
-
+    finally:
+        worker.stop()
+        worker.join(timeout=1)
+    assert not worker.is_alive()
+    assert layer.context_events == [
+        ("enter", "EngineWorker-0", None),
+        ("exit", "EngineWorker-0", None),
+    ]
+    resumed_worker = Worker(
+        ready_queue=ready_queue,
+        dispatch_queue=dispatch_queue,
+        frame_registry=frame_registry,
+        layers=[layer],
+        task_acquisition_lock=Lock(),
+        task_acquisition_enabled=task_acquisition_enabled,
+        worker_id=1,
+    )
+    resumed_worker.start()
+    try:
         ready_queue.put(
             ResumeTask(
                 invocation_id=await_task.invocation_id,
@@ -321,15 +383,28 @@ def test_worker_suspends_and_resumes_container_invocation() -> None:
         )
         succeeded = dispatch_queue.get(timeout=1)
     finally:
-        worker.stop()
-        worker.join(timeout=1)
+        resumed_worker.stop()
+        resumed_worker.join(timeout=1)
 
     assert isinstance(succeeded, NodeEventTask)
-    assert isinstance(succeeded.event, NodeRunSucceededEvent)
-    assert succeeded.event.node_run_result.outputs == {"answer": "ok"}
+    if resume_fails:
+        assert isinstance(succeeded.event, NodeRunFailedEvent)
+        assert succeeded.event.error == "resume failed"
+        assert layer.end_events == [None]
+    else:
+        assert isinstance(succeeded.event, NodeRunSucceededEvent)
+        assert succeeded.event.node_run_result.outputs == {"answer": "ok"}
+        assert layer.end_events == [succeeded.event]
     with pytest.raises(KeyError):
         runtime_state.get_container_run(await_task.invocation_id)
-    assert layer.end_events == [succeeded.event]
+    assert container_node.contexts == [started.event.id, started.event.id]
+    assert layer.hook_contexts == [started.event.id, started.event.id]
+    assert layer.context_events == [
+        ("enter", "EngineWorker-0", None),
+        ("exit", "EngineWorker-0", None),
+        ("enter", "EngineWorker-1", None),
+        ("exit", "EngineWorker-1", None),
+    ]
 
 
 def test_worker_reports_resume_failure_on_suspended_invocation_frame() -> None:

--- a/tests/engine/test_layer_node_run_context.py
+++ b/tests/engine/test_layer_node_run_context.py
@@ -1,0 +1,179 @@
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+import pytest
+
+from graphon.dsl import loads
+from graphon.engine.layer import Layer
+from graphon.engine_events.graph import GraphRunSucceededEvent
+from graphon.nodes.base.node import Node
+
+
+def test_nested_parallel_containers_pass_the_direct_parent_execution() -> None:
+    active: ContextVar[str | None] = ContextVar("active", default=None)
+    parents: dict[str, tuple[str, str | None]] = {}
+    activations: dict[str, int] = {}
+
+    class ContextLayer(Layer):
+        @contextmanager
+        def node_run_context(
+            self,
+            node: Node,
+            *,
+            parent_execution_id: str | None = None,
+        ) -> Iterator[None]:
+            parents[node.execution_id] = (node.id, parent_execution_id)
+            activations[node.execution_id] = activations.get(node.execution_id, 0) + 1
+            token = active.set(node.execution_id)
+            try:
+                yield
+            finally:
+                active.reset(token)
+
+    engine = loads(
+        json.dumps({
+            "kind": "graph",
+            "graph": {
+                "nodes": [
+                    {"id": "start", "data": {"type": "start", "variables": []}},
+                    {
+                        "id": "iteration",
+                        "data": {
+                            "type": "iteration",
+                            "start_node_id": "iteration-start",
+                            "iterator_selector": ["start", "items"],
+                            "output_selector": ["loop", "loop_round"],
+                            "is_parallel": True,
+                            "parallel_nums": 2,
+                        },
+                    },
+                    {
+                        "id": "iteration-start",
+                        "data": {
+                            "type": "iteration-start",
+                            "container_id": "iteration",
+                        },
+                    },
+                    {
+                        "id": "loop",
+                        "data": {
+                            "type": "loop",
+                            "container_id": "iteration",
+                            "loop_count": 2,
+                            "start_node_id": "loop-start",
+                            "break_conditions": [],
+                            "logical_operator": "and",
+                        },
+                    },
+                    {
+                        "id": "loop-start",
+                        "data": {
+                            "type": "loop-start",
+                            "container_id": "loop",
+                        },
+                    },
+                    {"id": "end", "data": {"type": "end", "outputs": []}},
+                ],
+                "edges": [
+                    {"source": "start", "target": "iteration"},
+                    {"source": "iteration-start", "target": "loop"},
+                    {"source": "iteration", "target": "end"},
+                ],
+            },
+        }),
+        start_inputs={"items": ["a", "b"]},
+        workers=2,
+    )
+    engine.add_layer(ContextLayer())
+
+    events = list(engine.run())
+
+    assert isinstance(events[-1], GraphRunSucceededEvent)
+    iteration_ids = {
+        execution_id
+        for execution_id, (node_id, _) in parents.items()
+        if node_id == "iteration"
+    }
+    loop_ids = {
+        execution_id
+        for execution_id, (node_id, _) in parents.items()
+        if node_id == "loop"
+    }
+    assert len(iteration_ids) == 1
+    assert len(loop_ids) == 2
+    assert sum(node_id == "loop-start" for node_id, _ in parents.values()) == 4
+    for execution_id, (node_id, parent_id) in parents.items():
+        if node_id in {"start", "iteration", "end"}:
+            assert parent_id is None
+        elif node_id in {"iteration-start", "loop"}:
+            assert parent_id in iteration_ids
+        else:
+            assert node_id == "loop-start"
+            assert parent_id in loop_ids
+        assert activations[execution_id] == {"iteration": 2, "loop": 3}.get(node_id, 1)
+    assert {
+        parent_id for node_id, parent_id in parents.values() if node_id == "loop-start"
+    } == loop_ids
+    assert active.get() is None
+
+
+@pytest.mark.parametrize("failure", ["enter", "exit"])
+def test_layer_context_failure_does_not_fail_node_or_skip_other_layers(
+    failure: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    steps: list[str] = []
+
+    class FailingLayer(Layer):
+        @contextmanager
+        def node_run_context(
+            self,
+            node: Node,
+            *,
+            parent_execution_id: str | None = None,
+        ) -> Iterator[None]:
+            _ = node
+            _ = parent_execution_id
+            if failure == "enter":
+                raise RuntimeError(failure)
+            try:
+                yield
+            finally:
+                raise RuntimeError(failure)
+
+    class RecordingLayer(Layer):
+        @contextmanager
+        def node_run_context(
+            self,
+            node: Node,
+            *,
+            parent_execution_id: str | None = None,
+        ) -> Iterator[None]:
+            _ = node
+            _ = parent_execution_id
+            steps.append("enter")
+            try:
+                yield
+            finally:
+                steps.append("exit")
+
+    engine = loads(
+        json.dumps({
+            "kind": "graph",
+            "graph": {
+                "nodes": [{"id": "start", "data": {"type": "start", "variables": []}}],
+                "edges": [],
+            },
+        }),
+        workers=1,
+    )
+    engine.add_layer(FailingLayer())
+    engine.add_layer(RecordingLayer())
+
+    events = list(engine.run())
+
+    assert isinstance(events[-1], GraphRunSucceededEvent)
+    assert steps == ["enter", "exit"]
+    assert f"RuntimeError: {failure}" in caplog.text


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #272

## Summary

Add a framework-neutral layer context manager around each initial or resumed worker execution segment. Context activation and cleanup stay in the same worker, including suspension and failures; logical node start/end hooks keep their existing semantics.

Pass the direct owning container execution ID into the context hook for built-in and custom frames. Downstream tracing layers can retain a span across suspension, activate it independently on each worker, and place child spans beneath their container. No tracing-provider dependency or snapshot schema change is introduced.

This is the upstream companion to langgenius/dify#40277.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation