### PR TITLE
fix(graph)!: reject malformed inputs and execution cycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ All agents working in this repository must follow the guidance in
 [CONTRIBUTING.md](CONTRIBUTING.md). If there is any ambiguity, treat
 `CONTRIBUTING.md` as the source of truth.
 
+At the start of every development workflow, read and follow
+[Development Style](CONTRIBUTING.md#development-style), including the required
+independent test review, knowledge review, and final naming pass.
+
 ## Where to start
 
 - [README.md](README.md): project overview and runnable examples.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,10 +42,12 @@ flowchart LR
     Stream --> Consumer[Engine.run consumer]
 ```
 
-1. [Graph.init](src/graphon/graph/graph.py) normalizes external node ownership,
-   scopes the graph, validates node schemas, constructs direct-frame nodes, and
-   runs structural validation. `Graph.new()` supplies the fluent builder for
-   directly instantiated nodes.
+1. [Graph.init](src/graphon/graph/graph.py) validates input IDs and edge fields,
+   normalizes ownership, scopes the graph, and prevalidates node schemas,
+   endpoints, and execution cycles throughout the retained subtree before
+   constructing direct-frame nodes. Root type is checked on the resolved node.
+   `Graph.new()` supplies the fluent builder for directly instantiated nodes and
+   validates their graph at `build()`.
 2. [Engine](src/graphon/engine/engine.py) binds a root frame, command processor,
    event stream, fixed worker pool, and dispatcher. Calling `run()` starts or
    resumes execution and yields graph lifecycle events plus processed node and
@@ -92,10 +94,17 @@ traversal events also carry `frame_id`. See [scoping tests](tests/graph/test_gra
 resolve the same class/version as `create_node()` without constructing a node,
 running `post_init()`, or initializing runtime dependencies. Factories rebind
 runtime state and scoped graph configuration without mutating parent/sibling
-configuration. The built-in structural rules check edge endpoints and root type;
-they do not provide general execution-graph cycle detection. See
+configuration. Default construction rejects invalid or duplicate node IDs,
+malformed edges, missing endpoints, and execution cycles throughout the retained
+subtree, including inactive paths. Container handlers provide repetition; each
+scope's edges must be acyclic. Root eligibility is checked afterward on the
+constructed node, preserving custom factory aliases for loop and iteration
+entry nodes.
+`skip_validation=True` bypasses endpoint existence, root type, and cycle checks,
+but still validates input fields, IDs, schemas, and ownership. The low-level
+`Graph(...)` constructor remains trusted assembly. See
 [factory contract](src/graphon/graph/graph.py), [validators](src/graphon/graph/validation.py),
-and [validation tests](tests/graph/test_graph_validation.py).
+and [scoping and preflight tests](tests/graph/test_graph_scoping.py).
 
 **Joins wait for branch resolution.** A node with incoming edges is ready only
 when none remain `UNKNOWN` and at least one is `TAKEN`. Branch completion selects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ before upgrading an integration.
 
 ### Changed
 
+- Graph construction now rejects invalid or duplicate node IDs, malformed edge
+  fields, duplicate edge IDs within a scope, and execution cycles
+  before constructing configured nodes, including errors in nested scopes.
+  The Python builder also rejects invalid IDs, handles, and cycles. DSL graph
+  validation failures now preserve their structured issue details.
 - Renamed the public execution API around `Engine`, `EngineEvent`, `NodeEvent`,
   `RuntimeState`, and `InitParams`; the corresponding packages now use singular,
   responsibility-based names.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,85 @@ By default, use `just` for routine development. Direct
 [`pytest`](https://docs.pytest.org/), and [`prek`](https://prek.j178.dev/)
 usage is still fine when you need a targeted command.
 
+## Development Style
+
+Read and follow this section at the start of every development workflow,
+including work performed by agents.
+
+### Tests first
+
+Follow test-driven development for behavior changes and bug fixes:
+
+1. Write or update the smallest behavior-focused test that expresses the
+   requirement or reproduces the bug before writing the implementation.
+2. Run the test and confirm it fails for the intended missing or incorrect
+   behavior. Unrelated setup or fixture failures do not establish this. If the
+   test already passes, investigate whether the behavior already exists or the
+   test misses the problem before changing the implementation.
+3. Delegate review of the tests and their observed failure to a
+   [fresh, context-free subagent](#context-free-reviews). Resolve its findings
+   before implementation.
+4. Write the minimum implementation needed to make the test pass, then run it
+   again to confirm the result.
+5. Refactor with the tests kept green, then run the relevant broader checks from
+   [Testing and Validation](#testing-and-validation).
+
+Choose tests around observable behavior and meaningful scenarios. Avoid overly
+fine-grained tests for every helper or private method. Assert only what the
+requirement depends on; do not assume internal call order, private structure, or
+unrelated outputs. Keep fixtures, mocks, and input assumptions limited to what
+the scenario needs, and ground expected results in the intended behavior.
+
+### Concrete names
+
+Use simple, intuitive, easily understood words for functions, methods, files,
+classes, and variables. Name functions and methods for what they do, files and
+classes for what they contain or represent, and variables for the values they
+hold. Avoid names built around abstract concepts or generic design-pattern
+labels that hide the actual action or data.
+
+Prefer concrete names such as `load_graph`, `Graph`, `node_ids`, and `graph.py`.
+Keep names concise without obscure abbreviations or loss of meaning.
+
+### Context-free reviews
+
+Delegate test review, knowledge review, and the final naming pass to separate,
+newly spawned subagents. Start each with no inherited conversation history
+(`fork_turns="none"` when using `spawn_agent`); do not reuse an implementation
+agent or an earlier reviewer. Supply only the task requirements, repository
+location, files or diff to review, repository rules, and relevant test
+commands/results. Do not pass the parent agent's plan, implementation narrative,
+or previous review conclusions. The subagent should inspect repository source,
+tests, and callers independently.
+
+- **Test review:** the subagent checks that tests express the requirements, fail
+  for the intended reason, use meaningful behavioral scenarios, and avoid
+  excessive granularity or unsupported assumptions. Resolve findings and have
+  the revised tests reviewed by a new context-free subagent. Later changes to
+  test behavior or assertions also require a fresh review; mechanical reference
+  updates during renaming only require verification.
+- **Knowledge review:** after each development cycle's implementation and
+  ordinary checks, an independent subagent reviews and updates the knowledge
+  relevant exclusively to the current revision. It must correct outdated
+  information, remove redundancy, and shorten overly detailed material where
+  needed, applying the edits itself. Follow the
+  [scope and validation guidance](docs/maintenance.md#review-for-drift).
+  Complete this review before the final naming pass.
+- **Final naming pass:** after implementation, refactoring, test and knowledge
+  reviews, all other reviews and fixes, documentation, and ordinary validation
+  are complete, spawn a new context-free naming subagent. It must identify and
+  rename non-compliant function, method, file, class, and variable names
+  introduced or changed by the task. Reporting suggestions alone does not complete
+  the pass.
+  Update affected callers, imports, tests, and documentation as part of each
+  rename, preserving behavior and following repository compatibility rules.
+  Keep renames within the task's scope.
+
+After the naming subagent finishes, rerun the checks affected by its renames and
+inspect the diff before handoff. If further substantive development is needed,
+complete it and repeat the knowledge review followed by the final naming pass,
+each with a new context-free subagent.
+
 ## Development Setup
 
 ### Requirements
@@ -210,8 +289,8 @@ When you open a pull request:
   section is not applicable, say so explicitly
 - if CLA Assistant prompts you, sign [CLA.md](CLA.md) in the pull request
   conversation before merge
-- add or update tests for behavior changes unless the change genuinely does not
-  require them
+- follow [Development Style](#development-style) for tests, independent reviews,
+  and the final naming pass
 - update contributor-facing or user-facing documentation when needed
 
 ## CLA

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -111,6 +111,39 @@ only after the engine emits `GraphRunPausedEvent`; do not infer a pause from a
 queued command. Loop handlers write only their configured selectors back to the
 parent, while iteration frame state remains isolated.
 
+### Graph validation
+
+Default `Graph.init()`, `graphon.dsl.loads()`, and `Graph.new().build()` now reject
+execution cycles, including self-edges and cycles in inactive paths or nested
+containers. Express repetition through Loop, Iteration, or a custom container
+handler with acyclic internal edges. Valid disconnected graphs and multiple
+roots remain supported.
+
+Executable node IDs must be non-empty strings and unique across the supplied
+configuration. Edges must name existing nodes in the same direct scope, and an
+explicit `sourceHandle` must be a string. Omitting it still defaults to `"source"`;
+other string handles retain their existing behavior. Duplicate edge IDs are
+rejected within each scope, including descendants, while sibling scopes may
+reuse IDs. Supported editor notes and legacy ownership fields still normalize.
+
+For configured graphs, input and topology checks run before node constructors
+or `post_init()` hooks throughout the retained subtree. A child graph's cycle
+check excludes its parent and sibling scopes.
+Root type is checked afterward against the resolved node, so custom factory
+aliases for loop and iteration entry nodes remain supported.
+The Python builder receives existing nodes and rejects invalid graphs by
+`build()`. Graph validation errors retain structured issues; DSL loading exposes
+them as `DslError(code="graph.validation_failed")` rather than an `AttributeError`.
+Existing DSL normalization errors keep their codes.
+
+Correct previously accepted invalid definitions before loading or restoring them.
+Snapshot formats and edge IDs for valid graphs are unchanged.
+`Graph.init(skip_validation=True)` still bypasses endpoint existence, root type,
+and cycle checks; raw field/ID/schema/ownership checks and root ID presence
+remain mandatory. The low-level `Graph(...)` constructor remains unchecked.
+These trusted paths do not
+provide the guarantees of default construction.
+
 ### Edge identity
 
 `Edge.id` is now the DSL edge ID and is unique only inside one graph. Code that

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ independent test and knowledge reviews, and the final naming pass.
 | How do I keep knowledge current or record a longer task? | [Knowledge maintenance](maintenance.md) |
 | What breaks when upgrading? | [Migration guide](../MIGRATION.md), [changelog](../CHANGELOG.md) |
 | What structural debt has been identified, and what should improve next? | [Architecture review and technical debt](technical-debt.md) |
-| What debt is planned for the next implementation? | [TD-02 graph validation plan](plans/graph-validation.md) |
+| What is the progress and evidence for TD-02? | [Graph validation plan](plans/graph-validation.md) |
 
 ## Component references
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@ Start with the question you need to answer, then follow the links to code and
 tests. These documents describe this checkout; they do not substitute for the
 implementation or establish new public contracts.
 
+At the start of every development workflow, read and follow
+[Development Style](../CONTRIBUTING.md#development-style) for tests first,
+independent test and knowledge reviews, and the final naming pass.
+
 ## Map
 
 | Question | Start here |
@@ -15,6 +19,7 @@ implementation or establish new public contracts.
 | How do I keep knowledge current or record a longer task? | [Knowledge maintenance](maintenance.md) |
 | What breaks when upgrading? | [Migration guide](../MIGRATION.md), [changelog](../CHANGELOG.md) |
 | What structural debt has been identified, and what should improve next? | [Architecture review and technical debt](technical-debt.md) |
+| What debt is planned for the next implementation? | [TD-02 graph validation plan](plans/graph-validation.md) |
 
 ## Component references
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -124,6 +124,12 @@ revision. Once all other development steps are complete, finish with the
   [the factory](../src/graphon/dsl/node_factory.py) before promising import support.
   Its default file adapters reject unsupported file operations; adding host file
   support also requires wiring the appropriate node dependencies.
+- Default graph construction checks input and topology throughout the retained
+  subtree before constructing nodes; root type is checked on the resolved node.
+  Use acyclic edges inside each container; invalid fields or duplicate IDs
+  are rejected instead of being silently discarded. See the
+  [graph validation migration notes](../MIGRATION.md#graph-validation) for the
+  supported defaults and trusted validation bypasses.
 
 When a change alters these workflows, update this page and the linked source or
 tests in the same change. Put user-visible compatibility changes in

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,8 @@
 # Development navigation
 
+At the start of every development workflow, read and follow
+[Development Style](../CONTRIBUTING.md#development-style).
+
 Read [CONTRIBUTING.md](../CONTRIBUTING.md) for setup, validation commands, CI,
 and contribution rules. This page connects changes to the code and tests that
 define their behavior; it does not replace those rules.
@@ -20,26 +23,33 @@ define their behavior; it does not replace those rules.
 
 ## Add or extend a node
 
-1. Read the closest existing implementation and its tests. Define validated data
+1. Read the closest existing implementation and its tests. Write behavior tests
+   next to the related node tests and run them to confirm the intended failure
+   before implementing the node. If DSL support changes, exercise `loads()` as
+   well. For changes to branching, outputs, failure handling, or containers,
+   assert the complete engine behavior using the existing
+   [workflow tests](../tests/workflows/test_full_engine_events.py).
+   Complete the [context-free test review](../CONTRIBUTING.md#context-free-reviews)
+   before implementation.
+2. Define validated data
    with [BaseNodeData](../src/graphon/entities/base_node_data.py), then subclass
    `Node[YourNodeData]`. Supply `node_type`, a numeric-string `version()`, and
    `_run()`. Existing nodes such as [StartNode](../src/graphon/nodes/start/start_node.py)
    show the result-returning form; streaming nodes emit node event payloads.
-2. Import the node module during host bootstrap. Subclasses register when their
+3. Import the node module during host bootstrap. Subclasses register when their
    modules are imported; registry lookup does not discover or import packages.
    Registration alone does not add support to the default DSL importer:
    [SlimDslNodeFactory.NODE_BUILDERS](../src/graphon/dsl/node_factory.py) explicitly
    controls that surface and wires its dependencies.
-3. For a custom host factory, follow [NodeFactory](../src/graphon/graph/graph.py).
+4. For a custom host factory, follow [NodeFactory](../src/graphon/graph/graph.py).
    `validate_node()` must resolve the same class/version as `create_node()` without
    constructing nodes, initializing services, or mutating execution state.
    `with_runtime_state()` and `with_graph_config()` must keep parent and sibling
    frames isolated. `post_init()` runs in the node constructor, so the scoped
    graph config must already be bound then.
-4. Add coverage next to the related node tests. If DSL support changes, exercise
-   `loads()` as well. If the change affects branching, outputs, failure handling,
-   or containers, assert the complete engine behavior using the existing
-   [workflow tests](../tests/workflows/test_full_engine_events.py).
+5. Run the tests again to confirm they pass, then refactor with the tests kept
+   green. Complete the [validation and final reviews](#validate-the-behavior-you-changed)
+   described below.
 
 ## Integrate host services
 
@@ -92,6 +102,9 @@ Before handing off a code change, follow the validation sequence in
 [CONTRIBUTING.md](../CONTRIBUTING.md#testing-and-validation). `just test` and
 `just tc` apply formatting and lint fixes, so review the diff afterward.
 For dependency changes, update [uv.lock](../uv.lock) with the package metadata.
+Complete the [knowledge review](maintenance.md#review-for-drift) for the current
+revision. Once all other development steps are complete, finish with the
+[context-free naming pass and rename verification](../CONTRIBUTING.md#context-free-reviews).
 
 ## Runtime pitfalls
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -74,12 +74,26 @@ API documentation. Never record credentials or private operational data in it.
 
 ## Review for drift
 
-When a task exposes stale knowledge, fix it with that task. During a broader
-documentation review, start with the local link check, then compare claims about
-changed modules against their current code and tests. Check whether linked open
-work has landed; replace proposal links with repository-local decisions when
-available. Remove duplicate or unused material and record unresolved gaps with
-evidence instead of assigning unsupported quality grades.
+At the end of each development cycle, complete the independent knowledge review
+required by [Development Style](../CONTRIBUTING.md#context-free-reviews) before
+the final naming pass. Give the subagent the revision's requirements and diff so
+it can identify the affected knowledge through the index and relevant links.
+
+Limit both review and edits exclusively to information relevant to this revision:
+changed behavior, APIs, workflows, affected guides, and their navigation or
+source/test references. A document being touched does not make every section
+in scope. Do not turn this step into a repository-wide audit or unrelated cleanup.
+
+The subagent must compare relevant claims against current source, tests, and
+requirements, then apply necessary corrections. Remove redundant explanations,
+prefer links to maintained definitions, and shorten detail that does not help
+with the revised behavior or workflow. Preserve required rules, compatibility
+guidance, useful decisions, and supporting evidence. Do not make edits merely to
+produce a cleanup diff.
+
+After editing, repair affected links and run the documentation check above.
+Report the changes made, or that no relevant cleanup was needed. Keep review
+dates limited to claims actually checked. Broader audits remain outside this step.
 
 This is an ordinary contribution workflow. There is no scheduled maintenance
 agent or semantic freshness checker configured by these documents.

--- a/docs/plans/graph-validation.md
+++ b/docs/plans/graph-validation.md
@@ -1,182 +1,106 @@
 # TD-02: Reject invalid graphs before execution
 
-**Status:** active planning; implementation has not started. The contract below
-is proposed, not accepted architecture policy.
+**Status:** completed locally; implementation, independent reviews, and checks complete.
 **Last update:** 2026-09-08.
-**Priority:** P1; recommended next debt item.
-**Owner:** unassigned; Graph/DSL is the suggested responsibility area.
+**Priority:** P1; selected as the first debt remediation.
+**Owner:** current Graph/DSL development task on `laipz8200/graph-validation`.
 **Tracking:** [TD-02 in the debt register](../technical-debt.md#td-02--graph-construction-and-structural-validation).
-[Issue #131](https://github.com/langgenius/graphon/issues/131) is related authoring
-work, assigned to `laipz8200`; it is not an assignment or implementation ticket
-for this plan. No dedicated implementation issue/PR was found in the search below.
+[Implementation issue #277](https://github.com/langgenius/graphon/issues/277)
+tracks this fix and its pull request. Related
+[authoring issue #131](https://github.com/langgenius/graphon/issues/131) is not this
+fix's implementation ticket.
 
-## Objective and priority
+## Objective and scope
 
-Make the validated construction paths reject graphs that silently lose nodes or
-edges, or cannot execute under the current scheduling rules. A workflow containing
-`start → a → b → a` currently emits `GraphRunSucceededEvent` after executing only
-`start`; `a` and `b` remain `UNKNOWN`. This was reproduced in the reviewed checkout
-through public `dsl.loads()`. The Python builder also accepts that cycle.
+Reject invalid graphs at validated construction boundaries before input can be
+silently discarded or execution can report false success. Before this change,
+`start → a → b → a` succeeded after running only `start`, leaving `a` and `b`
+`UNKNOWN`; duplicate node IDs and malformed edges could also disappear during
+normalization. These reproduced results justified selecting TD-02 ahead of the
+separate snapshot and file adapter work.
 
-Prioritize this over TD-03's snapshot consistency risk and TD-04's file adapter
-isolation work because it is a reproduced incorrect result without a concurrency
-or deployment prerequisite. TD-04 should take precedence if a deployment is about
-to run concurrent workflows with distinct host file adapters. This review has no
-production incident counts or deployment evidence.
+The implementation changes graph construction, default validation, and DSL error
+translation. It preserves scheduler behavior, container execution, snapshot
+formats, supported editor/legacy inputs, and edge IDs for valid graphs. Current
+behavior and upgrade guidance live in [Architecture](../../ARCHITECTURE.md#state-and-execution-invariants)
+and [Migration](../../MIGRATION.md#graph-validation).
 
-## Context and implementation boundaries
+## Implementation and evidence
 
-Reviewed commit: `cf6c732` (the knowledge/debt review is present, with no runtime
-remediation). Preserve the [execution and state invariants](../../ARCHITECTURE.md)
-and the [factory preflight contract](../development.md#add-or-extend-a-node).
-
-| Boundary | Observed problem | Planned change |
+| Boundary | Change | Evidence |
 | --- | --- | --- |
-| [Graph normalization](../../src/graphon/graph/graph.py), `_normalize_nodes()` and `_parse_node_configs()` | Duplicate executable IDs are indexed with the last configuration winning. | Reject duplicate and invalid executable node IDs before the first ID index is built. |
-| [Edge preparation, scoping, and construction](../../src/graphon/graph/graph.py) | Non-string endpoints disappear during filtering; an explicit null `sourceHandle` disappears during `_build_edges()`. | Validate raw executable edge fields before filtering can discard them. |
-| [Default validators](../../src/graphon/graph/validation.py) and `Graph.init()` preflight | Only endpoints and root type are checked by the default rules. Descendant schemas are preflighted, but descendant execution cycles are accepted. | Share a small topology check between subtree preflight and the builder's default validator. |
-| [GraphBuilder](../../src/graphon/graph/graph.py), `_register_node()`, `add_node()`, and `connect()` | Type annotations do not prevent non-string IDs or null handles from reaching the built graph. | Enforce the same ID and handle-type rules through the existing builder/validator path before `build()` returns. |
-| [DSL importer](../../src/graphon/dsl/importer.py), `loads()` | It delegates construction to `Graph.init()`, but its `GraphValidationError` handler reads `issue.__dict__` from a slotted dataclass and raises `AttributeError`. | Use `dataclasses.asdict()` to retain the existing structured `DslError` envelope. |
-| [Frame construction](../../src/graphon/engine/frame.py), `_create_child_with_state()` | Fresh and restored child frames call `Graph.init()` using retained configuration. | Cover these callers through the shared boundary; retain frame isolation and edge identity. |
-
-[Scheduler.is_node_ready()](../../src/graphon/engine/scheduler.py) waits for every
-incoming edge to resolve. `is_execution_complete()` checks only enqueued work.
-This explains the false success: neither cycle node becomes ready. Changing join
-or completion semantics would affect valid branching and would not recover
-discarded input. Fix construction instead.
-
-## Proposed contract
-
-- After removing supported `custom-note` widgets, executable node IDs must be
-  non-empty strings and unique across the supplied configuration. Preserve typed
-  `BaseNodeData` input, editor metadata, and canonical/legacy owner normalization.
-  Normalization must leave caller-owned configuration unchanged.
-- Executable edges must have string endpoints naming existing nodes in the same
-  direct scope. If `sourceHandle` is absent, keep the current `"source"` default;
-  if supplied, require a string. Do not add handle-name membership rules or reject
-  currently accepted string handles as part of this work.
-- Each executable scope must be acyclic, including self-edges and cycles in
-  inactive branches or retained descendants. Validate the retained subtree before
-  `create_node()` or `post_init()` runs. Loop, Iteration, and custom container
-  nodes remain valid: repetition is owned by their handlers, while their internal
-  execution edges follow the same rule. Acyclic disconnected and multiple-root
-  configurations remain allowed; this is not a reachability requirement.
-- Preserve explicit edge IDs, generated-ID allocation for valid inputs, and
-  sibling scopes' ability to reuse local edge IDs. Check endpoints before cycle
-  detection so an unknown endpoint does not become an implicit topology node.
-- Use the existing `GraphValidationIssue`/`GraphValidationError` types for new
-  graph rules. Diagnostics should identify the offending node/edge and the owning
-  scope for a cycle. Preserve existing DSL normalization error codes and the
-  `graph.validation_failed` envelope for errors raised by graph validators.
-- Apply these guarantees to default `Graph.init()`, `dsl.loads()`, and
-  `Graph.new().build()`. The builder receives already constructed nodes, so its
-  guarantee is rejection at `build()`, not prevention of caller-side construction.
-  For `Graph.init(skip_validation=True)`, keep node schemas, ID/type checks,
-  ownership checks, and edge-ID checks mandatory; bypass endpoint-existence,
-  root-execution-type, and cycle checks. Root ID presence is still required to
-  construct the graph, as today. The low-level `Graph(...)`
-  constructor remains a trusted assembly surface. Document both bypasses rather
-  than adding validation to every engine run. No in-repository caller currently
-  passes `skip_validation`.
+| [Graph configuration](../../src/graphon/graph/graph.py) | Reject invalid/duplicate executable node IDs and malformed edge fields before indexing or filtering; enforce edge ID uniqueness within each owning scope. | [Scoping tests](../../tests/graph/test_graph_scoping.py) cover rejection before construction, unchanged inputs, legacy ownership, scoped edge IDs, and valid custom containers. |
+| [Default validation](../../src/graphon/graph/validation.py) | Share endpoint and cycle checks between retained-subtree preflight and materialized graph validation. | [Scoping tests](../../tests/graph/test_graph_scoping.py) cover self-cycles, nested/inactive cycles, unknown endpoints, sibling-scope exclusion, and trusted bypasses; [validator tests](../../tests/graph/test_graph_validation.py) retain root/endpoint coverage. |
+| [Python builder](../../src/graphon/graph/graph.py) | Reject non-string/empty IDs at registration and invalid handles/cycles by `build()`. Nodes are already constructed by the caller. | [Builder tests](../../tests/graph/test_graph.py) exercise both edge creation methods and preserve valid DAGs. |
+| [DSL loading](../../src/graphon/dsl/importer.py) | Serialize slotted validation issues with `dataclasses.asdict()` into the existing `graph.validation_failed` envelope. | [Importer tests](../../tests/dsl/test_importer.py) reject the false-success cycle before execution, run its acyclic control, and inspect structured root/cycle errors. |
+| [Child frame construction](../../src/graphon/engine/frame.py) | Fresh/restored frames use the same `Graph.init()` boundary; no frame changes were needed. | Existing [container execution](../../tests/engine/test_cooperative_container_execution.py), [serialization](../../tests/engine/test_runtime_state_serialization.py), and [snapshot isolation](../../tests/test_snapshot_version_isolation.py) checks pass in the full suite. |
 
 ## Delivery steps
 
-- [x] Review knowledge, construction callers, related tests, and current tracking.
-- [x] Reproduce the cycle, input loss, and DSL error translation problems.
-- [ ] Before implementation, repeat the issue/PR search required by
-  [Contributing](../../CONTRIBUTING.md#issues), confirm an implementation owner,
-  and coordinate scope with #131. Record the implementation issue here before
-  opening its PR; the new authoring API is not a prerequisite.
-- [ ] Add focused regressions in the existing files listed below, then implement
-  input checks before lossy normalization/scoping. Keep the existing DSL-specific
-  paths and error context. Add the matching ID/handle checks to the existing
-  builder/validator path; type annotations alone do not enforce them. A new graph
-  schema or validation framework is unnecessary.
-- [ ] Add one reusable topology check in `graph/validation.py`, using stdlib
-  `graphlib.TopologicalSorter.prepare()` and `CycleError`. Apply it to each scope
-  of the retained config before node construction and through the builder's
-  default validator. Do not construct child graphs just to validate them.
-- [ ] Repair DSL issue serialization and verify rejection through public loading.
-  Keep this with the new validation so invalid graphs reliably return `DslError`.
-- [ ] Update [Architecture](../../ARCHITECTURE.md), the relevant
-  [development guidance](../development.md), and the unreleased 0.8.0 section of
-  [MIGRATION.md](../../MIGRATION.md). Explain that previously accepted invalid
-  graphs now fail and must be corrected, with explicit containers used for
-  repetition. Record release changes in [CHANGELOG.md](../../CHANGELOG.md).
-- [ ] Run the focused checks and contributor checks, then record the PR,
-  completion evidence, and final contract here and in the debt register.
+- [x] Inspect construction callers, reproduce the defects, and repeat the required
+  issue/PR search before implementation.
+- [x] Add behavior regressions, observe their intended failures, and complete
+  independent test reviews before implementation.
+- [x] Implement input validation, shared cycle detection, builder checks, and
+  structured DSL errors.
+- [x] Preserve resolved factory root types and explicit validation bypasses, with
+  independently reviewed compatibility regressions.
+- [x] Run focused and full checks; update affected guides, migration notes,
+  changelog, and debt evidence through the independent knowledge review.
+- [x] Complete the final naming pass and affected checks before handoff.
 
-Target one focused implementation PR. Expected production edits are
-`graph/graph.py`, `graph/validation.py`, and `dsl/importer.py`; engine changes,
-new dependencies, snapshot formats, and #131's authoring API are outside scope.
-
-## Acceptance checks
-
-Extend existing test helpers; use a small parameterized set of invalid inputs,
-not a new test framework.
-
-| Check | Evidence to add or preserve |
-| --- | --- |
-| Duplicate IDs cannot overwrite nodes, including IDs reused across scopes; malformed endpoints and null/non-string handles cannot drop edges. | [Graph validation tests](../../tests/graph/test_graph_validation.py) and [DSL importer tests](../../tests/dsl/test_importer.py). Retain DSL duplicate-ID errors and builder duplicate-node rejection. Add a focused [builder regression](../../tests/graph/test_graph.py) for non-string IDs and invalid handles supplied through both `add_node()` and `connect()`. |
-| Direct construction, DSL loading, and the builder reject self-cycles and `start → a → b → a`. | [Graph validation](../../tests/graph/test_graph_validation.py), [builder](../../tests/graph/test_graph.py), and [workflow event tests](../../tests/workflows/test_full_engine_events.py). The public loading regression must fail before execution can report success. |
-| A cycle or malformed edge in a nested/inactive descendant is rejected before any node is created. | Reuse the recording factory in [scoping tests](../../tests/graph/test_graph_scoping.py) and the `create_node` spy in [DSL factory tests](../../tests/dsl/test_node_factory.py); assert no construction. |
-| Valid branches, joins, multiple roots, containers, metadata, legacy ownership, omitted handles, and edge IDs retain behavior. | Existing [graph tests](../../tests/graph/), [workflow events](../../tests/workflows/test_full_engine_events.py), and [cooperative container tests](../../tests/engine/test_cooperative_container_execution.py), with small compatibility cases only where missing. |
-| Validation returns structured errors rather than `AttributeError`; bypass behavior is explicit. | In [DSL importer tests](../../tests/dsl/test_importer.py), inspect `DslError.code` and `details["issues"]`. In graph tests, check the chosen `skip_validation` behavior without executing the deliberately invalid graph. |
-| Valid restored child graphs keep their queued work and identities. | Preserve [engine serialization](../../tests/engine/test_runtime_state_serialization.py), [runtime tests](../../tests/runtime/test_runtime_state.py), and [snapshot version isolation](../../tests/test_snapshot_version_isolation.py); do not regenerate historical fixtures. |
+The duplicate search was repeated before preparing the draft PR, and
+[issue #277](https://github.com/langgenius/graphon/issues/277) was created as
+required by [Contributing](../../CONTRIBUTING.md#issues).
 
 ## Decision log
 
-- **2026-09-08 — Proposed:** choose TD-02 first based on reproduced incorrect
-  success and input loss. Keep TD-03/TD-04 separate unless deployment evidence
-  changes their urgency.
-- **2026-09-08 — Proposed:** reject execution cycles using a stdlib check at
-  construction, sharing the implementation across config and builder paths.
-  Explicit container handlers already provide repetition; scheduler changes and
-  a generic graph-analysis framework would expand the task unnecessarily.
-- **2026-09-08 — Proposed compatibility:** retain trusted bypasses, reject cycles
-  even in inactive scopes, and document stricter default validation for 0.8.0.
-  Maintainer review must confirm these public-contract choices and the release
-  target before implementation is treated as accepted policy.
+- **2026-09-08 — Implementation authorized:** the user requested committing the
+  prior documentation and proceeding with TD-02. That documentation is committed
+  as `cc674fa`; this plan records the subsequent local implementation.
+- **2026-09-08 — Construction boundary:** use stdlib
+  `graphlib.TopologicalSorter.prepare()` after endpoint checks. Cross-scope edges
+  are already rejected, so one topology check covers the retained scopes without
+  constructing children. Changing scheduling would neither recover discarded
+  input nor make unsupported cycles valid.
+- **2026-09-08 — Compatibility:** root eligibility stays on the constructed
+  node's execution/type information, preserving custom factory aliases for
+  built-in container entries. `skip_validation=True` bypasses endpoint existence,
+  root type, and cycles while mandatory input/ownership checks remain. Raw
+  `Graph(...)` stays a trusted assembly surface. The unreleased 0.8.0 migration
+  notes describe these changes; local implementation is not a release or an
+  accepted repository-wide design decision.
 
 ## Validation and outcome
 
-On 2026-09-08, Python 3.12.13, the following baseline passed: **93 tests**.
+On Python 3.12.13, the initial regressions produced **32 failures and 66 passing
+controls** for the missing behavior. A later compatibility run produced **3
+failures and 1 passing control** before its fixes. Fresh context-free test reviews
+covered both sets.
+
+The current focused command passes **136 tests**:
 
 ```bash
 uv run pytest -n 0 \
-  tests/test_repository_docs.py \
+  tests/graph/test_graph_scoping.py \
   tests/graph/test_graph.py \
   tests/graph/test_graph_validation.py \
-  tests/graph/test_graph_scoping.py \
   tests/dsl/test_importer.py \
   tests/dsl/test_node_factory.py
 ```
 
-Additional local probes confirmed duplicate-ID collapse, edge loss for null
-handles and non-string endpoints, builder cycle acceptance, and successful root
-construction despite a descendant cycle. The
-[public cycle reproduction](../technical-debt.md#validation-record) still produced
-`GraphRunSucceededEvent`, `['start']`, and unknown states for `a`/`b`. Selecting
-the template node as the DSL root reproduced the slotted-issue `AttributeError`.
-Builder probes also accepted an integer node ID and a null source handle.
-These are baseline defects, not passing acceptance checks for a fix.
+`just test` passes **815 tests**; `just check` and `git diff --check` also pass.
+An earlier full run had one gevent subprocess timeout; its isolated rerun and the
+current full run passed. Python 3.13 and live external integrations have not been
+run locally. After the independent knowledge review's documentation edits,
+`uv run pytest -n 0 tests/test_repository_docs.py` passes **1 test**.
+The final naming pass applied mechanical renames, and the focused checks,
+`just check`, and full 815-test suite passed again afterward.
 
-The documentation link/reachability check passed after adding this plan and its
-index links. Runtime implementation remains unchanged.
-
-After implementation, rerun the baseline plus the workflow, container, and
-snapshot checks linked above, then follow `just test` and `just check` in
-[Contributing](../../CONTRIBUTING.md#testing-and-validation). Full-suite and
-Python 3.13 validation have not been run for this planning change.
-
-Tracking was checked read-only on 2026-09-08: all 10 open issues and 14 open PRs,
-plus open/closed title/body searches for graph validation, cycle, duplicate,
-`sourceHandle`, duplicate node, acyclic, cycles, TD-02, and references to #131.
-[PR #3](https://github.com/langgenius/graphon/pull/3) already added builder
-validation but no cycle rule. [PR #276](https://github.com/langgenius/graphon/pull/276)
-merged the debt review only. #131 remains open; no dedicated fix was found in
-these targeted searches. [PR #271](https://github.com/langgenius/graphon/pull/271)
-and [PR #200](https://github.com/langgenius/graphon/pull/200) remain open work on
-filter performance and decision records, respectively, and do not supersede this
-plan. Repeat the search when implementation begins; no tracking records were
-created or changed during planning.
+The preimplementation tracking search covered open and closed graph-validation
+issues/PRs and found no dedicated or overlapping fix. Related
+[issue #131](https://github.com/langgenius/graphon/issues/131) covers authoring,
+[PR #271](https://github.com/langgenius/graphon/pull/271) filter performance, and
+[PR #200](https://github.com/langgenius/graphon/pull/200) decision records. The
+draft-PR preparation search also found no overlapping fix; #277 now provides
+dedicated implementation tracking.

--- a/docs/plans/graph-validation.md
+++ b/docs/plans/graph-validation.md
@@ -1,0 +1,182 @@
+# TD-02: Reject invalid graphs before execution
+
+**Status:** active planning; implementation has not started. The contract below
+is proposed, not accepted architecture policy.
+**Last update:** 2026-09-08.
+**Priority:** P1; recommended next debt item.
+**Owner:** unassigned; Graph/DSL is the suggested responsibility area.
+**Tracking:** [TD-02 in the debt register](../technical-debt.md#td-02--graph-construction-and-structural-validation).
+[Issue #131](https://github.com/langgenius/graphon/issues/131) is related authoring
+work, assigned to `laipz8200`; it is not an assignment or implementation ticket
+for this plan. No dedicated implementation issue/PR was found in the search below.
+
+## Objective and priority
+
+Make the validated construction paths reject graphs that silently lose nodes or
+edges, or cannot execute under the current scheduling rules. A workflow containing
+`start → a → b → a` currently emits `GraphRunSucceededEvent` after executing only
+`start`; `a` and `b` remain `UNKNOWN`. This was reproduced in the reviewed checkout
+through public `dsl.loads()`. The Python builder also accepts that cycle.
+
+Prioritize this over TD-03's snapshot consistency risk and TD-04's file adapter
+isolation work because it is a reproduced incorrect result without a concurrency
+or deployment prerequisite. TD-04 should take precedence if a deployment is about
+to run concurrent workflows with distinct host file adapters. This review has no
+production incident counts or deployment evidence.
+
+## Context and implementation boundaries
+
+Reviewed commit: `cf6c732` (the knowledge/debt review is present, with no runtime
+remediation). Preserve the [execution and state invariants](../../ARCHITECTURE.md)
+and the [factory preflight contract](../development.md#add-or-extend-a-node).
+
+| Boundary | Observed problem | Planned change |
+| --- | --- | --- |
+| [Graph normalization](../../src/graphon/graph/graph.py), `_normalize_nodes()` and `_parse_node_configs()` | Duplicate executable IDs are indexed with the last configuration winning. | Reject duplicate and invalid executable node IDs before the first ID index is built. |
+| [Edge preparation, scoping, and construction](../../src/graphon/graph/graph.py) | Non-string endpoints disappear during filtering; an explicit null `sourceHandle` disappears during `_build_edges()`. | Validate raw executable edge fields before filtering can discard them. |
+| [Default validators](../../src/graphon/graph/validation.py) and `Graph.init()` preflight | Only endpoints and root type are checked by the default rules. Descendant schemas are preflighted, but descendant execution cycles are accepted. | Share a small topology check between subtree preflight and the builder's default validator. |
+| [GraphBuilder](../../src/graphon/graph/graph.py), `_register_node()`, `add_node()`, and `connect()` | Type annotations do not prevent non-string IDs or null handles from reaching the built graph. | Enforce the same ID and handle-type rules through the existing builder/validator path before `build()` returns. |
+| [DSL importer](../../src/graphon/dsl/importer.py), `loads()` | It delegates construction to `Graph.init()`, but its `GraphValidationError` handler reads `issue.__dict__` from a slotted dataclass and raises `AttributeError`. | Use `dataclasses.asdict()` to retain the existing structured `DslError` envelope. |
+| [Frame construction](../../src/graphon/engine/frame.py), `_create_child_with_state()` | Fresh and restored child frames call `Graph.init()` using retained configuration. | Cover these callers through the shared boundary; retain frame isolation and edge identity. |
+
+[Scheduler.is_node_ready()](../../src/graphon/engine/scheduler.py) waits for every
+incoming edge to resolve. `is_execution_complete()` checks only enqueued work.
+This explains the false success: neither cycle node becomes ready. Changing join
+or completion semantics would affect valid branching and would not recover
+discarded input. Fix construction instead.
+
+## Proposed contract
+
+- After removing supported `custom-note` widgets, executable node IDs must be
+  non-empty strings and unique across the supplied configuration. Preserve typed
+  `BaseNodeData` input, editor metadata, and canonical/legacy owner normalization.
+  Normalization must leave caller-owned configuration unchanged.
+- Executable edges must have string endpoints naming existing nodes in the same
+  direct scope. If `sourceHandle` is absent, keep the current `"source"` default;
+  if supplied, require a string. Do not add handle-name membership rules or reject
+  currently accepted string handles as part of this work.
+- Each executable scope must be acyclic, including self-edges and cycles in
+  inactive branches or retained descendants. Validate the retained subtree before
+  `create_node()` or `post_init()` runs. Loop, Iteration, and custom container
+  nodes remain valid: repetition is owned by their handlers, while their internal
+  execution edges follow the same rule. Acyclic disconnected and multiple-root
+  configurations remain allowed; this is not a reachability requirement.
+- Preserve explicit edge IDs, generated-ID allocation for valid inputs, and
+  sibling scopes' ability to reuse local edge IDs. Check endpoints before cycle
+  detection so an unknown endpoint does not become an implicit topology node.
+- Use the existing `GraphValidationIssue`/`GraphValidationError` types for new
+  graph rules. Diagnostics should identify the offending node/edge and the owning
+  scope for a cycle. Preserve existing DSL normalization error codes and the
+  `graph.validation_failed` envelope for errors raised by graph validators.
+- Apply these guarantees to default `Graph.init()`, `dsl.loads()`, and
+  `Graph.new().build()`. The builder receives already constructed nodes, so its
+  guarantee is rejection at `build()`, not prevention of caller-side construction.
+  For `Graph.init(skip_validation=True)`, keep node schemas, ID/type checks,
+  ownership checks, and edge-ID checks mandatory; bypass endpoint-existence,
+  root-execution-type, and cycle checks. Root ID presence is still required to
+  construct the graph, as today. The low-level `Graph(...)`
+  constructor remains a trusted assembly surface. Document both bypasses rather
+  than adding validation to every engine run. No in-repository caller currently
+  passes `skip_validation`.
+
+## Delivery steps
+
+- [x] Review knowledge, construction callers, related tests, and current tracking.
+- [x] Reproduce the cycle, input loss, and DSL error translation problems.
+- [ ] Before implementation, repeat the issue/PR search required by
+  [Contributing](../../CONTRIBUTING.md#issues), confirm an implementation owner,
+  and coordinate scope with #131. Record the implementation issue here before
+  opening its PR; the new authoring API is not a prerequisite.
+- [ ] Add focused regressions in the existing files listed below, then implement
+  input checks before lossy normalization/scoping. Keep the existing DSL-specific
+  paths and error context. Add the matching ID/handle checks to the existing
+  builder/validator path; type annotations alone do not enforce them. A new graph
+  schema or validation framework is unnecessary.
+- [ ] Add one reusable topology check in `graph/validation.py`, using stdlib
+  `graphlib.TopologicalSorter.prepare()` and `CycleError`. Apply it to each scope
+  of the retained config before node construction and through the builder's
+  default validator. Do not construct child graphs just to validate them.
+- [ ] Repair DSL issue serialization and verify rejection through public loading.
+  Keep this with the new validation so invalid graphs reliably return `DslError`.
+- [ ] Update [Architecture](../../ARCHITECTURE.md), the relevant
+  [development guidance](../development.md), and the unreleased 0.8.0 section of
+  [MIGRATION.md](../../MIGRATION.md). Explain that previously accepted invalid
+  graphs now fail and must be corrected, with explicit containers used for
+  repetition. Record release changes in [CHANGELOG.md](../../CHANGELOG.md).
+- [ ] Run the focused checks and contributor checks, then record the PR,
+  completion evidence, and final contract here and in the debt register.
+
+Target one focused implementation PR. Expected production edits are
+`graph/graph.py`, `graph/validation.py`, and `dsl/importer.py`; engine changes,
+new dependencies, snapshot formats, and #131's authoring API are outside scope.
+
+## Acceptance checks
+
+Extend existing test helpers; use a small parameterized set of invalid inputs,
+not a new test framework.
+
+| Check | Evidence to add or preserve |
+| --- | --- |
+| Duplicate IDs cannot overwrite nodes, including IDs reused across scopes; malformed endpoints and null/non-string handles cannot drop edges. | [Graph validation tests](../../tests/graph/test_graph_validation.py) and [DSL importer tests](../../tests/dsl/test_importer.py). Retain DSL duplicate-ID errors and builder duplicate-node rejection. Add a focused [builder regression](../../tests/graph/test_graph.py) for non-string IDs and invalid handles supplied through both `add_node()` and `connect()`. |
+| Direct construction, DSL loading, and the builder reject self-cycles and `start → a → b → a`. | [Graph validation](../../tests/graph/test_graph_validation.py), [builder](../../tests/graph/test_graph.py), and [workflow event tests](../../tests/workflows/test_full_engine_events.py). The public loading regression must fail before execution can report success. |
+| A cycle or malformed edge in a nested/inactive descendant is rejected before any node is created. | Reuse the recording factory in [scoping tests](../../tests/graph/test_graph_scoping.py) and the `create_node` spy in [DSL factory tests](../../tests/dsl/test_node_factory.py); assert no construction. |
+| Valid branches, joins, multiple roots, containers, metadata, legacy ownership, omitted handles, and edge IDs retain behavior. | Existing [graph tests](../../tests/graph/), [workflow events](../../tests/workflows/test_full_engine_events.py), and [cooperative container tests](../../tests/engine/test_cooperative_container_execution.py), with small compatibility cases only where missing. |
+| Validation returns structured errors rather than `AttributeError`; bypass behavior is explicit. | In [DSL importer tests](../../tests/dsl/test_importer.py), inspect `DslError.code` and `details["issues"]`. In graph tests, check the chosen `skip_validation` behavior without executing the deliberately invalid graph. |
+| Valid restored child graphs keep their queued work and identities. | Preserve [engine serialization](../../tests/engine/test_runtime_state_serialization.py), [runtime tests](../../tests/runtime/test_runtime_state.py), and [snapshot version isolation](../../tests/test_snapshot_version_isolation.py); do not regenerate historical fixtures. |
+
+## Decision log
+
+- **2026-09-08 — Proposed:** choose TD-02 first based on reproduced incorrect
+  success and input loss. Keep TD-03/TD-04 separate unless deployment evidence
+  changes their urgency.
+- **2026-09-08 — Proposed:** reject execution cycles using a stdlib check at
+  construction, sharing the implementation across config and builder paths.
+  Explicit container handlers already provide repetition; scheduler changes and
+  a generic graph-analysis framework would expand the task unnecessarily.
+- **2026-09-08 — Proposed compatibility:** retain trusted bypasses, reject cycles
+  even in inactive scopes, and document stricter default validation for 0.8.0.
+  Maintainer review must confirm these public-contract choices and the release
+  target before implementation is treated as accepted policy.
+
+## Validation and outcome
+
+On 2026-09-08, Python 3.12.13, the following baseline passed: **93 tests**.
+
+```bash
+uv run pytest -n 0 \
+  tests/test_repository_docs.py \
+  tests/graph/test_graph.py \
+  tests/graph/test_graph_validation.py \
+  tests/graph/test_graph_scoping.py \
+  tests/dsl/test_importer.py \
+  tests/dsl/test_node_factory.py
+```
+
+Additional local probes confirmed duplicate-ID collapse, edge loss for null
+handles and non-string endpoints, builder cycle acceptance, and successful root
+construction despite a descendant cycle. The
+[public cycle reproduction](../technical-debt.md#validation-record) still produced
+`GraphRunSucceededEvent`, `['start']`, and unknown states for `a`/`b`. Selecting
+the template node as the DSL root reproduced the slotted-issue `AttributeError`.
+Builder probes also accepted an integer node ID and a null source handle.
+These are baseline defects, not passing acceptance checks for a fix.
+
+The documentation link/reachability check passed after adding this plan and its
+index links. Runtime implementation remains unchanged.
+
+After implementation, rerun the baseline plus the workflow, container, and
+snapshot checks linked above, then follow `just test` and `just check` in
+[Contributing](../../CONTRIBUTING.md#testing-and-validation). Full-suite and
+Python 3.13 validation have not been run for this planning change.
+
+Tracking was checked read-only on 2026-09-08: all 10 open issues and 14 open PRs,
+plus open/closed title/body searches for graph validation, cycle, duplicate,
+`sourceHandle`, duplicate node, acyclic, cycles, TD-02, and references to #131.
+[PR #3](https://github.com/langgenius/graphon/pull/3) already added builder
+validation but no cycle rule. [PR #276](https://github.com/langgenius/graphon/pull/276)
+merged the debt review only. #131 remains open; no dedicated fix was found in
+these targeted searches. [PR #271](https://github.com/langgenius/graphon/pull/271)
+and [PR #200](https://github.com/langgenius/graphon/pull/200) remain open work on
+filter performance and decision records, respectively, and do not supersede this
+plan. Repeat the search when implementation begins; no tracking records were
+created or changed during planning.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -2,8 +2,9 @@
 
 **Reviewed:** 2026-09-08, Graphon 0.7.0, commit
 `9d13c716d527a8b7099df00cc448254ac7b6e98b`.
-**Status:** review complete; the remediation below is proposed, not implemented
-or accepted architecture policy. Priorities express this review's judgment.
+**Status:** original review complete; TD-02 implementation and reviews are complete
+locally. Other remediation remains proposed, not accepted architecture
+policy. Priorities express the original review's judgment.
 **Scope:** repository structure, execution and integration boundaries, developer
 feedback, and knowledge maintenance. Evidence includes source, callers, test
 definitions, focused tests, and small local reproductions. This is not a
@@ -100,7 +101,7 @@ queue dependency and facade side effects below have concrete isolation costs.
   from construction. [Factory tests](../tests/dsl/test_node_factory.py) protect
   validation before adapter initialization. Canonical ownership and explicit
   legacy translation in [scoping](../src/graphon/graph/scoping.py) are useful
-  protections; TD-02 covers the remaining structural gaps.
+  protections; TD-02 addresses the structural gaps found in the original review.
 - **Ports mostly follow actual consumers.** HTTP nodes capture their injected
   client, code nodes accept an executor, and provider wrappers require only
   their capability contracts. [Model dispatch tests](../tests/model_runtime/test_model_dispatch.py)
@@ -127,8 +128,9 @@ queue dependency and facade side effects below have concrete isolation costs.
 
 ## Debt register
 
-All entries are **proposed**. P1 means a reproduced correctness problem or a
-boundary that must be addressed before the stated deployment use. P2 is targeted
+TD-02 is **implemented locally**; other entries remain **proposed**. P1 means a
+reproduced correctness problem or a boundary that must be addressed before the
+stated deployment use. P2 is targeted
 architecture or feedback work. P3 can follow the more consequential changes.
 Suggested owners are responsibility areas, not assigned people; effort is a
 relative change size, not a delivery estimate.
@@ -136,7 +138,7 @@ relative change size, not a delivery estimate.
 | ID | Section | Priority | Suggested owner | Size |
 | --- | --- | --- | --- | --- |
 | TD-01 | Dependency direction and runtime queue ownership | P2 | Engine/runtime | Medium |
-| TD-02 | Graph construction and structural validation | P1 | Graph/DSL | Medium |
+| TD-02 | [Graph construction and structural validation](#td-02--graph-construction-and-structural-validation), implemented locally | P1 | Graph/DSL | Medium |
 | TD-03 | Snapshot consistency at the public boundary | P2 | Runtime/engine | Medium |
 | TD-04 | Execution-scoped file integration | P2; P1 before concurrent distinct host adapters | File/host integration | Medium–large |
 | TD-05 | Side effects of importing public contracts | P2 | Public API/node bootstrap | Small–medium |
@@ -179,53 +181,37 @@ and retain [runtime coverage](../tests/runtime/test_runtime_state.py).
 
 ## TD-02 — Graph construction and structural validation
 
-**Planning update (2026-09-08):** recommended as the next implementation priority.
-The [graph validation plan](plans/graph-validation.md) records verified failures,
-scope, compatibility proposals, acceptance checks, and current tracking. An
-implementation owner is not yet assigned; remediation remains proposed.
+**Implementation update (2026-09-08):** implemented locally by the current
+Graph/DSL development task on `laipz8200/graph-validation`; independent reviews and
+checks are complete. The [graph validation plan](plans/graph-validation.md) records decisions,
+checks, and tracking. [Implementation issue #277](https://github.com/langgenius/graphon/issues/277)
+tracks this fix and its pull request;
+[issue #131](https://github.com/langgenius/graphon/issues/131) remains related
+authoring work.
 
-**Working well:** DSL normalization rejects duplicate IDs and invalid edge
-endpoints; `GraphBuilder` rejects duplicate nodes. Scoped ownership and descendant
-schema validation are already covered. Keep intentionally supported editor
-metadata and legacy container forms.
+**Original evidence:** direct `Graph.init()` silently overwrote duplicate node IDs
+and discarded malformed edges. Default validators accepted execution cycles, so
+`start → a → b → a` could emit `GraphRunSucceededEvent` after only `start` ran,
+leaving `a` and `b` `UNKNOWN`. Public `dsl.loads()` reproduced that false success.
+The DSL normalizer already rejected some invalid inputs, but these checks did
+not establish a shared construction boundary.
 
-**Evidence and consequence:** protections differ between entry points.
-[Graph._normalize_nodes and _parse_node_configs](../src/graphon/graph/graph.py)
-index node IDs without rejecting duplicates. `_build_edges()` drops edges with
-non-string endpoints or source handles. The
-[DSL normalizer](../src/graphon/dsl/importer.py) catches duplicate node IDs and bad
-endpoints, but does not establish a complete shared graph contract.
-[Default structural validators](../src/graphon/graph/validation.py) cover endpoints
-and root type, not execution cycles. [Scheduler](../src/graphon/engine/scheduler.py)
-waits for incoming edges to resolve but declares completion when no enqueued
-work remains.
+**Current result:** [graph construction](../src/graphon/graph/graph.py) rejects
+invalid/duplicate IDs and malformed edges before indexing or filtering.
+[Shared validation](../src/graphon/graph/validation.py) checks endpoints and cycles
+throughout the retained subtree before node construction and through the Python
+builder. [DSL loading](../src/graphon/dsl/importer.py) preserves structured
+validation issues. Scheduler behavior is unchanged. Supported ownership forms,
+resolved factory root types, edge identities, and trusted bypasses are retained;
+see the [migration guidance](../MIGRATION.md#graph-validation).
 
-Local probes established three behaviors: direct `Graph.init()` accepts a
-duplicate ID with the last configuration winning; an explicitly null
-`sourceHandle` can disappear from the executable graph; and
-`start → a → b → a` can emit `GraphRunSucceededEvent` after only `start` executes,
-leaving `a` and `b` `UNKNOWN`. The cycle was also reproduced through public
-`dsl.loads()`. These are narrower claims than saying all DSL validation is
-missing.
-
-**Proposed change:** establish the shared graph invariants before lossy indexing
-or filtering. Reject duplicate IDs and malformed executable edges, preserving
-documented normalization such as a missing source handle default. Reject
-unsupported cycles within each executable scope; stdlib
-`graphlib.TopologicalSorter` is sufficient if the intended contract is acyclic
-scopes with explicit Loop/Iteration containers. Check the same structural rule
-through the builder. Validate descendants before constructor side effects where
-possible. Do not change join semantics to make unsupported cycles appear to run.
-
-**Done when:** focused regressions cover all three cases through the applicable
-construction APIs, one engine regression rules out false success, and existing
-multi-root, branch, nested-container, and preflight cases remain valid. Extend
-[graph validation](../tests/graph/test_graph_validation.py),
-[scoping](../tests/graph/test_graph_scoping.py), and
-[workflow tests](../tests/workflows/test_full_engine_events.py). Stricter rejection
-changes accepted input behavior and needs migration notes. Coordinate with open
-[graph authoring issue #131](https://github.com/langgenius/graphon/issues/131)
-before implementation, without making a new authoring API a prerequisite.
+**Evidence of remediation:** [scoping tests](../tests/graph/test_graph_scoping.py),
+[builder tests](../tests/graph/test_graph.py), and
+[public loading tests](../tests/dsl/test_importer.py) cover the defects and valid
+controls. The focused graph/DSL command passes 136 tests; `just test` passes 815,
+and `just check` passes on Python 3.12.13. The plan records the initial failures,
+full-suite caveat, and remaining validation limits. This is local implementation
+evidence, not a merged fix or a release claim.
 
 ## TD-03 — Snapshot consistency at the public boundary
 
@@ -465,8 +451,9 @@ generator are not prerequisites. No recurring automation was configured here.
 
 ## Suggested order and limits
 
-1. Fix TD-02 first: it has a reproduced false-success outcome and can be corrected
-   within existing graph boundaries.
+1. TD-02 was selected first for its reproduced false-success outcome. Its local
+   implementation and completed reviews are tracked in the
+   [graph validation plan](plans/graph-validation.md).
 2. Define TD-03's snapshot eligibility and TD-04's file adapter scope before
    promising live checkpoints or concurrent distinct host integrations. TD-04
    may be staged if all deployed hosts use one process-wide adapter.
@@ -504,37 +491,8 @@ uv run pytest -n 0 \
 ```
 
 Additional ephemeral probes established the graph, file runtime, and import
-behaviors described in TD-01, TD-02, TD-04, and TD-05. For example, this public-API
-reproduction on the reviewed commit produces success after only the start node:
-
-```bash
-uv run python - <<'PY'
-import json
-from graphon.dsl import loads
-from graphon.engine_events import NodeRunSucceededEvent
-
-nodes = [{"id": "start", "data": {"type": "start", "variables": []}}]
-nodes += [
-    {"id": name, "data": {
-        "type": "template-transform", "variables": [], "template": "ok"
-    }}
-    for name in ("a", "b")
-]
-edges = [
-    {"source": source, "target": target}
-    for source, target in (("start", "a"), ("a", "b"), ("b", "a"))
-]
-engine = loads(json.dumps({
-    "kind": "graph", "dependencies": [], "graph": {"nodes": nodes, "edges": edges}
-}))
-events = list(engine.run())
-print(type(events[-1]).__name__)
-print([event.node_id for event in events if isinstance(event, NodeRunSucceededEvent)])
-print({name: node.state.value for name, node in engine.graph.nodes.items()})
-PY
-```
-
-Observed output:
+behaviors described in TD-01, TD-02, TD-04, and TD-05 on the original reviewed
+commit. The public cycle probe returned:
 
 ```text
 GraphRunSucceededEvent
@@ -542,8 +500,13 @@ GraphRunSucceededEvent
 {'start': 'taken', 'a': 'unknown', 'b': 'unknown'}
 ```
 
-Passing existing tests does not refute gaps those tests do not cover. The full
-suite, Python 3.13 matrix, benchmarks, and live external integrations were not
-run for this documentation review. After writing the report, the documentation
-check passed again and the embedded reproduction was executed verbatim with the
-output above. No runtime behavior was changed.
+That result is historical evidence. The permanent
+[DSL loading regression](../tests/dsl/test_importer.py) now requires the same
+cycle to fail during loading and its acyclic control to execute every node.
+See the [TD-02 plan](plans/graph-validation.md#validation-and-outcome) for current
+implementation checks.
+
+The original documentation review did not run the full suite, Python 3.13 matrix,
+benchmarks, or live external integrations, and changed no runtime behavior.
+Its documentation check passed after the report was written. Other debt entries
+retain that original review scope and evidence.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -179,6 +179,11 @@ and retain [runtime coverage](../tests/runtime/test_runtime_state.py).
 
 ## TD-02 — Graph construction and structural validation
 
+**Planning update (2026-09-08):** recommended as the next implementation priority.
+The [graph validation plan](plans/graph-validation.md) records verified failures,
+scope, compatibility proposals, acceptance checks, and current tracking. An
+implementation owner is not yet assigned; remediation remains proposed.
+
 **Working well:** DSL normalization rejects duplicate IDs and invalid edge
 endpoints; `GraphBuilder` rejects duplicate nodes. Scoped ownership and descendant
 schema validation are already covered. Keep intentionally supported editor

--- a/src/graphon/dsl/importer.py
+++ b/src/graphon/dsl/importer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from dataclasses import asdict
 from enum import StrEnum, auto
 from typing import Any, cast
 from uuid import uuid4
@@ -161,7 +162,7 @@ def loads(
             str(error),
             code="graph.validation_failed",
             kind=plan.document.kind,
-            details={"issues": [issue.__dict__ for issue in error.issues]},
+            details={"issues": [asdict(issue) for issue in error.issues]},
         ) from error
     except Exception as error:
         raise _dsl_error(

--- a/src/graphon/graph/graph.py
+++ b/src/graphon/graph/graph.py
@@ -15,7 +15,12 @@ from graphon.nodes.base.node import Node
 
 from .edge import Edge
 from .scoping import resolve_container_id
-from .validation import get_graph_validator
+from .validation import (
+    GraphValidationError,
+    GraphValidationIssue,
+    get_edge_issues,
+    get_graph_validator,
+)
 
 if TYPE_CHECKING:
     from graphon.runtime.runtime_state import RuntimeState
@@ -195,11 +200,8 @@ class Graph:
         out_edges: dict[str, list[str]] = defaultdict(list)
 
         for edge_config in edge_configs:
-            source = edge_config.get("source")
-            target = edge_config.get("target")
-
-            if not isinstance(source, str) or not isinstance(target, str):
-                continue
+            source = edge_config["source"]
+            target = edge_config["target"]
 
             edge_id = edge_config["id"]
             if edge_id in edge_ids:
@@ -208,8 +210,6 @@ class Graph:
             edge_ids.add(edge_id)
 
             source_handle = edge_config.get("sourceHandle", "source")
-            if not isinstance(source_handle, str):
-                continue
 
             edge = Edge(
                 id=edge_id,
@@ -229,24 +229,20 @@ class Graph:
         graph_config: Mapping[str, Any],
         container_ids: Mapping[str, str],
     ) -> list[dict[str, Any]]:
-        """Copy edge configs and ensure every valid edge has a public DSL ID.
+        """Validate edge fields and copy configs with public DSL IDs.
 
-        An edge is valid for legacy numbering when both ``source`` and
-        ``target`` are strings. Missing IDs start with the historical
-        ``edge_N`` ordinal, including edges later ignored because another field
-        is invalid, and advance only when that ID was supplied or generated
-        elsewhere. Supplied IDs are reserved within their owning graph before
+        Missing IDs start with the historical ``edge_N`` ordinal and advance
+        past IDs supplied or generated elsewhere in the same scope.
+        Supplied IDs are reserved within their owning graph before
         generation, making mixed explicit and fallback IDs independent of
         config order without preventing separate graphs from reusing a local
         ID. The generated public ID is retained in scoped graph configs, so
         child graphs use the same ID when they are materialized later. Supplied
         IDs must be non-empty strings.
 
-        Duplicate IDs are deliberately not checked here because this method
-        sees a container subtree, not one materialized graph. ``_build_edges``
-        enforces uniqueness after scoping, allowing separate child graphs to
-        reuse the same local edge ID. Each edge dictionary is copied before an
-        ID is added, so the caller's config is never mutated.
+        Duplicate IDs are rejected within their owning scope, allowing separate
+        child graphs to reuse the same local edge ID. Each dictionary is copied
+        before an ID is added, so the caller's config is never mutated.
 
         Args:
             graph_config: Complete or previously scoped workflow graph config.
@@ -256,6 +252,7 @@ class Graph:
             Copied edge dictionaries carrying public DSL edge IDs.
 
         Raises:
+            GraphValidationError: If edge fields or scoped edge IDs are invalid.
             ValueError: If a supplied edge ID is not a non-empty string.
 
         """
@@ -267,15 +264,26 @@ class Graph:
         ]
         edge_container_ids: list[str | None] = []
         reserved_edge_ids: defaultdict[str | None, set[str]] = defaultdict(set)
-        for edge_config in edge_configs:
+        for edge_index, edge_config in enumerate(edge_configs):
             source = edge_config.get("source")
             target = edge_config.get("target")
-            source_container_id = (
-                container_ids.get(source) if isinstance(source, str) else None
-            )
-            target_container_id = (
-                container_ids.get(target) if isinstance(target, str) else None
-            )
+            for field, value in (
+                ("source", source),
+                ("target", target),
+                ("sourceHandle", edge_config.get("sourceHandle", "source")),
+            ):
+                if not isinstance(value, str):
+                    raise GraphValidationError([
+                        GraphValidationIssue(
+                            code="INVALID_EDGE",
+                            message=(
+                                f"Graph edge at index {edge_index}: "
+                                f"{field} must be a string."
+                            ),
+                        )
+                    ])
+            source_container_id = container_ids.get(source)
+            target_container_id = container_ids.get(target)
             edge_container_id = (
                 source_container_id
                 if source_container_id is not None
@@ -285,32 +293,37 @@ class Graph:
             edge_container_ids.append(edge_container_id)
             edge_id = edge_config.get("id")
             if isinstance(edge_id, str) and edge_id:
+                if (
+                    edge_container_id is not None
+                    and edge_id in reserved_edge_ids[edge_container_id]
+                ):
+                    raise GraphValidationError([
+                        GraphValidationIssue(
+                            code="DUPLICATE_EDGE_ID",
+                            message=(
+                                f"Duplicate graph edge ID: {edge_id} "
+                                f"in scope {edge_container_id!r}"
+                            ),
+                        )
+                    ])
                 reserved_edge_ids[edge_container_id].add(edge_id)
 
-        edge_counter = 0
-        for edge_config, edge_container_id in zip(
-            edge_configs,
-            edge_container_ids,
-            strict=True,
+        for edge_index, (edge_config, edge_container_id) in enumerate(
+            zip(edge_configs, edge_container_ids, strict=True),
         ):
             if "id" in edge_config and (
                 not isinstance(edge_config["id"], str) or not edge_config["id"]
             ):
                 msg = "Graph edge ID must be a non-empty string"
                 raise ValueError(msg)
-            source = edge_config.get("source")
-            target = edge_config.get("target")
-            if not isinstance(source, str) or not isinstance(target, str):
-                continue
             if "id" not in edge_config:
-                fallback_index = edge_counter
+                fallback_index = edge_index
                 edge_id = f"edge_{fallback_index}"
                 while edge_id in reserved_edge_ids[edge_container_id]:
                     fallback_index += 1
                     edge_id = f"edge_{fallback_index}"
                 edge_config["id"] = edge_id
                 reserved_edge_ids[edge_container_id].add(edge_id)
-            edge_counter += 1
         return edge_configs
 
     @classmethod
@@ -370,25 +383,42 @@ class Graph:
             Copied node configurations with canonical container IDs, followed by
             the same IDs indexed by node ID. ``""`` identifies the root graph.
 
+        Raises:
+            GraphValidationError: If node IDs are invalid or duplicated.
+
         """
         normalized_nodes = [
             dict(node_config)
             for node_config in node_configs
             if node_config.get("type", "") != "custom-note"
         ]
-        nodes_by_id = {
-            node_id: node_config
-            for node_config in normalized_nodes
-            if isinstance((node_id := node_config.get("id")), str)
-        }
+        nodes_by_id: dict[str, dict[str, Any]] = {}
+        for node_config in normalized_nodes:
+            node_id = node_config.get("id")
+            if not isinstance(node_id, str) or not node_id:
+                raise GraphValidationError([
+                    GraphValidationIssue(
+                        code="INVALID_NODE_ID",
+                        message=(
+                            f"Graph node ID must be a non-empty string: {node_id!r}"
+                        ),
+                    )
+                ])
+            if node_id in nodes_by_id:
+                raise GraphValidationError([
+                    GraphValidationIssue(
+                        code="DUPLICATE_NODE_ID",
+                        message=f"Duplicate graph node ID: {node_id}",
+                        node_id=node_id,
+                    )
+                ])
+            nodes_by_id[node_id] = node_config
         container_ids = {
             node_id: resolve_container_id(node_config, nodes_by_id=nodes_by_id)
             for node_id, node_config in nodes_by_id.items()
         }
         for node_config in normalized_nodes:
-            node_id = node_config.get("id")
-            if not isinstance(node_id, str):
-                continue
+            node_id = node_config["id"]
             data = node_config.get("data")
             if isinstance(data, BaseNodeData):
                 normalized_data = data.model_dump(mode="python", exclude_unset=True)
@@ -452,10 +482,8 @@ class Graph:
         direct_edge_configs: list[dict[str, Any]] = []
         subtree_edge_configs: list[dict[str, Any]] = []
         for edge_config in edge_configs:
-            source = edge_config.get("source")
-            target = edge_config.get("target")
-            if not isinstance(source, str) or not isinstance(target, str):
-                continue
+            source = edge_config["source"]
+            target = edge_config["target"]
 
             if (
                 source in container_ids
@@ -552,7 +580,6 @@ class Graph:
         :param active_root_id: ID of the active root node
         """
         # Find all top-level root nodes
-        # (nodes with ROOT execution type and no incoming edges)
         top_level_roots: list[str] = [
             node.id
             for node in nodes.values()
@@ -572,11 +599,15 @@ class Graph:
             if root_id in nodes:
                 nodes[root_id].state = NodeState.SKIPPED
 
+        # Unchecked graphs can contain cycles or missing targets.
+        visited_node_ids: set[str] = set()
+
         # Recursively mark downstream nodes and edges
         def mark_downstream(node_id: str) -> None:
             """Recursively mark downstream nodes and edges as skipped."""
-            if nodes[node_id].state != NodeState.SKIPPED:
+            if node_id in visited_node_ids or nodes[node_id].state != NodeState.SKIPPED:
                 return
+            visited_node_ids.add(node_id)
             # If this node is skipped, mark all its outgoing edges as skipped
             out_edge_ids = out_edges.get(node_id, [])
             for edge_id in out_edge_ids:
@@ -584,7 +615,9 @@ class Graph:
                 edge.state = NodeState.SKIPPED
 
                 # Check the target node of this edge
-                target_node = nodes[edge.head]
+                target_node = nodes.get(edge.head)
+                if target_node is None:
+                    continue
                 in_edge_ids = in_edges.get(target_node.id, [])
                 in_edge_states = [edges[eid].state for eid in in_edge_ids]
 
@@ -597,6 +630,30 @@ class Graph:
         # Process each inactive root and its downstream nodes
         for root_id in inactive_roots:
             mark_downstream(root_id)
+
+    @staticmethod
+    def _validate_subtree_edges(
+        graph_config: Mapping[str, Any],
+        container_ids: Mapping[str, str],
+    ) -> None:
+        """Validate retained subtree edges before any node is constructed."""
+        issues = get_edge_issues(
+            {
+                node_config["id"]: container_ids[node_config["id"]]
+                for node_config in graph_config["nodes"]
+            },
+            (
+                Edge(
+                    id=edge_config["id"],
+                    tail=edge_config["source"],
+                    head=edge_config["target"],
+                    source_handle=edge_config.get("sourceHandle", "source"),
+                )
+                for edge_config in graph_config["edges"]
+            ),
+        )
+        if issues:
+            raise GraphValidationError(issues)
 
     @classmethod
     def init(
@@ -614,6 +671,8 @@ class Graph:
         :param node_factory: factory for creating node instances from config data
         :param root_node_id: active root node id
         :param container_id: direct container scope to materialize; empty for root
+        :param skip_validation: bypass endpoint existence, root type, and cycle
+            checks; input fields, IDs, schemas, and ownership are still validated
 
         Returns:
             Initialized graph instance rooted at `root_node_id`.
@@ -674,6 +733,12 @@ class Graph:
         if root_node_id not in node_configs_map:
             msg = f"Root node id {root_node_id} not found in the graph"
             raise ValueError(msg)
+
+        if not skip_validation:
+            cls._validate_subtree_edges(
+                scoped_graph_config,
+                container_ids,
+            )
 
         # Build edges
         edges, in_edges, out_edges = cls._build_edges(direct_edge_configs)
@@ -845,8 +910,8 @@ class GraphBuilder:
         return graph
 
     def _register_node(self, node: Node) -> None:
-        if not node.id:
-            msg = "Node must have a non-empty id"
+        if not isinstance(node.id, str) or not node.id:
+            msg = "Node must have a non-empty string id"
             raise ValueError(msg)
         if node.id in self._nodes_by_id:
             msg = f"Duplicate node id detected: {node.id}"

--- a/src/graphon/graph/validation.py
+++ b/src/graphon/graph/validation.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from graphlib import CycleError, TopologicalSorter
 from typing import TYPE_CHECKING, Protocol
 
 from graphon.enums import BuiltinNodeTypes, NodeExecutionType, NodeType
 
 if TYPE_CHECKING:
+    from .edge import Edge
     from .graph import Graph
 
 
@@ -41,38 +43,71 @@ class GraphValidationRule(Protocol):
         ...
 
 
-@dataclass(frozen=True, slots=True)
-class _EdgeEndpointValidator:
-    """Ensures all edges reference existing nodes."""
+def get_edge_issues(
+    node_scopes: Mapping[str, str],
+    edges: Iterable[Edge],
+) -> list[GraphValidationIssue]:
+    """Check edge fields, endpoints, and cycles without constructing nodes.
 
-    missing_node_code: str = "MISSING_NODE"
+    Cross-scope edges are rejected during scoping, so one topological check
+    covers all disconnected scopes in a retained subtree.
 
+    Args:
+        node_scopes: Node IDs mapped to their direct container IDs.
+        edges: Edges from the scopes being validated.
+
+    Returns:
+        Issues for invalid edges or a cycle; empty for a valid graph.
+    """
+    issues: list[GraphValidationIssue] = []
+    predecessors: dict[str, list[str]] = {node_id: [] for node_id in node_scopes}
+    for edge in edges:
+        if not isinstance(edge.source_handle, str):
+            issues.append(
+                GraphValidationIssue(
+                    code="INVALID_EDGE",
+                    message=f"Edge {edge.id!r} sourceHandle must be a string.",
+                    node_id=edge.tail,
+                )
+            )
+        for field, node_id in (("source", edge.tail), ("target", edge.head)):
+            if node_id not in node_scopes:
+                issues.append(
+                    GraphValidationIssue(
+                        code="MISSING_NODE",
+                        message=(
+                            f"Edge {edge.id} references unknown {field} node "
+                            f"'{node_id}'."
+                        ),
+                        node_id=node_id,
+                    ),
+                )
+        if edge.tail in node_scopes and edge.head in node_scopes:
+            predecessors[edge.head].append(edge.tail)
+    if not issues:
+        try:
+            TopologicalSorter(predecessors).prepare()
+        except CycleError as error:
+            cycle_node_ids: list[str] = error.args[1]
+            issues.append(
+                GraphValidationIssue(
+                    code="CYCLE",
+                    message=(
+                        f"Graph scope {node_scopes[cycle_node_ids[0]]!r} "
+                        f"contains a cycle: {' -> '.join(cycle_node_ids)}"
+                    ),
+                    node_id=cycle_node_ids[0],
+                )
+            )
+    return issues
+
+
+class _EdgeValidator:
     def validate(self, graph: Graph) -> Sequence[GraphValidationIssue]:
-        issues: list[GraphValidationIssue] = []
-        for edge in graph.edges.values():
-            if edge.tail not in graph.nodes:
-                issues.append(
-                    GraphValidationIssue(
-                        code=self.missing_node_code,
-                        message=(
-                            f"Edge {edge.id} references unknown source node "
-                            f"'{edge.tail}'."
-                        ),
-                        node_id=edge.tail,
-                    ),
-                )
-            if edge.head not in graph.nodes:
-                issues.append(
-                    GraphValidationIssue(
-                        code=self.missing_node_code,
-                        message=(
-                            f"Edge {edge.id} references unknown target node "
-                            f"'{edge.head}'."
-                        ),
-                        node_id=edge.head,
-                    ),
-                )
-        return issues
+        return get_edge_issues(
+            dict.fromkeys(graph.nodes, ""),
+            graph.edges.values(),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,7 +170,7 @@ class GraphValidator:
 
 
 _DEFAULT_RULES: tuple[GraphValidationRule, ...] = (
-    _EdgeEndpointValidator(),
+    _EdgeValidator(),
     _RootNodeValidator(),
 )
 

--- a/tests/dsl/test_importer.py
+++ b/tests/dsl/test_importer.py
@@ -6,8 +6,11 @@ import pytest
 import yaml
 
 from graphon.dsl import inspect as inspect_dsl
+from graphon.dsl import loads
 from graphon.dsl.entities import LoadStatus
 from graphon.dsl.errors import DslError
+from graphon.engine_events.graph import GraphRunSucceededEvent
+from graphon.engine_events.node import NodeRunSucceededEvent
 
 _OPENAI_PLUGIN_ID = "langgenius/openai:0.3.8@test"
 
@@ -127,6 +130,89 @@ def _parameter_extractor_data() -> dict[str, Any]:
         "instruction": "Extract the requested location.",
         "reasoning_mode": "prompt",
     }
+
+
+@pytest.mark.parametrize("has_cycle", [False, True])
+def test_graph_loading_rejects_cycles_and_runs_dags(has_cycle: bool) -> None:
+    edges = [
+        {"source": "start", "target": "a"},
+        {"source": "a", "target": "b"},
+    ]
+    if has_cycle:
+        edges.append({"source": "b", "target": "a"})
+    dsl = _graph_dsl_for_nodes(
+        nodes=[
+            {
+                "id": node_id,
+                "data": {
+                    "type": "template-transform",
+                    "variables": [],
+                    "template": node_id,
+                },
+            }
+            for node_id in ("a", "b")
+        ],
+        edges=edges,
+    )
+
+    if has_cycle:
+        with pytest.raises(DslError) as exc_info:
+            loads(dsl)
+
+        assert exc_info.value.code == "graph.validation_failed"
+        issues = exc_info.value.details["issues"]
+        assert any(issue["node_id"] in {"a", "b"} for issue in issues)
+        assert all(issue["code"] and issue["message"] for issue in issues)
+    else:
+        events = list(loads(dsl).run())
+
+        assert isinstance(events[-1], GraphRunSucceededEvent)
+        assert {
+            event.node_id
+            for event in events
+            if isinstance(event, NodeRunSucceededEvent)
+        } == {"start", "a", "b"}
+
+
+@pytest.mark.parametrize("source_handle", [None, 1])
+def test_graph_loading_rejects_non_string_handles(source_handle: object) -> None:
+    dsl = _graph_dsl_for_nodes(
+        nodes=[
+            {
+                "id": "node",
+                "data": {
+                    "type": "template-transform",
+                    "variables": [],
+                    "template": "hello",
+                },
+            },
+        ],
+        edges=[
+            {"source": "start", "target": "node", "sourceHandle": source_handle},
+        ],
+    )
+
+    with pytest.raises(DslError):
+        loads(dsl)
+
+
+def test_graph_loading_reports_invalid_root_as_structured_error() -> None:
+    dsl = _graph_dsl_for_node({
+        "type": "template-transform",
+        "variables": [],
+        "template": "hello",
+    })
+
+    with pytest.raises(DslError) as exc_info:
+        loads(dsl, root_node_id="node")
+
+    assert exc_info.value.code == "graph.validation_failed"
+    assert any(
+        issue["code"] == "INVALID_ROOT"
+        and issue["node_id"] == "node"
+        and issue["message"]
+        for issue in exc_info.value.details["issues"]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/graph/test_graph.py
+++ b/tests/graph/test_graph.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
@@ -30,6 +31,75 @@ class TestGraphBuilder:
             Graph.new().add_root(root).build()
 
         assert any(issue.code == "INVALID_ROOT" for issue in exc.value.issues)
+
+    @pytest.mark.parametrize("head", ["a", "b"])
+    def test_build_rejects_cycles(self, head: str) -> None:
+        builder = (
+            Graph
+            .new()
+            .add_root(create_mock_node("start", NodeExecutionType.ROOT))
+            .add_node(create_mock_node("a", NodeExecutionType.EXECUTABLE))
+            .add_node(create_mock_node("b", NodeExecutionType.EXECUTABLE))
+            .connect(tail="b", head=head)
+        )
+
+        with pytest.raises(GraphValidationError):
+            builder.build()
+
+    @pytest.mark.parametrize("node_id", ["", None, 1])
+    def test_build_rejects_invalid_node_ids(self, node_id: object) -> None:
+        builder = Graph.new().add_root(
+            create_mock_node("start", NodeExecutionType.ROOT),
+        )
+
+        with pytest.raises(ValueError, match=r"(?i)node.*id"):
+            builder.add_node(
+                create_mock_node(cast(str, node_id), NodeExecutionType.EXECUTABLE),
+            ).build()
+
+    @pytest.mark.parametrize("source_handle", [None, 1])
+    @pytest.mark.parametrize("builder_method", ["add_node", "connect"])
+    def test_build_rejects_non_string_handles(
+        self,
+        source_handle: object,
+        builder_method: str,
+    ) -> None:
+        builder = Graph.new().add_root(
+            create_mock_node("start", NodeExecutionType.ROOT),
+        )
+        node = create_mock_node("a", NodeExecutionType.EXECUTABLE)
+
+        if builder_method == "add_node":
+            with pytest.raises(GraphValidationError):
+                builder.add_node(
+                    node,
+                    source_handle=cast(str, source_handle),
+                ).build()
+        else:
+            with pytest.raises(GraphValidationError):
+                builder.add_node(node).connect(
+                    tail="start",
+                    head="a",
+                    source_handle=cast(str, source_handle),
+                ).build()
+
+    def test_build_accepts_a_dag(self) -> None:
+        graph = (
+            Graph
+            .new()
+            .add_root(create_mock_node("start", NodeExecutionType.ROOT))
+            .add_node(create_mock_node("a", NodeExecutionType.EXECUTABLE))
+            .add_node(create_mock_node("b", NodeExecutionType.EXECUTABLE))
+            .connect(tail="start", head="b")
+            .build()
+        )
+
+        assert set(graph.nodes) == {"start", "a", "b"}
+        assert {(edge.tail, edge.head) for edge in graph.edges.values()} == {
+            ("start", "a"),
+            ("a", "b"),
+            ("start", "b"),
+        }
 
 
 class TestMarkInactiveRootBranches:

--- a/tests/graph/test_graph_scoping.py
+++ b/tests/graph/test_graph_scoping.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import Any, cast
 from unittest.mock import Mock
@@ -10,10 +11,13 @@ import pytest
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.entities.graph_config import NodeConfigDict, NodeConfigDictAdapter
 from graphon.enums import NodeExecutionType, NodeState
+from graphon.graph.edge import Edge
 from graphon.graph.graph import Graph
 from graphon.graph.validation import GraphValidationError
 from graphon.nodes.base.node import Node
+from graphon.nodes.loop.loop_start_node import LoopStartNode
 from graphon.runtime.runtime_state import RuntimeState
+from tests.helpers import build_init_params, build_variable_pool
 
 
 class _NodeDataWithContainerDefault(BaseNodeData):
@@ -134,6 +138,277 @@ def _config_edges(graph_config: Mapping[str, Any]) -> set[tuple[str, str]]:
 
 def _graph_edges(graph: Graph) -> set[tuple[str, str]]:
     return {(edge.tail, edge.head) for edge in graph.edges.values()}
+
+
+@pytest.mark.parametrize("node_id", [None, "", 42, [], "start", "a-start"])
+def test_invalid_node_ids_fail_before_construction(node_id: object) -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["nodes"].append({"id": node_id, "data": {"type": "answer"}})
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(GraphValidationError):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+        )
+
+    assert node_factory.created_node_ids == []
+
+
+@pytest.mark.parametrize(
+    ("edge_index", "edge_field", "invalid_value"),
+    [
+        (0, "source", None),
+        (0, "target", 42),
+        (0, "sourceHandle", None),
+        (5, "source", []),
+        (5, "target", "missing"),
+        (5, "sourceHandle", {}),
+    ],
+)
+def test_invalid_edges_fail_before_construction(
+    edge_index: int,
+    edge_field: str,
+    invalid_value: object,
+) -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"][edge_index][edge_field] = invalid_value
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(GraphValidationError):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+        )
+
+    assert node_factory.created_node_ids == []
+
+
+@pytest.mark.parametrize(
+    ("source", "target", "container_id"),
+    [
+        ("end", "container-a", ""),
+        ("end", "end", ""),
+        ("nested-end", "nested-start", "nested-container"),
+    ],
+)
+def test_cycles_fail_before_construction(
+    source: str, target: str, container_id: str
+) -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"].append(_edge(source, target))
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(GraphValidationError, match=r"(?i)cycle") as error:
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+        )
+
+    assert source in str(error.value)
+    assert target in str(error.value)
+    if container_id:
+        assert container_id in str(error.value)
+    assert node_factory.created_node_ids == []
+
+
+@pytest.mark.parametrize("has_inactive_root", [False, True])
+def test_cycles_outside_the_active_path_are_rejected(has_inactive_root: bool) -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["nodes"].extend([_node("a"), _node("b")])
+    graph_config["edges"].extend([_edge("a", "b"), _edge("b", "a")])
+    if has_inactive_root:
+        graph_config["nodes"].append(_node("other-start", node_type="start"))
+        graph_config["edges"].append(_edge("other-start", "a"))
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(GraphValidationError, match=r"(?i)cycle"):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+        )
+
+    assert node_factory.created_node_ids == []
+
+
+def test_child_validation_does_not_include_sibling_cycles() -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"].append(_edge("b-end", "b-start"))
+
+    graph = Graph.init(
+        graph_config=graph_config,
+        node_factory=_RecordingNodeFactory(),
+        root_node_id="a-start",
+        container_id="container-a",
+    )
+
+    assert set(graph.nodes) == {"a-start", "nested-container", "a-end"}
+
+
+def test_graph_init_preserves_input_and_handles() -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["nodes"].append({"id": "start", "type": "custom-note", "data": {}})
+    graph_config["edges"][1]["sourceHandle"] = ""
+    graph_config["edges"][2]["sourceHandle"] = "custom"
+    original_graph_config = deepcopy(graph_config)
+
+    graph = Graph.init(
+        graph_config=graph_config,
+        node_factory=_RecordingNodeFactory(),
+        root_node_id="start",
+    )
+
+    assert graph_config == original_graph_config
+    assert [edge.source_handle for edge in graph.edges.values()] == [
+        "source",
+        "",
+        "custom",
+    ]
+
+
+def test_skip_validation_allows_cycle_and_missing_target() -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"].extend([
+        _edge("end", "container-a"),
+        _edge("end", "missing"),
+    ])
+
+    graph = Graph.init(
+        graph_config=graph_config,
+        node_factory=_RecordingNodeFactory(),
+        root_node_id="end",
+        skip_validation=True,
+    )
+
+    assert graph.root_node.id == "end"
+    assert ("end", "missing") in _graph_edges(graph)
+    assert ("end", "container-a") in _graph_edges(graph)
+
+
+@pytest.mark.parametrize("invalid_input", ["duplicate", "handle"])
+def test_skip_validation_still_rejects_invalid_input(invalid_input: str) -> None:
+    graph_config = _scoped_graph_config()
+    if invalid_input == "duplicate":
+        graph_config["nodes"].append(_node("end"))
+    else:
+        graph_config["edges"][0]["sourceHandle"] = None
+
+    with pytest.raises(GraphValidationError):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=_RecordingNodeFactory(),
+            root_node_id="start",
+            skip_validation=True,
+        )
+
+
+def test_invalid_root_is_rejected() -> None:
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(GraphValidationError) as error:
+        Graph.init(
+            graph_config=_scoped_graph_config(),
+            node_factory=node_factory,
+            root_node_id="end",
+        )
+
+    assert any(issue.code == "INVALID_ROOT" for issue in error.value.issues)
+
+
+def test_root_validation_accepts_factory_alias_for_loop_entry() -> None:
+    class LoopStartNodeFactory(_RecordingNodeFactory):
+        def validate_node(self, node_config: NodeConfigDict) -> NodeExecutionType:
+            LoopStartNode.validate_node_data(node_config["data"])
+            return LoopStartNode.execution_type
+
+        def create_node(self, node_config: NodeConfigDict) -> Node:
+            return LoopStartNode(
+                node_id=node_config["id"],
+                data=LoopStartNode.validate_node_data(node_config["data"]),
+                init_params=build_init_params(graph_config=self.graph_config),
+                runtime_state=RuntimeState(
+                    workflow_id="workflow",
+                    variable_pool=build_variable_pool(),
+                    start_at=0,
+                ),
+            )
+
+    graph = Graph.init(
+        graph_config={
+            "nodes": [_node("entry", node_type="entry-alias")],
+            "edges": [],
+        },
+        node_factory=LoopStartNodeFactory(),
+        root_node_id="entry",
+    )
+
+    assert isinstance(graph.root_node, LoopStartNode)
+
+
+@pytest.mark.parametrize("target", ["missing", "other-start"])
+def test_skip_validation_allows_invalid_inactive_branches(target: str) -> None:
+    graph = Graph.init(
+        graph_config={
+            "nodes": [
+                _node("start", node_type="start"),
+                _node("other-start", node_type="start"),
+            ],
+            "edges": [_edge("other-start", target)],
+        },
+        node_factory=_RecordingNodeFactory(),
+        root_node_id="start",
+        skip_validation=True,
+    )
+
+    assert graph.root_node.id == "start"
+    assert graph.nodes["other-start"].state == NodeState.SKIPPED
+    assert ("other-start", target) in _graph_edges(graph)
+
+
+def test_duplicate_child_edge_ids_fail_before_construction() -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"][3]["id"] = "duplicate"
+    graph_config["edges"][4]["id"] = "duplicate"
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(ValueError, match="Duplicate graph edge ID: duplicate"):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+        )
+
+    assert node_factory.created_node_ids == []
+
+
+def test_skip_validation_still_rejects_cross_scope_edges() -> None:
+    graph_config = _scoped_graph_config()
+    graph_config["edges"].append(_edge("start", "nested-end"))
+    node_factory = _RecordingNodeFactory()
+
+    with pytest.raises(ValueError, match="crosses container scopes"):
+        Graph.init(
+            graph_config=graph_config,
+            node_factory=node_factory,
+            root_node_id="start",
+            skip_validation=True,
+        )
+
+    assert node_factory.created_node_ids == []
+
+
+def test_graph_constructor_accepts_cycle() -> None:
+    root = cast(Node, Mock(spec=Node, id="node"))
+    edge = Edge(id="cycle", tail="node", head="node")
+
+    graph = Graph(root_node=root, nodes={"node": root}, edges={"cycle": edge})
+
+    assert graph.root_node is root
+    assert graph.edges["cycle"] is edge
 
 
 def test_graph_init_materializes_only_root_scope_by_default() -> None:


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #277

## Summary

A graph containing `start → a → b → a` could report success after running only `start`. Duplicate node IDs and malformed edges could also disappear during construction.

Reject malformed IDs and edge fields before information is lost, and reject execution cycles throughout retained container subtrees before constructing nodes. Apply the same structural rules to the Python builder and preserve structured DSL errors instead of raising `AttributeError` while serializing them.

Previously accepted malformed or cyclic definitions must be corrected; use Loop, Iteration, or custom container handlers for repetition. Valid scopes, custom factory entry aliases, edge identities, and explicit trusted construction paths retain their behavior. The knowledge base also adds development style guidance and records the TD-02 outcome and migration requirements.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
