### PR TITLE
fix(runtime)!: reject snapshots during active execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,6 +137,16 @@ IDs after migration. See
 [runtime tests](tests/runtime/test_runtime_state.py), and
 [version-isolation test](tests/test_snapshot_version_isolation.py).
 
+**Public snapshots require quiescence.** `RuntimeState.dumps()` and its read-only
+wrapper reject active engine runs and execution threads, including pause draining
+and threads that outlive shutdown timeouts. A transient guard on the shared
+[GraphExecution](src/graphon/runtime/execution.py) covers all frames and excludes
+execution startup and other snapshot writers throughout serialization. Internal
+frame snapshots remain engine operations. See
+[snapshot eligibility](MIGRATION.md#snapshot-eligibility) for persistence timing
+and host responsibilities, and
+[serialization tests](tests/engine/test_runtime_state_serialization.py) for evidence.
+
 ## Extension seams
 
 | Change | Start here | Existing check |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ before upgrading an integration.
 
 ### Changed
 
+- Public runtime snapshots now reject active engine runs and execution threads,
+  including threads still running after shutdown times out. Persist paused state
+  after fully consuming the run iterator, or from a quiescent `on_graph_end` hook.
+  Snapshot formats are unchanged.
 - Graph construction now rejects invalid or duplicate node IDs, malformed edge
   fields, duplicate edge IDs within a scope, and execution cycles
   before constructing configured nodes, including errors in nested scopes.
@@ -31,7 +35,8 @@ before upgrading an integration.
 - Made `NodeFactory.with_runtime_state()` part of the public protocol used to bind
   nodes to child-frame state.
 - Made aborts and fatal failures take precedence over a concurrent pause. Persist
-  resumable state only after receiving `GraphRunPausedEvent`.
+  resumable state only after receiving `GraphRunPausedEvent` and fully consuming
+  the run iterator.
 - Kept loop write-backs explicit and parent-owned while iteration frame state
   remains isolated; external variable-update commands stay authoritative.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -107,9 +107,10 @@ do not expose siblings or parent graph structure. They do not provide a live
 fallback to later parent-pool changes.
 
 An abort or fatal failure now wins over a concurrent pause. Persist resumable state
-only after the engine emits `GraphRunPausedEvent`; do not infer a pause from a
-queued command. Loop handlers write only their configured selectors back to the
-parent, while iteration frame state remains isolated.
+only after the engine emits `GraphRunPausedEvent` and its run iterator has been
+fully consumed; do not infer a pause from a queued command. Loop handlers write
+only their configured selectors back to the parent, while iteration frame state
+remains isolated.
 
 ### Graph validation
 
@@ -218,6 +219,25 @@ package.
   and expiry operations. For a rolling deployment, keep the legacy pending marker
   and wrapped update payload for at least one configured command TTL after all old
   consumers have stopped.
+
+### Snapshot eligibility
+
+`RuntimeState.dumps()` and the layer read-only wrapper now raise `RuntimeError`
+while an engine run or any of its execution threads is active. This includes
+start, node, and event callbacks, even when a pause or completion flag is set.
+Receiving a terminal event alone does not finish the run iterator.
+
+For resumable persistence, request a cooperative pause and fully consume the
+iterator before taking a snapshot. Layers can persist from `on_graph_end` once
+all execution threads have stopped. Closing an iterator also initiates teardown,
+but aborts, failures, and early closure can leave threads alive beyond the shutdown
+timeout; snapshots remain unavailable until those threads exit. Closing alone
+does not establish a resumable pause.
+
+Pre-run and restored states remain serializable, subject to existing migration
+requirements. Snapshot formats are unchanged. Serialization excludes engine
+startup and other snapshot writers across all frames; the host must avoid
+concurrent direct mutations of runtime objects.
 
 ### Persisted state
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ independent test and knowledge reviews, and the final naming pass.
 | What breaks when upgrading? | [Migration guide](../MIGRATION.md), [changelog](../CHANGELOG.md) |
 | What structural debt has been identified, and what should improve next? | [Architecture review and technical debt](technical-debt.md) |
 | What is the progress and evidence for TD-02? | [Graph validation plan](plans/graph-validation.md) |
+| What is the progress and evidence for TD-03? | [Snapshot eligibility plan](plans/snapshot-eligibility.md) |
 
 ## Component references
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,6 +108,10 @@ revision. Once all other development steps are complete, finish with the
 
 ## Runtime pitfalls
 
+- Once execution starts, `RuntimeState.dumps()` requires teardown and all
+  execution threads to stop. Start, node, and event callbacks cannot take runtime
+  snapshots; quiescent `on_graph_end` hooks can. See the
+  [snapshot eligibility guidance](../MIGRATION.md#snapshot-eligibility).
 - A direct `Node.run()` call requires `bind_execution_id()` first. The engine
   normally handles this; [the binding test](../tests/nodes/base/test_node_execution_binding.py)
   captures the failure when it is missing.

--- a/docs/plans/snapshot-eligibility.md
+++ b/docs/plans/snapshot-eligibility.md
@@ -1,0 +1,71 @@
+# Snapshot eligibility (TD-03)
+
+**Status:** implementation and reviews complete locally, 2026-09-08.
+**Tracking:** [issue #279](https://github.com/langgenius/graphon/issues/279),
+[TD-03](../technical-debt.md#td-03--snapshot-consistency-at-the-public-boundary).
+**Branch:** `laipz8200/snapshot-eligibility`, stacked on
+[PR #278](https://github.com/langgenius/graphon/pull/278).
+
+## Objective and scope
+
+Reject public runtime snapshots while engine activity can mutate the execution.
+Preserve pre-run, restored, and quiescent paused/completed snapshots and existing
+snapshot formats. Apply the same boundary to layer wrappers and child frames.
+Internal frame snapshots remain part of engine execution.
+
+## Context and decisions
+
+- [Engine.run](../../src/graphon/engine/engine.py) invokes start hooks before
+  starting workers and yields terminal events before teardown. Snapshot callers
+  must finish consuming or close the iterator and wait for execution to stop.
+- Persisted `started`, `paused`, and `completed` flags do not prove quiescence.
+  Pause drains active workers; abort and failure can leave workers running beyond
+  the bounded shutdown joins.
+- Use the shared [GraphExecution](../../src/graphon/runtime/execution.py) to
+  account for live run, dispatcher, and worker activity. Child frames already
+  share this object. Keep the guard transient, outside snapshot schemas.
+- Exclude execution startup and other snapshot writers for the entire public
+  serialization. This protects engine-owned changes, not arbitrary concurrent
+  host mutations of exposed runtime objects.
+- A quiescent `on_graph_end` can persist state. Active start, node, and event
+  callbacks must request a cooperative pause and persist after teardown.
+  Timed-out shutdown continues rejecting snapshots until lingering threads exit.
+- Keep shutdown timeouts and the existing pause path; adding live checkpoint
+  orchestration or changing cancellation behavior is outside this revision.
+
+## Steps
+
+- [x] Add behavior regressions and confirm the intended failures.
+- [x] Complete independent test review, then implement the guard.
+- [x] Run focused compatibility checks and ordinary repository tests.
+- [x] Complete independent knowledge review.
+- [x] Complete the final naming pass and affected checks.
+
+## Validation and outcome
+
+`uv run pytest -n 0 tests/engine/test_runtime_state_serialization.py -k test_runtime_snapshot`
+failed all six reviewed cases for the intended missing behavior: active callbacks,
+paused child frames, and workers/dispatchers surviving iterator closure could
+serialize; concurrent startup and snapshot writers overlapped a held snapshot.
+Fresh independent test review completed before implementation; all six cases pass
+with the guard in place.
+
+Existing [serialization tests](../../tests/engine/test_runtime_state_serialization.py),
+[runtime tests](../../tests/runtime/test_runtime_state.py), and
+[version isolation](../../tests/test_snapshot_version_isolation.py) cover paused
+containers, task preservation, historical snapshots, and current formats.
+
+The focused serialization/runtime/isolation/dispatch/container/layer-context set
+passes **100 tests**. `just test` passes **821 tests** on Python 3.12.13. An earlier
+run caught an assumption that standalone workers always have a root frame; the
+guard now uses the shared execution from any registered frame, preserving empty
+and child-only registry controls. An initial full run also hit the existing
+gevent subprocess's ten-second timeout; the final full run passed both variants.
+`just check` and `git diff --check` pass. Independent knowledge review checked
+the guard, lifecycle, child-frame sharing, and unchanged snapshot codecs against
+source and tests, corrected the debt register, and consolidated repeated guidance.
+`uv run pytest -n 0 tests/test_repository_docs.py` passes (**1 test**) after those edits.
+The independent final naming pass renamed the snapshot lock method and test
+helpers/variables without changing behavior; all six regression cases pass after
+the renames. Publication is tracked through issue #279.
+Python 3.13 and live external integrations were not exercised locally.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -3,8 +3,9 @@
 **Reviewed:** 2026-09-08, Graphon 0.7.0, commit
 `9d13c716d527a8b7099df00cc448254ac7b6e98b`.
 **Status:** original review complete; TD-02 implementation and reviews are complete
-locally. Other remediation remains proposed, not accepted architecture
-policy. Priorities express the original review's judgment.
+locally. TD-03 implementation and independent reviews are complete locally. Other
+remediation remains proposed, not accepted architecture policy. Priorities express
+the original review's judgment.
 **Scope:** repository structure, execution and integration boundaries, developer
 feedback, and knowledge maintenance. Evidence includes source, callers, test
 definitions, focused tests, and small local reproductions. This is not a
@@ -128,10 +129,10 @@ queue dependency and facade side effects below have concrete isolation costs.
 
 ## Debt register
 
-TD-02 is **implemented locally**; other entries remain **proposed**. P1 means a
-reproduced correctness problem or a boundary that must be addressed before the
-stated deployment use. P2 is targeted
-architecture or feedback work. P3 can follow the more consequential changes.
+TD-02 and TD-03 are **implemented locally**; other entries remain **proposed**. P1
+means a reproduced correctness problem or a boundary that must be addressed before
+the stated deployment use. P2 is targeted architecture or feedback work. P3 can
+follow the more consequential changes.
 Suggested owners are responsibility areas, not assigned people; effort is a
 relative change size, not a delivery estimate.
 
@@ -139,7 +140,7 @@ relative change size, not a delivery estimate.
 | --- | --- | --- | --- | --- |
 | TD-01 | Dependency direction and runtime queue ownership | P2 | Engine/runtime | Medium |
 | TD-02 | [Graph construction and structural validation](#td-02--graph-construction-and-structural-validation), implemented locally | P1 | Graph/DSL | Medium |
-| TD-03 | Snapshot consistency at the public boundary | P2 | Runtime/engine | Medium |
+| TD-03 | [Snapshot consistency at the public boundary](#td-03--snapshot-consistency-at-the-public-boundary), implemented locally | P2 | Runtime/engine | Medium |
 | TD-04 | Execution-scoped file integration | P2; P1 before concurrent distinct host adapters | File/host integration | Medium–large |
 | TD-05 | Side effects of importing public contracts | P2 | Public API/node bootstrap | Small–medium |
 | TD-06 | Ignored LLM integration arguments | P2 | Model/node API | Small, with a compatibility window |
@@ -215,35 +216,32 @@ evidence, not a merged fix or a release claim.
 
 ## TD-03 — Snapshot consistency at the public boundary
 
-**Working well:** the dispatcher already stops acquisition, drains active work,
-and snapshots child frames on cooperative pause. Version handling and defensive
-output copies are strong.
+**Implementation update (2026-09-08):** implemented locally for
+[issue #279](https://github.com/langgenius/graphon/issues/279), with independent test,
+knowledge, and naming reviews complete. The
+[snapshot eligibility plan](plans/snapshot-eligibility.md) records scope, decisions,
+and checks.
 
-**Evidence and consequence:** [ReadOnlyRuntimeState.dumps](../src/graphon/runtime/runtime_state_protocol.py)
-advertises snapshot access as read-only; its
-[wrapper](../src/graphon/runtime/read_only_wrappers.py) forwards to runtime.
-The [v3 writer](../src/graphon/runtime/runtime_state/v3.py) reads graph state,
-variables, execution state, and queues separately.
-[InMemoryReadyQueue.dumps](../src/graphon/engine/ready_queue/in_memory.py) drains
-and reinserts queued tasks and explicitly requires quiescent producers and
-consumers. [RuntimeState.dumps](../src/graphon/runtime/runtime_state/state.py)
-guards pending migration, but does not enforce that execution is quiescent.
-Thus callers can reach an operation whose consistency prerequisite is only
-documented inside the queue. No concurrent corruption was reproduced in this
-review; this is a contract and consistency risk.
+**Original evidence:** public runtime and layer snapshots could read graph state,
+variables, execution state, and shared queues during execution. Queue serialization
+requires quiescence, but the public boundary did not enforce it. Pause and
+completion flags did not prove worker/dispatcher inactivity, especially after
+bounded shutdown joins. The original review identified a consistency risk without
+reproducing concurrent corruption.
 
-**Proposed change:** define snapshot eligibility at the public runtime/layer API.
-Reject serialization while execution is active, or provide an engine-controlled
-checkpoint using the existing pause/drain path. Account for worker activity,
-not just the moment a pause flag is set. Start with the existing lifecycle
-mechanism; a lock around queue serialization alone cannot make all frame state
-consistent. Preserve valid pre-run, paused, completed, and restored-state use.
+**Current result:** [RuntimeState.dumps](../src/graphon/runtime/runtime_state/state.py)
+enforces [quiescent snapshots](../ARCHITECTURE.md#state-and-execution-invariants) across
+all frames, including threads that outlive shutdown. Internal frame snapshots and
+persisted formats are unchanged. The
+[migration guidance](../MIGRATION.md#snapshot-eligibility) defines the public
+contract and host responsibilities.
 
-**Done when:** snapshot attempts from an active layer callback have defined,
-tested behavior; a paused dump/restore preserves queued tasks and nested frames;
-historical fixtures and format isolation still pass. Extend
-[runtime tests](../tests/runtime/test_runtime_state.py) and
-[engine serialization tests](../tests/engine/test_runtime_state_serialization.py).
+**Evidence of remediation:** six new
+[serialization cases](../tests/engine/test_runtime_state_serialization.py) reproduce
+and prevent active callback snapshots, paused child-frame snapshots, snapshots
+while threads outlive shutdown, and concurrent startup/writer overlap. Focused
+compatibility and full-suite results are recorded in the plan. This is local
+implementation evidence, not a merge or release claim.
 
 ## TD-04 — Execution-scoped file integration
 
@@ -454,9 +452,10 @@ generator are not prerequisites. No recurring automation was configured here.
 1. TD-02 was selected first for its reproduced false-success outcome. Its local
    implementation and completed reviews are tracked in the
    [graph validation plan](plans/graph-validation.md).
-2. Define TD-03's snapshot eligibility and TD-04's file adapter scope before
-   promising live checkpoints or concurrent distinct host integrations. TD-04
-   may be staged if all deployed hosts use one process-wide adapter.
+2. TD-03's local implementation enforces quiescent snapshots; live checkpoints
+   remain outside its scope. Define TD-04's file adapter scope before promising
+   concurrent distinct host integrations. TD-04 may be staged if all deployed
+   hosts use one process-wide adapter.
 3. Combine the related import work in TD-01 and TD-05, with a focused boundary
    test for each. Handle TD-06 in a separately documented API transition.
 4. Add TD-08's offline example; use it in TD-07's minimal-install check. Continue

--- a/src/graphon/engine/dispatcher.py
+++ b/src/graphon/engine/dispatcher.py
@@ -92,6 +92,11 @@ class Dispatcher:
 
     def _dispatcher_loop(self) -> None:
         """Main dispatcher loop."""
+        with self._graph_execution.track_execution():
+            self._dispatch_until_complete()
+
+    def _dispatch_until_complete(self) -> None:
+        """Process results and publish completion before releasing activity."""
         try:
             paused = self._run_until_exit()
             self._finish_dispatching(paused)

--- a/src/graphon/engine/engine.py
+++ b/src/graphon/engine/engine.py
@@ -201,17 +201,21 @@ class Engine:
 
         """
         try:
-            yield from self._run_graph()
-        except Exception as error:
-            failed_event = GraphRunFailedEvent(
-                error=str(error),
-                exceptions_count=self._graph_execution.exceptions_count,
-            )
-            self._event_stream.notify_layers(failed_event)
-            yield failed_event
-            raise
+            with self._graph_execution.track_execution():
+                try:
+                    yield from self._run_graph()
+                except Exception as error:
+                    failed_event = GraphRunFailedEvent(
+                        error=str(error),
+                        exceptions_count=self._graph_execution.exceptions_count,
+                    )
+                    self._event_stream.notify_layers(failed_event)
+                    yield failed_event
+                    raise
+                finally:
+                    self._stop_execution()
         finally:
-            self._stop_execution()
+            self._notify_graph_end()
 
     def _run_graph(self) -> Generator[EngineEvent, None, None]:
         self._event_stream.reset()
@@ -348,7 +352,8 @@ class Engine:
         self._worker_pool.stop()
         # Don't mark complete here as the dispatcher already does it
 
-        # Notify layers
+    def _notify_graph_end(self) -> None:
+        """Notify layers after teardown so quiescent state can be persisted."""
         for layer in self._layers:
             try:
                 layer.on_graph_end(self._graph_execution.error)

--- a/src/graphon/engine/layer/README.md
+++ b/src/graphon/engine/layer/README.md
@@ -48,3 +48,10 @@ class MetricsLayer(Layer):
 
 `engine.add_layer()` binds the read-only runtime state before execution, so
 `runtime_state` is always available inside layer hooks.
+
+`runtime_state.dumps()` requires quiescent execution. Start, node, and event
+callbacks (including terminal events) raise `RuntimeError` if they try to take
+a runtime snapshot. Persist in `on_graph_end` after execution threads have stopped,
+or after fully consuming the run iterator. See the
+[snapshot migration guidance](../../../../MIGRATION.md#snapshot-eligibility) for
+resumable pauses and shutdown timeouts.

--- a/src/graphon/engine/worker/worker.py
+++ b/src/graphon/engine/worker/worker.py
@@ -122,6 +122,16 @@ class Worker(threading.Thread):
         Continuously pulls node IDs from ready_queue, executes them,
         and pushes results to the dispatch queue until stopped.
         """
+        frames = self._frame_registry.frames()
+        with (
+            frames[0].state.graph_execution.track_execution()
+            if frames
+            else nullcontext()
+        ):
+            self._run_tasks()
+
+    def _run_tasks(self) -> None:
+        """Acquire and execute tasks until this worker is stopped."""
         while not self._stop_event.is_set():
             with self._task_acquisition_lock:
                 if not self._task_acquisition_enabled.is_set():

--- a/src/graphon/runtime/execution.py
+++ b/src/graphon/runtime/execution.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Annotated, Final, Literal
 from uuid import uuid4
@@ -107,6 +110,48 @@ class GraphExecution:
         default_factory=dict[tuple[str, str], NodeExecution],
     )
     exceptions_count: int = 0
+
+    _active_executions: int = field(default=0, init=False, repr=False, compare=False)
+    _snapshot_lock: threading.Lock = field(
+        # Resolve at construction so late gevent patching is honored.
+        default_factory=lambda: threading.Lock(),  # ruff: ignore[unnecessary-lambda]
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    @contextmanager
+    def track_execution(self) -> Iterator[None]:
+        """Keep snapshots disabled for one engine run or execution thread.
+
+        Each participant remains active until it exits, even if a shutdown join
+        times out. This accounting is transient and shared by all runtime frames.
+        """
+        with self._snapshot_lock:
+            self._active_executions += 1
+        try:
+            yield
+        finally:
+            with self._snapshot_lock:
+                self._active_executions -= 1
+
+    @contextmanager
+    def lock_for_snapshot(self) -> Iterator[None]:
+        """Exclude execution startup and other snapshots during serialization.
+
+        Raises:
+            RuntimeError: If an engine run or execution thread is still active.
+
+        """
+        with self._snapshot_lock:
+            if self._active_executions:
+                msg = (
+                    "Cannot serialize runtime state during active execution; "
+                    "finish consuming or close Engine.run() and wait for all "
+                    "execution threads to stop"
+                )
+                raise RuntimeError(msg)
+            yield
 
     def start(self) -> None:
         """Mark the graph execution as started."""

--- a/src/graphon/runtime/read_only_wrappers.py
+++ b/src/graphon/runtime/read_only_wrappers.py
@@ -70,5 +70,5 @@ class ReadOnlyRuntimeStateWrapper:
         return self._state.get_output(key, default)
 
     def dumps(self) -> str:
-        """Serialize the underlying runtime state for external persistence."""
+        """Serialize quiescent state, enforcing the runtime's snapshot guard."""
         return self._state.dumps()

--- a/src/graphon/runtime/runtime_state/state.py
+++ b/src/graphon/runtime/runtime_state/state.py
@@ -266,6 +266,11 @@ class RuntimeState:  # ruff:ignore[too-many-public-methods]
     def dumps(self) -> str:
         """Serialize runtime state into a version 3 JSON string.
 
+        Finish consuming or close the engine run iterator and wait for all
+        execution threads to stop first. The guard is shared by child frames and
+        excludes engine startup and other snapshots throughout serialization.
+        Hosts must also avoid concurrent direct mutations of runtime objects.
+
         A restored state with a graph-aware migration must first attach its graph
         so persisted identities can be converted safely. Refusing to serialize
         before that point prevents unconverted data from being labeled current.
@@ -274,7 +279,8 @@ class RuntimeState:  # ruff:ignore[too-many-public-methods]
             The complete version 3 runtime snapshot as JSON.
 
         Raises:
-            RuntimeError: If a snapshot migration is waiting for graph attachment.
+            RuntimeError: If execution is active or a snapshot migration is
+                waiting for graph attachment.
 
         """
         if self._graph_state_migration is not None:
@@ -285,7 +291,8 @@ class RuntimeState:  # ruff:ignore[too-many-public-methods]
             raise RuntimeError(msg)
         from .v3 import dumps  # ruff:ignore[import-outside-top-level]
 
-        return dumps(self)
+        with self._graph_execution.lock_for_snapshot():
+            return dumps(self)
 
     @classmethod
     def from_snapshot(

--- a/src/graphon/runtime/runtime_state_protocol.py
+++ b/src/graphon/runtime/runtime_state_protocol.py
@@ -83,5 +83,11 @@ class ReadOnlyRuntimeState(Protocol):
 
     @abstractmethod
     def dumps(self) -> str:
-        """Serialize the runtime state into a JSON snapshot (read-only)."""
+        """Serialize quiescent runtime state without changing its values.
+
+        Raises:
+            RuntimeError: While the engine run or any execution thread is active,
+                or a restored migration still requires graph attachment.
+
+        """
         ...

--- a/tests/engine/test_runtime_state_serialization.py
+++ b/tests/engine/test_runtime_state_serialization.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import json
 import queue
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from threading import Event, Lock
+from threading import Event, Lock, Thread, current_thread
 from time import monotonic, sleep
 from types import SimpleNamespace
 from typing import Any, ClassVar, cast
@@ -20,6 +20,7 @@ from graphon.dsl.node_factory import SlimDslNodeFactory
 from graphon.engine import Engine
 from graphon.engine.container_handler import LoopContainerHandler
 from graphon.engine.frame import ExecutionFrame, FrameRegistry
+from graphon.engine.layer import Layer
 from graphon.engine.ready_queue.entities import ResumeTask, StartTask
 from graphon.engine.ready_queue.in_memory import InMemoryReadyQueue
 from graphon.engine.scheduler import Scheduler
@@ -28,6 +29,7 @@ from graphon.engine_events.base import EngineEvent
 from graphon.engine_events.graph import (
     GraphRunPausedEvent,
     GraphRunStartedEvent,
+    GraphRunSucceededEvent,
 )
 from graphon.engine_events.iteration import (
     NodeRunIterationStartedEvent,
@@ -39,6 +41,7 @@ from graphon.engine_events.loop import (
 )
 from graphon.engine_events.node import (
     NodeRunPauseRequestedEvent,
+    NodeRunStartedEvent,
     NodeRunSucceededEvent,
 )
 from graphon.entities.graph_config import NodeConfigDict
@@ -324,6 +327,261 @@ def _complete_iteration_hitl(context: HITLContext) -> Completed:
     item = context.variable_pool.get(("iteration", "item"))
     assert item is not None
     return _completed_hitl(f"{item.text}!")
+
+
+def _try_snapshot(dumps: Callable[[], str]) -> str | Exception:
+    """Keep snapshot failures observable outside exception-isolating callbacks."""
+    try:
+        return dumps()
+    except Exception as error:  # ruff: ignore[blind-except]
+        return error
+
+
+def test_runtime_snapshot_rejects_active_callbacks() -> None:
+    state = _new_runtime_state({})
+    snapshots: dict[str, str | Exception] = {}
+
+    class SnapshotLayer(Layer):
+        def on_graph_start(self) -> None:
+            snapshots["graph_start"] = _try_snapshot(self.runtime_state.dumps)
+
+        def on_event(self, event: EngineEvent) -> None:
+            if isinstance(
+                event,
+                (GraphRunStartedEvent, NodeRunSucceededEvent, GraphRunSucceededEvent),
+            ):
+                snapshots[type(event).__name__] = _try_snapshot(
+                    self.runtime_state.dumps
+                )
+
+        def on_node_run_start(self, node: Node) -> None:
+            snapshots["node_start"] = _try_snapshot(self.runtime_state.dumps)
+            snapshots["node_runtime"] = _try_snapshot(node.runtime_state.dumps)
+
+        def on_graph_end(self, error: Exception | None) -> None:
+            _ = error
+            snapshots["graph_end"] = _try_snapshot(self.runtime_state.dumps)
+
+    engine = _hitl_engine(
+        _graph_dsl(nodes=[_start_node()], edges=[]),
+        runtime_state=state,
+        callback=_complete_loop_hitl,
+    )
+    engine.add_layer(SnapshotLayer())
+    assert RuntimeState.from_snapshot(state.dumps()).dumps()
+    events = engine.run()
+    assert isinstance(next(events), GraphRunStartedEvent)
+    snapshots["started_iterator"] = _try_snapshot(state.dumps)
+    assert isinstance(list(events)[-1], GraphRunSucceededEvent)
+
+    completed = state.dumps()
+    assert RuntimeState.from_snapshot(completed).dumps()
+    assert isinstance(snapshots.pop("graph_end"), str)
+    assert set(snapshots) == {
+        "graph_start",
+        "GraphRunStartedEvent",
+        "GraphRunSucceededEvent",
+        "NodeRunSucceededEvent",
+        "node_start",
+        "node_runtime",
+        "started_iterator",
+    }
+    assert all(isinstance(result, RuntimeError) for result in snapshots.values()), {
+        name: type(result).__name__ for name, result in snapshots.items()
+    }
+
+
+def test_runtime_snapshot_rejects_paused_workers_and_child_frames() -> None:
+    state = _new_runtime_state({"items": ["alpha", "beta"]})
+    alpha_started = Event()
+    child_states: list[RuntimeState] = []
+    snapshots: list[str | Exception] = []
+
+    class ChildStateLayer(Layer):
+        def on_node_run_start(self, node: Node) -> None:
+            if node.id == "human-input":
+                item = node.runtime_state.variable_pool.get(("iteration", "item"))
+                if item is not None and item.text == "alpha":
+                    child_states.append(node.runtime_state)
+
+    layer = ChildStateLayer()
+
+    def pause_with_active_sibling(context: HITLContext) -> Completed | PauseRequested:
+        item = context.variable_pool.get(("iteration", "item"))
+        assert item is not None
+        if item.text == "beta":
+            assert alpha_started.wait(timeout=2)
+            return PauseRequested(session_id="session-beta")
+        alpha_started.set()
+        deadline = monotonic() + 2
+        while not state.graph_execution.paused:
+            assert monotonic() < deadline
+            sleep(0.001)
+        snapshots.extend([
+            _try_snapshot(layer.runtime_state.dumps),
+            _try_snapshot(child_states[0].dumps),
+        ])
+        return _completed_hitl("alpha!")
+
+    engine = _hitl_engine(
+        _iteration_dsl(), runtime_state=state, callback=pause_with_active_sibling
+    )
+    engine.add_layer(layer)
+    snapshot, _ = _snapshot_after_hitl_pause(engine)
+    restored = RuntimeState.from_snapshot(snapshot)
+    assert restored.dumps()
+    resumed = list(
+        _hitl_engine(
+            _iteration_dsl(),
+            runtime_state=restored,
+            callback=_complete_iteration_hitl,
+        ).run()
+    )
+
+    assert child_states[0] is not state
+    assert final_outputs(resumed) == {"items": ["alpha!", "beta!"]}
+    assert len(snapshots) == 2
+    assert all(isinstance(result, RuntimeError) for result in snapshots), [
+        type(result).__name__ for result in snapshots
+    ]
+
+
+@pytest.mark.parametrize("thread_kind", ["worker", "dispatcher"])
+def test_runtime_snapshot_rejects_thread_alive_after_iterator_close(  # ruff: ignore[complex-structure]
+    thread_kind: str,
+) -> None:
+    state = _new_runtime_state({})
+    thread_blocked = Event()
+    release_thread = Event()
+    blocked_threads: list[Thread] = []
+    worker_threads: set[Thread] = set()
+    released: list[bool] = []
+
+    def block_thread() -> None:
+        blocked_threads.append(current_thread())
+        thread_blocked.set()
+        released.append(release_thread.wait(timeout=10))
+
+    class BlockingLayer(Layer):
+        def on_node_run_start(self, node: Node) -> None:
+            _ = node
+            worker_threads.add(current_thread())
+
+        def on_event(self, event: EngineEvent) -> None:
+            if (
+                thread_kind == "dispatcher"
+                and isinstance(event, NodeRunStartedEvent)
+                and event.node_id == "human-input"
+            ):
+                block_thread()
+
+    def wait_for_release(context: HITLContext) -> Completed:
+        _ = context
+        if thread_kind == "worker":
+            block_thread()
+        return _completed_hitl("done")
+
+    engine = _hitl_engine(
+        _graph_dsl(
+            nodes=[
+                _start_node(),
+                {"id": "human-input", "data": {"type": "human-input"}},
+                _end_node([]),
+            ],
+            edges=[_edge("start", "human-input"), _edge("human-input", "end")],
+        ),
+        runtime_state=state,
+        callback=wait_for_release,
+    )
+    engine.add_layer(BlockingLayer())
+    events = engine.run()
+    try:
+        for event in events:
+            if (
+                isinstance(event, NodeRunStartedEvent)
+                and event.node_id == "human-input"
+            ):
+                break
+        assert thread_blocked.wait(timeout=2)
+        events.close()
+        assert list(events) == []
+        assert blocked_threads[0].is_alive()
+        if thread_kind == "dispatcher":
+            assert worker_threads
+            assert all(not worker.is_alive() for worker in worker_threads)
+        snapshot = _try_snapshot(state.dumps)
+    finally:
+        release_thread.set()
+        events.close()
+        for thread in {*worker_threads, *blocked_threads}:
+            thread.join(timeout=2)
+
+    assert released == [True]
+    assert all(not thread.is_alive() for thread in {*worker_threads, *blocked_threads})
+    assert state.dumps()
+    assert isinstance(snapshot, RuntimeError), type(snapshot).__name__
+
+
+@pytest.mark.parametrize("operation", ["run", "dump"])
+def test_runtime_snapshot_excludes_concurrent_operations(
+    operation: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _new_runtime_state({})
+    snapshot_started = Event()
+    release_snapshot = Event()
+    operation_started = Event()
+    overlap = Event()
+    results: list[object] = []
+    queue_dumps = state.ready_queue.dumps
+
+    def hold_snapshot() -> str:
+        if snapshot_started.is_set():
+            if not release_snapshot.is_set():
+                overlap.set()
+        else:
+            snapshot_started.set()
+            assert release_snapshot.wait(timeout=2)
+        return queue_dumps()
+
+    class SnapshotOverlapLayer(Layer):
+        def on_graph_start(self) -> None:
+            if not release_snapshot.is_set():
+                overlap.set()
+
+    engine = _hitl_engine(
+        _graph_dsl(nodes=[_start_node()], edges=[]),
+        runtime_state=state,
+        callback=_complete_loop_hitl,
+    )
+    engine.add_layer(SnapshotOverlapLayer())
+    monkeypatch.setattr(state.ready_queue, "dumps", hold_snapshot)
+
+    def run_operation() -> None:
+        operation_started.set()
+        if operation == "run":
+            results.append(list(engine.run()))
+        else:
+            results.append(_try_snapshot(state.dumps))
+
+    snapshot_thread = Thread(target=lambda: results.append(_try_snapshot(state.dumps)))
+    competing_thread = Thread(target=run_operation)
+    snapshot_thread.start()
+    try:
+        assert snapshot_started.wait(timeout=1)
+        competing_thread.start()
+        assert operation_started.wait(timeout=1)
+        overlapped = overlap.wait(timeout=0.1)
+    finally:
+        release_snapshot.set()
+        snapshot_thread.join(timeout=2)
+        if competing_thread.ident is not None:
+            competing_thread.join(timeout=2)
+
+    assert not snapshot_thread.is_alive()
+    assert not competing_thread.is_alive()
+    assert len(results) == 2
+    assert not any(isinstance(result, Exception) for result in results)
+    assert not overlapped
 
 
 def _execution_frame(


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #279

## Summary

Runtime snapshots could serialize graph state, variables, execution state, and shared queues while engine activity was still modifying them. Paused or completed flags did not guarantee that workers and the dispatcher had stopped.

Guard public runtime snapshots with transient activity tracking shared across every frame. Cover the run iterator, dispatcher, and worker lifetimes, including threads still running after shutdown times out. Exclude concurrent execution startup and other snapshot writers throughout serialization.

Persist paused state after fully consuming the run iterator; layers can persist from `on_graph_end` once execution threads have stopped. Pre-run and restored snapshots remain available, and persisted formats and internal container snapshots are unchanged.

Stacked on #278.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [ ] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation
