### PR TITLE
feat(llm): carry a per-node invocation policy and report time to first token

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,5 @@
 <!-- knowledge
-last_checked: "2026-09-10T01:03:07Z"
+last_checked: "2026-09-10T11:15:55Z"
 -->
 # Development navigation
 
@@ -60,6 +60,13 @@ public surface.
   and capability wrappers have separate protocols; see the
   [model runtime guide](../src/graphon/model_runtime/README.md) and
   [dispatch tests](../tests/model_runtime/test_model_dispatch.py).
+  Per-node policy for how a model is called, rather than what is asked of it,
+  lives in the [`invocation` block](../src/graphon/nodes/llm/entities.py) of LLM
+  and question-classifier node data. Graphon carries it and enforces nothing, so
+  read it from `Node.node_data`. It stays out of `ModelConfig.completion_params`,
+  which reaches the provider verbatim, and out of `LLMProtocol`, which would
+  otherwise gain an argument adapters cannot honour
+  ([TD-06](technical-debt.md#td-06--ignored-llm-integration-arguments)).
 - **Files and HTTP:** use the [file binding guidance](../ARCHITECTURE.md#state-and-execution-invariants)
   when wiring engines, filters, or host rendering. Node-specific ports live in
   [nodes/protocols.py](../src/graphon/nodes/protocols.py); generated LLM files use

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -1,5 +1,5 @@
 <!-- knowledge
-last_checked: "2026-09-10T01:03:07Z"
+last_checked: "2026-09-10T11:15:55Z"
 -->
 # Technical debt
 
@@ -37,7 +37,10 @@ remain publicly exported. Supplied configuration can therefore have no effect.
 Document the effective replacements and choose a compatibility window before
 rejecting or removing arguments. Prepared `model_instance` injection is the
 current graph-facing model seam; do not build an unused factory just to justify
-an existing parameter. See the [host integration guide](development.md#integrate-host-services).
+an existing parameter. Configuration the host reads off node data, such as the
+[`invocation` block](../src/graphon/nodes/llm/entities.py), is carried
+deliberately and is not part of this debt. See the
+[host integration guide](development.md#integrate-host-services).
 
 **Completion:** tests cover supplied ignored arguments on all three nodes, the
 transition is documented, and examples use effective dependencies. Preserve

--- a/src/graphon/enums.py
+++ b/src/graphon/enums.py
@@ -230,6 +230,8 @@ class WorkflowNodeExecutionMetadataKey(StrEnum):
     DATASOURCE_INFO = "datasource_info"
     TRIGGER_INFO = "trigger_info"
     COMPLETED_REASON = "completed_reason"  # completed reason for loop node
+    # streamed LLM first-token latency
+    TIME_TO_FIRST_TOKEN = "time_to_first_token"  # ruff: ignore[hardcoded-password-string]
 
 
 class WorkflowNodeExecutionStatus(StrEnum):

--- a/src/graphon/nodes/llm/entities.py
+++ b/src/graphon/nodes/llm/entities.py
@@ -22,6 +22,23 @@ class ModelConfig(BaseModel):
     completion_params: dict[str, Any] = Field(default_factory=dict)
 
 
+class InvocationConfig(BaseModel):
+    """Per-node policy for how a model is called, as opposed to what is asked of it.
+
+    Kept out of `ModelConfig.completion_params`, which is forwarded to the provider
+    verbatim. graphon carries these settings; the host applies them.
+    """
+
+    first_token_timeout_ms: int | None = Field(default=None, gt=0)
+
+    @property
+    def first_token_timeout(self) -> float | None:
+        """The first-token timeout in seconds, the unit every host hop works in."""
+        if self.first_token_timeout_ms is None:
+            return None
+        return self.first_token_timeout_ms / 1000
+
+
 class ContextConfig(BaseModel):
     enabled: bool
     variable_selector: list[str] | None = None
@@ -67,6 +84,7 @@ class LLMNodeCompletionModelPromptTemplate(CompletionModelPromptTemplate):
 class LLMNodeData(BaseNodeData):
     type: NodeType = BuiltinNodeTypes.LLM
     model: ModelConfig
+    invocation: InvocationConfig = Field(default_factory=InvocationConfig)
     prompt_template: (
         Sequence[LLMNodeChatModelMessage] | LLMNodeCompletionModelPromptTemplate
     )

--- a/src/graphon/nodes/llm/node.py
+++ b/src/graphon/nodes/llm/node.py
@@ -429,17 +429,21 @@ class LLMNode(Node[LLMNodeData]):
             chunk="",
             is_final=True,
         )
+        metadata: dict[WorkflowNodeExecutionMetadataKey, Any] = {
+            WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: usage.total_tokens,
+            WorkflowNodeExecutionMetadataKey.TOTAL_PRICE: usage.total_price,
+            WorkflowNodeExecutionMetadataKey.CURRENCY: usage.currency,
+        }
+        if usage.time_to_first_token is not None:
+            first_token_key = WorkflowNodeExecutionMetadataKey.TIME_TO_FIRST_TOKEN
+            metadata[first_token_key] = usage.time_to_first_token
         yield StreamCompletedEvent(
             node_run_result=NodeRunResult(
                 status=WorkflowNodeExecutionStatus.SUCCEEDED,
                 inputs=node_inputs,
                 process_data=process_data,
                 outputs=outputs,
-                metadata={
-                    WorkflowNodeExecutionMetadataKey.TOTAL_TOKENS: usage.total_tokens,
-                    WorkflowNodeExecutionMetadataKey.TOTAL_PRICE: usage.total_price,
-                    WorkflowNodeExecutionMetadataKey.CURRENCY: usage.currency,
-                },
+                metadata=metadata,
                 llm_usage=usage,
             ),
         )

--- a/src/graphon/nodes/question_classifier/entities.py
+++ b/src/graphon/nodes/question_classifier/entities.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from graphon.entities.base_node_data import BaseNodeData
 from graphon.enums import BuiltinNodeTypes, NodeType
 from graphon.nodes.llm.entities import (
+    InvocationConfig,
     ModelConfig,
     VisionConfig,
 )
@@ -33,6 +34,7 @@ class QuestionClassifierNodeData(BaseNodeData):
     type: NodeType = BuiltinNodeTypes.QUESTION_CLASSIFIER
     query_variable_selector: list[str]
     model: ModelConfig
+    invocation: InvocationConfig = Field(default_factory=InvocationConfig)
     classes: list[ClassConfig]
     instruction: str | None = None
     memory: MemoryConfig | None = None

--- a/tests/nodes/llm/test_node.py
+++ b/tests/nodes/llm/test_node.py
@@ -7,13 +7,17 @@ from typing import Any, Literal, Never, cast
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from graphon.engine_events.node import (
     NodeRunModelPollingProgressEvent,
     NodeRunReasoningChunkEvent,
 )
 from graphon.entities.base_node_data import BaseNodeData
-from graphon.enums import WorkflowNodeExecutionStatus
+from graphon.enums import (
+    WorkflowNodeExecutionMetadataKey,
+    WorkflowNodeExecutionStatus,
+)
 from graphon.file import helpers as file_helpers
 from graphon.file.enums import FileTransferMethod, FileType
 from graphon.file.models import File
@@ -122,6 +126,22 @@ def _stream_results(
     yield from results
 
 
+def _llm_node_payload(**overrides: Any) -> dict[str, Any]:
+    return {
+        "type": "llm",
+        "title": "LLM",
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "prompt_template": [{"role": "user", "text": "Hello"}],
+        "context": {"enabled": False},
+        **overrides,
+    }
+
+
 def _build_llm_node(
     *,
     model_instance: object | None = None,
@@ -146,22 +166,11 @@ def _build_llm_node(
 
     node = LLMNode(
         node_id="llm",
-        data=LLMNodeData.model_validate({
-            "title": "LLM",
-            "model": {
-                "provider": "openai",
-                "name": "gpt-4o",
-                "mode": "chat",
-                "completion_params": {},
-            },
-            "prompt_template": [
-                {
-                    "role": "user",
-                    "text": prompt_text,
-                }
-            ],
-            "context": {"enabled": False},
-        }),
+        data=LLMNodeData.model_validate(
+            _llm_node_payload(
+                prompt_template=[{"role": "user", "text": prompt_text}],
+            ),
+        ),
         init_params=build_init_params(
             graph_config={"nodes": [], "edges": []},
             run_context=run_context,
@@ -229,6 +238,52 @@ def test_structured_output_switch_survives_node_data_round_trip(
     assert dumped["structured_output_switch_on"] is True
     assert "structured_output_enabled" not in dumped
     assert restored_from_dump.structured_output_switch_on is True
+
+
+def test_llm_node_data_converts_first_token_timeout_ms_to_seconds() -> None:
+    node_data = LLMNodeData.model_validate(
+        _llm_node_payload(invocation={"first_token_timeout_ms": 1500}),
+    )
+
+    assert node_data.invocation.first_token_timeout == pytest.approx(1.5)
+    assert node_data.model.completion_params == {}
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [{}, {"invocation": {}}],
+    ids=["no-invocation", "empty-invocation"],
+)
+def test_llm_node_data_without_first_token_timeout_ms_has_no_timeout(
+    overrides: dict[str, Any],
+) -> None:
+    node_data = LLMNodeData.model_validate(_llm_node_payload(**overrides))
+
+    assert node_data.invocation.first_token_timeout is None
+
+
+@pytest.mark.parametrize("timeout_ms", [0, -1], ids=["zero", "negative"])
+def test_llm_node_data_rejects_non_positive_first_token_timeout_ms(
+    timeout_ms: int,
+) -> None:
+    with pytest.raises(ValidationError):
+        LLMNodeData.model_validate(
+            _llm_node_payload(invocation={"first_token_timeout_ms": timeout_ms}),
+        )
+
+
+def test_llm_node_data_exports_first_token_timeout_ms_under_invocation() -> None:
+    payload = _llm_node_payload(invocation={"first_token_timeout_ms": 1500})
+
+    node_data = LLMNode.validate_node_data(BaseNodeData.model_validate(payload))
+    revalidated = LLMNode.validate_node_data(node_data)
+    dumped = revalidated.model_dump(mode="python", by_alias=True)
+    restored = LLMNode.validate_node_data(dumped)
+
+    assert revalidated.invocation.first_token_timeout == pytest.approx(1.5)
+    assert dumped["invocation"] == {"first_token_timeout_ms": 1500}
+    assert dumped["model"]["completion_params"] == {}
+    assert restored.invocation.first_token_timeout == pytest.approx(1.5)
 
 
 def test_fetch_structured_output_schema_checks_draft7_schema() -> None:
@@ -438,6 +493,67 @@ def test_run_emits_model_identity_in_node_result_inputs(
 
     assert completed_event.node_run_result.inputs["model_provider"] == "openai"
     assert completed_event.node_run_result.inputs["model_name"] == "gpt-4o"
+
+
+@pytest.mark.parametrize("time_to_first_token", [0.25, 0.0], ids=["positive", "zero"])
+def test_run_emits_time_to_first_token_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    time_to_first_token: float,
+) -> None:
+    node = _build_llm_node()
+
+    _stub_simple_prompt(monkeypatch, node)
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text="Hello back",
+                usage=LLMUsage.empty_usage().model_copy(
+                    update={"time_to_first_token": time_to_first_token},
+                ),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    completed_event = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+
+    metadata = completed_event.node_run_result.metadata
+    assert (
+        metadata[WorkflowNodeExecutionMetadataKey.TIME_TO_FIRST_TOKEN]
+        == time_to_first_token
+    )
+
+
+def test_run_omits_time_to_first_token_metadata_when_usage_has_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = _build_llm_node()
+
+    _stub_simple_prompt(monkeypatch, node)
+    monkeypatch.setattr(
+        "graphon.nodes.llm.node.LLMNode.invoke_llm",
+        lambda **_: iter([
+            ModelInvokeCompletedEvent(
+                text="Hello back",
+                usage=LLMUsage.empty_usage(),
+                finish_reason="stop",
+            ),
+        ]),
+    )
+
+    completed_event = next(
+        event for event in node._run() if isinstance(event, StreamCompletedEvent)
+    )
+
+    node_run_result = completed_event.node_run_result
+    assert node_run_result.status == WorkflowNodeExecutionStatus.SUCCEEDED
+    assert (
+        WorkflowNodeExecutionMetadataKey.TIME_TO_FIRST_TOKEN
+        not in node_run_result.metadata
+    )
 
 
 def test_run_records_resolved_prompt_inputs(

--- a/tests/nodes/question_classifier/test_question_classifier_node.py
+++ b/tests/nodes/question_classifier/test_question_classifier_node.py
@@ -66,6 +66,31 @@ def test_question_classifier_node_data_defaults_label_to_empty_string() -> None:
     assert not node_data.classes[0].label
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_timeout"),
+    [({"invocation": {"first_token_timeout_ms": 2500}}, 2.5), ({}, None)],
+    ids=["with-timeout", "no-invocation"],
+)
+def test_question_classifier_node_data_reads_first_token_timeout_in_seconds(
+    overrides: dict[str, Any],
+    expected_timeout: float | None,
+) -> None:
+    node_data = QuestionClassifierNodeData.model_validate({
+        "title": "Classifier",
+        "query_variable_selector": ["start", "sys.query"],
+        "model": {
+            "provider": "openai",
+            "name": "gpt-4o",
+            "mode": "chat",
+            "completion_params": {},
+        },
+        "classes": [{"id": "billing", "name": "Questions about invoices and charges"}],
+        **overrides,
+    })
+
+    assert node_data.invocation.first_token_timeout == pytest.approx(expected_timeout)
+
+
 def _build_question_classifier_node(
     node_data: QuestionClassifierNodeData,
     *,


### PR DESCRIPTION
## Important

1. Make sure you have read our [contribution guidelines](../CONTRIBUTING.md)
2. Search existing issues and pull requests to confirm this change is not a duplicate
3. Open or identify the issue this pull request resolves or advances
4. Use a Conventional Commits title for this pull request, and mark breaking changes with `!`
5. Remember that the pull request title will become the squash merge commit message
6. If CLA Assistant prompts you, sign [CLA.md](../CLA.md) in the pull request conversation

## Related Issue

Closes #293

## Summary

Adds an `invocation` block to LLM-family node data, and publishes the time-to-first-token the LLM node already measures as node execution metadata.

**`invocation` is a sibling of `model`, not part of `completion_params`.** A per-node first-token budget is being threaded through the Dify plugin chain, and `completion_params` is the wrong home for it: that dictionary is forwarded to model providers verbatim, so every consumer needs a defensive `pop`, and the value shows up in exported DSL next to `temperature` as if the provider understood it.

```yaml
data:
  model: { provider: openai, name: gpt-4o, mode: chat, completion_params: {} }
  invocation:
    first_token_timeout_ms: 2000
```

`first_token_timeout_ms` is an optional positive integer; absent means no budget. The block exposes it as `first_token_timeout` in **seconds**, which is the unit every hop below graphon works in — milliseconds are the DSL and UI unit only, and this is the single place the conversion happens.

`LLMNodeData` and `QuestionClassifierNodeData` get the block. `ParameterExtractorNodeData` deliberately does not: that node invokes with `stream=False`, where a single result arrives only once generation has finished, so a first-token budget there would quietly become a total-generation budget.

**graphon carries the value and enforces nothing.** It is read off the node data by the host adapter, which owns the transport. In particular this adds no parameter to `LLMProtocol` — that would hand every adapter that cannot honour it one more argument with no effect, which is the shape [TD-06](docs/technical-debt.md#td-06--ignored-llm-integration-arguments) already tracks. Closed PR #212 attempted exactly that and its own compatibility table shows the cost: any implementation without the keyword and without `**kwargs` raises `TypeError` on every LLM call, forcing an ordering constraint on the host's pin bump. Keeping graphon a carrier removes that constraint.

The second change is smaller. `LLMNode` already measures TTFT into `LLMUsage.time_to_first_token` but never surfaced it per node, so an operator had no number to base a budget on. It now writes `WorkflowNodeExecutionMetadataKey.TIME_TO_FIRST_TOKEN` alongside the existing token and price keys, and omits the key entirely when no content streamed rather than recording a null.

Both changes are additive and optional. Workflows saved before this deserialize unchanged, and a host that ignores `invocation` behaves exactly as it does today.

## Checklist

- [x] This pull request links the issue it resolves or advances
- [x] This pull request title follows Conventional Commits, and any breaking change is marked with `!`
- [x] If CLA Assistant prompted me, I signed [CLA.md](../CLA.md) in the pull request conversation

